### PR TITLE
Update events dependencies.

### DIFF
--- a/.changeset/fix-subscription-deps.md
+++ b/.changeset/fix-subscription-deps.md
@@ -1,0 +1,7 @@
+---
+"@effection/events": patch
+---
+
+as of 0.7.0 @effection/events depends on @effection/subscription for
+its implementation. This allows higher order functions over event
+streams via `Subscribeable`.

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -19,6 +19,9 @@
     "prepack": "tsdx build --tsconfig tsconfig.dist.json",
     "mocha": "mocha -r ts-node/register"
   },
+  "dependencies": {
+    "@effection/subscription": "^0.6.3"
+  },
   "devDependencies": {
     "@frontside/tsconfig": "0.0.1",
     "@types/node": "^12.7.11",


### PR DESCRIPTION
`@effection/events` package was updated to depend on `@effection/subscription` so that `on()` now returns a subscription. However, this dependency was not actually added to the`@effection/events` package.