### PR TITLE
Add `match` method to subscribable 

### DIFF
--- a/.changeset/subscribable-match.md
+++ b/.changeset/subscribable-match.md
@@ -1,0 +1,5 @@
+---
+"@effection/subscription": minor
+---
+
+Add the `match` method to `Subscribable` to filter a subscription by pattern

--- a/packages/subscription/README.md
+++ b/packages/subscription/README.md
@@ -88,6 +88,16 @@ that match `predicate`.
 Subscribable.from(websocket).filter(message => message.type === 'command');
 ```
 
+### Subscribable#match(reference)
+
+Return a new `Subscribable` that only produces items from its source that match
+`reference` in the sense that the produced items have the same properties and
+values as `reference`.
+
+``` javascript
+Subscribable.from(websocket).match({ type: 'command' });
+```
+
 ### Subscribable#first()
 
 An operation that produces the first item in a subscription or

--- a/packages/subscription/src/match.ts
+++ b/packages/subscription/src/match.ts
@@ -1,0 +1,15 @@
+export type DeepPartial<T> = {
+  [P in keyof T]?: DeepPartial<T[P]>
+};
+
+export function matcher<T>(reference: unknown): (value: T) => boolean {
+  return (value: unknown) => {
+    if(typeof(value) === 'object' && typeof(reference) === 'object') {
+      let castedValue = value as Record<string, any>;
+      let castedReference = reference as Record<string, any>;
+      return Object.entries(castedReference).every(([key, ref]) => matcher(ref)(castedValue[key]));
+    } else {
+      return value === reference;
+    }
+  };
+}

--- a/packages/subscription/src/subscribable.ts
+++ b/packages/subscription/src/subscribable.ts
@@ -1,5 +1,6 @@
 import { Operation } from 'effection';
 import { Subscription, createSubscription, Subscriber } from './subscription';
+import { DeepPartial, matcher } from './match';
 
 export const SymbolSubscribable: unique symbol = Symbol.for('Symbol.subscription');
 
@@ -44,6 +45,10 @@ export class Chain<T, TReturn> implements Subscribable<T,TReturn> {
         publish(item);
       }
     }))
+  }
+
+  match(reference: DeepPartial<T>): Chain<T,TReturn> {
+    return this.filter(matcher(reference));
   }
 
   chain<X = T,XReturn = TReturn>(next: (source: SubscriptionSource<T,TReturn>) => Subscriber<X,XReturn>): Chain<X,XReturn> {

--- a/packages/subscription/test/subscribable.test.ts
+++ b/packages/subscription/test/subscribable.test.ts
@@ -92,6 +92,52 @@ describe('subscribable objects', () => {
     });
   });
 
+  describe('match', () => {
+    describe('with simple filter', () => {
+      let values: Thing[];
+      let result: number;
+
+      beforeEach(async () => {
+        values = [];
+        let filtered = Subscribable.from(source).match({ type: 'person' });
+        result = await spawn(filtered.forEach(function*(item) { values.push(item) }));
+      });
+
+      it('filters the items', () => {
+        expect(values).toEqual([
+          {name: 'bob', type: 'person' },
+          {name: 'alice', type: 'person' },
+        ]);
+      });
+
+      it('preserves the return type', () => {
+        expect(result).toEqual(3);
+      });
+    });
+
+    describe('with deep filter', () => {
+      let values: Array<{ thing: Thing }>;
+      let result: number;
+
+      beforeEach(async () => {
+        values = [];
+        let filtered = Subscribable.from(source).map((t) => ({ thing: t })).match({ thing: { type: 'person' } });
+        result = await spawn(filtered.forEach(function*(item) { values.push(item) }));
+      });
+
+      it('filters the items', () => {
+        expect(values).toEqual([
+          { thing: {name: 'bob', type: 'person' } },
+          { thing: {name: 'alice', type: 'person' } }
+        ]);
+      });
+
+      it('preserves the return type', () => {
+        expect(result).toEqual(3);
+      });
+    });
+  });
+
   describe('first', () => {
     let first: string | undefined;
 

--- a/packages/subscription/test/subscribable.test.ts
+++ b/packages/subscription/test/subscribable.test.ts
@@ -1,4 +1,5 @@
 import * as expect from 'expect';
+import { describe, it, beforeEach } from 'mocha';
 import { spawn } from './helpers';
 
 import { createSubscription, Subscribable, SymbolSubscribable, forEach } from '../src/index';


### PR DESCRIPTION
This was originally proposed for the channel API in #121.

I believe that this is the most common way of using `filter` and it is much easier to read and write. Also given `DeepPartial<T>` is is actually typesafe in TypeScript as well.