### PR TITLE
include sources with npm packages

### DIFF
--- a/.changeset/ship-sourcemaps.md
+++ b/.changeset/ship-sourcemaps.md
@@ -1,0 +1,8 @@
+---
+"effection": patch
+"@effection/subscription": patch
+"@effection/events": patch
+"@effection/node": patch
+---
+
+include typescript sources with package in order for sourcemaps to work.

--- a/packages/effection/package.json
+++ b/packages/effection/package.json
@@ -13,7 +13,8 @@
   "files": [
     "README.md",
     "dist/**/*",
-    "src/**/*"
+    "src/**/*",
+    "types/index.d.ts"
   ],
   "scripts": {
     "coverage": "nyc --reporter=html --reporter=text npm run test",

--- a/packages/effection/package.json
+++ b/packages/effection/package.json
@@ -10,6 +10,11 @@
   "source": "src/index.js",
   "main": "dist/effection.js",
   "module": "dist/effection.module.js",
+  "files": [
+    "README.md",
+    "dist/**/*",
+    "src/**/*"
+  ],
   "scripts": {
     "coverage": "nyc --reporter=html --reporter=text npm run test",
     "coveralls": "nyc report --reporter=text-lcov | coveralls",

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -9,9 +9,9 @@
   "author": "Frontside Engineering <engineering@frontside.io>",
   "license": "MIT",
   "files": [
-    "dist/*",
-    "src",
-    "README.md"
+    "README.md",
+    "dist/**/*",
+    "src/**/*"
   ],
   "scripts": {
     "lint": "echo [skip @effection/events]",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -8,9 +8,9 @@
   "author": "Frontside Engineering <engineering@frontside.io>",
   "license": "MIT",
   "files": [
-    "dist/*",
     "README.md",
-    "src"
+    "dist/**/*",
+    "src/**/*"
   ],
   "scripts": {
     "lint": "echo [skip @effection/node]",

--- a/packages/subscription/package.json
+++ b/packages/subscription/package.json
@@ -8,9 +8,9 @@
   "author": "Frontside Engineering <engineering@frontside.com>",
   "license": "MIT",
   "files": [
-    "dist/*",
     "README.md",
-    "src"
+    "dist/**/*",
+    "src/**/*"
   ],
   "scripts": {
     "lint": "echo 'skip'",


### PR DESCRIPTION
Without the source files in the distribution, the references contained in the sourcemaps are broken. As a result, building them into webapps produces warnings like the following:

```
$ parcel build --no-minify --out-dir dist/app app/index.html app/harness.ts
⚠️  Could not load existing sourcemap of "../../../node_modules/effection/dist/effection.js".
⚠️  Could not load existing sourcemap of "../../../node_modules/effection/dist/effection.js".
⚠️  Could not load source file "../src/index.ts" in source map of "../../../node_modules/@effection/events/dist/index.js".
⚠️  Could not load source file "../src/once.ts" in source map of "../../../node_modules/@effection/events/dist/once.js".
⚠️  Could not load source file "../src/on.ts" in source map of "../../../node_modules/@effection/events/dist/on.js".
⚠️  Could not load source file "../src/throw-on-error-event.ts" in source map of "../../../node_modules/@effection/events/dist/throw-on-error-event.js".
⚠️  Could not load source file "../src/event-source.ts" in source map of "../../../node_modules/@effection/events/dist/event-source.js".
✨  Built in 2.63s.
```

This adds sourcefiles to all of the packages so that source lookups will work. It also standardizes on glob patterns that will pickup all the dist files and all the source files instead of a single level of files. E.g. `dist/**/*` instead of just `dist/*`