### PR TITLE
Update action to 1.7 from 1.6

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Publish Releases
-      uses: thefrontside/actions/synchronize-with-npm@v1.6
+      uses: thefrontside/actions/synchronize-with-npm@v1.7
       with:
         before_all: yarn prepack
         npm_publish: yarn publish


### PR DESCRIPTION
## Motivation
Updating the synchronize-with-npm action to 1.7 from 1.6 will publish packages by checking every package against the registry as opposed to comparing files between commits to decide which pages to publish.