### PR TITLE
feat: better child_process defaults for windows

### DIFF
--- a/.changeset/clever-badgers-begin.md
+++ b/.changeset/clever-badgers-begin.md
@@ -2,4 +2,4 @@
 "@effection/node": major
 ---
 
-Let spawn shell be set, but default to process.env.shell which is a good default for Windows along with windowsHide.
+Remove shell default and only force detached as that is a requirement.

--- a/.changeset/clever-badgers-begin.md
+++ b/.changeset/clever-badgers-begin.md
@@ -1,5 +1,5 @@
 ---
-"@effection/node": patch
+"@effection/node": major
 ---
 
 Let spawn shell be set, but default to process.env.shell which is a good default for Windows along with windowsHide.

--- a/.changeset/clever-badgers-begin.md
+++ b/.changeset/clever-badgers-begin.md
@@ -1,0 +1,5 @@
+---
+"@effection/node": patch
+---
+
+Let spawn shell be set, but default to process.env.shell which is a good default for Windows along with windowsHide.

--- a/.changeset/clever-badgers-begin.md
+++ b/.changeset/clever-badgers-begin.md
@@ -1,5 +1,5 @@
 ---
-"@effection/node": major
+"@effection/node": minor
 ---
 
 Remove shell default and only force detached as that is a requirement.

--- a/packages/node/src/child_process.ts
+++ b/packages/node/src/child_process.ts
@@ -34,14 +34,8 @@ function *supervise(child: ChildProcess, command: string, args: readonly string[
 }
 
 export function *spawn(command: string, args?: ReadonlyArray<string>, options?: SpawnOptions): Operation {
-  // Use the process.env.shell if it isn't set. This will likely be most useful for Windows
-  // as there are more terminals and the defaults are not amazing.
-  // windowsHide also hides the terminals from showing when a child process is init. Setting the boolean
-  // to true makes this operate in line with other OS, and how one might expect.
   let child = childProcess.spawn(command, args || [], Object.assign({}, options, {
-    shell: !options && !options.shell ? process.env.shell : options.shell,
     detached: true,
-    windowsHide: !options && !options.windowsHide ? true : options.windowsHide,
   }));
   return yield resource(child, supervise(child, command, args));
 }

--- a/packages/node/src/child_process.ts
+++ b/packages/node/src/child_process.ts
@@ -34,9 +34,14 @@ function *supervise(child: ChildProcess, command: string, args: readonly string[
 }
 
 export function *spawn(command: string, args?: ReadonlyArray<string>, options?: SpawnOptions): Operation {
+  // Use the process.env.shell if it isn't set. This will likely be most useful for Windows
+  // as there are more terminals and the defaults are not amazing.
+  // windowsHide also hides the terminals from showing when a child process is init. Setting the boolean
+  // to true makes this operate in line with other OS, and how one might expect.
   let child = childProcess.spawn(command, args || [], Object.assign({}, options, {
-    shell: true,
+    shell: !options && !options.shell ? process.env.shell : options.shell,
     detached: true,
+    windowsHide: !options && !options.windowsHide ? true : options.windowsHide,
   }));
   return yield resource(child, supervise(child, command, args));
 }


### PR DESCRIPTION
This sets better defaults for `spawn` on Windows, and allows them to be overwritten.