### PR TITLE
Respond to SIGTERM in @effection/node/main

### DIFF
--- a/packages/node/src/main.ts
+++ b/packages/node/src/main.ts
@@ -7,6 +7,7 @@ export function main<T>(operation: Operation<T>): Context<T> {
       let debug = () => console.debug(mainContext.toString());
       try {
         process.on('SIGINT', interrupt);
+        process.on('SIGTERM', interrupt);
         process.on('SIGUSR1', debug);
         return yield operation;
       } catch(e) {
@@ -14,6 +15,7 @@ export function main<T>(operation: Operation<T>): Context<T> {
         process.exit(-1);
       } finally {
         process.off('SIGINT', interrupt);
+        process.off('SIGTERM', interrupt);
         process.off('SIGUSR1', debug);
       }
     });

--- a/packages/node/test/helpers.ts
+++ b/packages/node/test/helpers.ts
@@ -18,7 +18,7 @@ afterEach(() => {
 })
 
 export class TestStream {
-  private output = "";
+  public output = "";
 
   static *of(value: Readable) {
     let testStream = new TestStream(value);

--- a/packages/node/test/main.test.ts
+++ b/packages/node/test/main.test.ts
@@ -1,0 +1,42 @@
+import * as path from 'path';
+import { describe, it, beforeEach } from 'mocha';
+import { ChildProcess, spawn as spawnProcess } from 'child_process';
+import { once } from '@effection/events';
+
+import { World, TestStream } from './helpers';
+
+describe('main', () => {
+  let child: ChildProcess;
+  let stdout: TestStream;
+  beforeEach(async () => {
+    child = spawnProcess("ts-node", [path.join(__dirname, 'text-writer.ts')]);
+
+    stdout = await World.spawn(TestStream.of(child.stdout));
+    await World.spawn(stdout.waitFor("started"));
+  });
+  afterEach(() => {
+    child.kill('SIGKILL');
+  })
+
+  describe('sending SIGINT', () => {
+    beforeEach(async () => {
+      setTimeout(() => child.kill('SIGINT'), 10);
+      await World.spawn(once(child, 'exit'));
+    });
+
+    it('shuts down gracefully', async () => {
+      await World.spawn(stdout.waitFor("stopped"));
+    });
+  });
+
+  describe('sending SIGTERM', () => {
+    beforeEach(async () => {
+      child.kill('SIGTERM');
+      await World.spawn(once(child, 'exit'));
+    });
+
+    it('shuts down gracefully', async () => {
+      await World.spawn(stdout.waitFor("stopped"));
+    });
+  });
+});

--- a/packages/node/test/text-writer.ts
+++ b/packages/node/test/text-writer.ts
@@ -1,0 +1,16 @@
+import { Operation } from 'effection';
+import { main } from '../src/main';
+
+import { createServer } from 'net';
+
+main(function*(): Operation<void> {
+  console.log('started');
+  let server = createServer();
+  try {
+    server.listen();
+    yield;
+  } finally {
+    server.close();
+    console.log('stopped');
+  }
+})


### PR DESCRIPTION
We were only responding to `SIGINT` inside our `main` handler. What this meant, was that if an effection process contained sub-effection processes, managed by one of the `child_process` resources, then because the main context was not getting torn down, the subsequent resources that represented child process were not getting sent their shutdown signals.

This adds SIGTERM to the list of signals that will cause a shutdown of the main effection context. That way, effection processes that manage other process will shut them down whenever they are themselves terminated.

[1]: https://www.gnu.org/software/libc/manual/html_node/Termination-Signals.html