### PR TITLE
Remove automatic changeset release creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,3 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
-    - name: Create Release Pull Request
-      uses: changesets/action@master
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This [did not quite work][1] and since we'll be replacing it soon with a fully featured app of our own creation, we'll continue making release pull requests manually. The only difference is that we'll be using `changset` cli from here on out.

[1]: https://github.com/thefrontside/effection/runs/732344851?check_suite_focus=true