### PR TITLE
Make resolution of `once` asynchronous

### DIFF
--- a/packages/events/src/once.ts
+++ b/packages/events/src/once.ts
@@ -5,11 +5,14 @@ import { EventSource, addListener, removeListener } from './event-source';
  * Takes an event source and event name and returns a yieldable
  * operation which resumes when the event occurs.
  */
-export function once(source: EventSource, eventName: string): Operation {
-  return ({ resume, ensure }) => {
-    let listener = (...args: unknown[]) => resume(args);
-    ensure(() => removeListener(source, eventName, listener));
-
-    addListener(source, eventName, listener);
-  };
+export function *once(source: EventSource, eventName: string): Operation {
+  let onceListener;
+  try {
+    return yield new Promise((resolve) => {
+      onceListener = (...args: unknown[]) => resolve(args);
+      addListener(source, eventName, onceListener);
+    });
+  } finally {
+    removeListener(source, eventName, onceListener);
+  }
 }

--- a/packages/events/test/throw-on-error-event.test.ts
+++ b/packages/events/test/throw-on-error-event.test.ts
@@ -11,6 +11,7 @@ import { throwOnErrorEvent } from '../src/index';
 describe("throwOnErrorEvent", () => {
   let emitter: EventEmitter;
   let context: Context;
+  let error = new Error("moo");
 
   beforeEach(async () => {
     emitter = new EventEmitter();
@@ -22,12 +23,11 @@ describe("throwOnErrorEvent", () => {
 
   describe('throws an erro when the event occurs', () => {
     beforeEach(() => {
-      emitter.emit("error", new Error("moo"));
+      emitter.emit("error", error);
     });
 
     it('throws error', async () => {
-      expect(context.state).toEqual("errored");
-      expect(context.result.message).toEqual("moo");
+      await expect(context).rejects.toEqual(error);
     });
   });
 });


### PR DESCRIPTION
If we run the `resume` in the same tick as the listener, then we can run into a problem with the event listener being removed in the same tick as it is running. Some badly behaved event libraries (looking at you yaeti) assume that this will not happen 🙄

We really shouldn't have to do this, but here we are.