### PR TITLE
Make subscription iterable

### DIFF
--- a/packages/events/src/on.ts
+++ b/packages/events/src/on.ts
@@ -2,7 +2,7 @@ import { resource, Operation } from 'effection';
 import { EventSource, addListener, removeListener } from './event-source';
 import { once } from './once';
 
-export class Subscription<T extends Array<unknown>> {
+export class Subscription<T extends Array<unknown>> implements Iterable<Operation<T>> {
   private events: T[] = [];
 
   constructor(private source: EventSource, private eventName: string) {}
@@ -27,6 +27,12 @@ export class Subscription<T extends Array<unknown>> {
       removeListener(this.source, this.eventName, listener);
     }
 
+  }
+
+  [Symbol.iterator]() {
+    return {
+      next: () => ({ done: false, value: this.next() })
+    }
   }
 }
 

--- a/packages/events/test/on.test.ts
+++ b/packages/events/test/on.test.ts
@@ -82,4 +82,38 @@ describe("on", () => {
       });
     });
   });
+
+  describe('iterating through a subscription', () => {
+    let target: EventEmitter;
+    let events: string[];
+
+    beforeEach(() => {
+      target = new EventEmitter();
+      events = [];
+
+      World.spawn(function*() {
+        for (let next of yield on(target, "thing")) {
+          let event = yield next;
+          events.push(event);
+        }
+      })
+    });
+
+    describe('sending a few events', () => {
+      beforeEach(async () => {
+        target.emit("thing", 1)
+        target.emit("thing", 2)
+        await Promise.resolve();
+      });
+
+      it('receives the events', () => {
+        expect(events).toEqual([[1],[2]]);
+      });
+
+    });
+
+
+
+  });
+
 });


### PR DESCRIPTION
Motivation
----------

The most common pattern for working with subscriptions is to:

1. allocate the subscription by evaluating an `on` operation.
2. loop infinitely and evaluate `subscription.next()`

This introduces a lot of noise to get at the meat of the operation which is to just do something for every event that gets received on a particular target. We encountered this recently when fixing a bug in the bigtest proxy server where we had to re-write a server event loop to something like:

```ts
yield spawn(function*(): Operation<void> {
  let subscription = yield on(server, 'request');

  while (true) {
    let [req, res]: [http.IncomingMessage, http.ServerResponse] = yield subscription.next();
    yield spawn(function*() {
      try {
        proxyServer.web(req, res)
        yield once(res, 'close');
      } finally {
        req.destroy();
      }
    });
  }
});
```

Approach
----------

We can remove a lot of the noise of the subscription mechanics by making the subscription object itself iterable as a stream of operations that yield the next item. That way, we can re-write this as:

```ts
yield spawn(function*(): Operation<void> {
  for (let next of yield on(server, 'request')) {
    let [req, res]: [http.IncomingMessage, http.ServerResponse] = yield next;
    yield spawn(function*() {
      try {
        proxyServer.web(req, res)
        yield once(res, 'close');
      } finally {
        req.destroy();
      }
    });
  }
})
```

This is very similar to the [async iterator][1] syntax, and it might even be worth exploring later on if we can use the async generator syntax to be able to iterate over a subscription implicitly in parallel since any operation can be trivially converted into a promise by calling spawn on it.

```ts
yield spawn(async function*() {
  for await (let [req,res] of yield on(server, 'request')) {
    try {
      proxyServer.web(req, res)
      yield once(res, 'close');
    } finally {
      req.destroy();
    }
  }
})
```

The idea that each body of a `for` loop would be executed in parallel is kinda crazy to wrap your head around, but is pretty straightforward to implement, and would be absurdly powerful. For example, it would make implementing a race operation nearly trivial.

All food for thought. The scope of this PR is simple iterable subscriptions.

[1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of