### PR TITLE
Add `Deffered` an alternative to explicit control functions

### DIFF
--- a/packages/effection/src/deferred.js
+++ b/packages/effection/src/deferred.js
@@ -1,0 +1,23 @@
+/**
+ * Create an object that holds a promise along with the control
+ * functions needed to control it:
+ *
+ *   let { resolve, reject, promise } = Deferred();
+ *
+ *   promise.then(num => console.log('your number is ', 10);
+ */
+export function Deferred() {
+  let resolve;
+  let reject;
+
+  let promise = new Promise((_resolve, _reject) => {
+    resolve = _resolve;
+    reject = _reject;
+  }) ;
+
+  return {
+    resolve,
+    reject,
+    promise
+  };
+}

--- a/packages/effection/src/index.js
+++ b/packages/effection/src/index.js
@@ -1,3 +1,4 @@
+export { Deferred } from './deferred';
 export { timeout } from './timeout';
 export { fork, join, spawn, spawn as monitor } from './control';
 

--- a/packages/effection/src/timeout.js
+++ b/packages/effection/src/timeout.js
@@ -1,3 +1,4 @@
+import { Deferred } from './deferred';
 /**
 * Create an execution controller that resumes after the specified
 * duration. E.g.
@@ -7,9 +8,12 @@
 *     console.log(`Hello ${target}!`);
 *   }
 */
-export function timeout(duration) {
-  return ({ resume, ensure }) => {
-    let timeoutId = setTimeout(() => resume(), duration);
-    ensure(() => clearTimeout(timeoutId));
-  };
+export function* timeout(duration) {
+  let { resolve, promise } = Deferred();
+  let timeoutId = setTimeout(resolve, duration);
+  try {
+    yield promise;
+  } finally {
+    clearTimeout(timeoutId);
+  }
 }

--- a/packages/effection/types/deferred.test.ts
+++ b/packages/effection/types/deferred.test.ts
@@ -1,0 +1,26 @@
+import { Deferred } from 'effection';
+
+let noValue = Deferred<void>();
+noValue.resolve();
+
+let yieldsNumber = Deferred<number>();
+
+// you cannot resolve a number future with void
+// $ExpectError
+yieldsNumber.resolve();
+
+// you cannot resolve a number future with void
+// $ExpectError
+yieldsNumber.resolve('Hello World');
+
+yieldsNumber.resolve(10);
+
+let { reject } = Deferred<void>();
+
+// you have to reject with an instace of Error
+// $ExpectError
+reject('Hello');
+
+reject(new Error('boom!'));
+
+let future: Deferred<void> = Deferred();

--- a/packages/effection/types/imports.test.ts
+++ b/packages/effection/types/imports.test.ts
@@ -3,5 +3,6 @@ import {
   Context,
   fork,
   join,
-  timeout
+  timeout,
+  Deferred
 } from 'effection';

--- a/packages/effection/types/index.d.ts
+++ b/packages/effection/types/index.d.ts
@@ -44,4 +44,12 @@ declare module "effection" {
   export function timeout(durationMillis: number): Operation<void>;
 
   export function contextOf(object: Object): Context<any> | undefined;
+
+  export function Deferred<T>(): Deferred<T>;
+
+  export interface Deferred<T> {
+    resolve(value: T): void;
+    reject(error: Error): void;
+    promise: Promise<T>;
+  }
 }


### PR DESCRIPTION
Motivation
-----------

One of the ongoing discussions we've been having is that we want to move away from control functions and really focus on having generators and promises be the base primitives that people work with in effection.

Approach
----------

As a baby step towards that goal, this introduces a `Deferred` function that returns an object containing a `resolve` / `reject` / `promise` calling `resolve()` will resolve `promise`, and calling `reject`, will reject `promise`.

This provides a simple control pattern very similar to the exsting control functions, but based on standard and familiar apis: promise and generator.

> Ok, generators may not feel familiar, but they are at least "familiar-ish" in the sense that they're just JS code.

Thus, we can re-write any control function to be `Deferred` + `try/finally` with a yield to the futures promise.

As an example, `timeout` is written in this way.