### PR TITLE
Export function of child_process

### DIFF
--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -1,3 +1,2 @@
 export { main } from './main';
-export { spawn, fork } from './child_process';
 export * as ChildProcess from './child_process';

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -1,2 +1,3 @@
 export { main } from './main';
 export { spawn, fork } from './child_process';
+export * as ChildProcess from './child_process';


### PR DESCRIPTION
## Motivation
[This](https://github.com/thefrontside/effection.js/pull/101#issuecomment-620168884) comment.

## Approach
I think I may be underestimating/misunderstanding the issue but can't we just do: 
```ts
// > packages/node/src/index.ts

export * as ChildProcess from './child_process';
``` 

This seems to allow us to:
```ts
import { ChildProcess } from `@effection/node`;

export function * echo() {
  yield ChildProcess.fork("echo", ["Hello World"]);
}
``` 

Not knowing how `effection` works I'm not sure how I can test to make sure it doesn't conflict with `@effection`'s `fork` but hovering over the imported functions seems to display the intended result:

![Screen Shot 2020-04-27 at 3 37 43 PM](https://user-images.githubusercontent.com/29791650/80420457-ca694000-88a8-11ea-81b3-18c4b02150dd.png)
