### PR TITLE
Switch to frontside.com domain

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at oss@frontside.io. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at oss@frontside.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/effection)](https://bundlephobia.com/result?p=effection)
 [![CircleCI](https://circleci.com/gh/thefrontside/effection.svg?style=svg)](https://circleci.com/gh/thefrontside/effection)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Created by Frontside](https://img.shields.io/badge/created%20by-frontside.io-blue.svg)](https://frontside.com)
+[![Created by Frontside](https://img.shields.io/badge/created%20by-frontside-26abe8.svg)](https://frontside.com)
 [![Chat on Discord](https://img.shields.io/discord/700803887132704931?Label=Discord)](https://discord.gg/Ug5nWH8)
 
 # effection

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0-monorepo",
   "description": "Effortlessly composable structured concurrency primitive for JavaScript",
   "repository": "git@github.com:thefrontside/effection.git",
-  "author": "Frontside Engineering <engineering@frontside.io>",
+  "author": "Frontside Engineering <engineering@frontside.com>",
   "license": "MIT",
   "private": true,
   "workspaces": {

--- a/packages/effection/package.json
+++ b/packages/effection/package.json
@@ -3,7 +3,7 @@
   "version": "0.6.4",
   "description": "Effortlessly composable structured concurrency primitive for JavaScript",
   "repository": "http://github.com/thefrontside/effection",
-  "author": "Charles Lowell <cowboyd@frontside.io>",
+  "author": "Charles Lowell <cowboyd@frontside.com>",
   "license": "MIT",
   "private": false,
   "types": "types/index.d.ts",

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -6,7 +6,7 @@
   "types": "dist/index.d.ts",
   "module": "dist/events.esm.js",
   "repository": "https://github.com/thefrontside/bigtest.git",
-  "author": "Frontside Engineering <engineering@frontside.io>",
+  "author": "Frontside Engineering <engineering@frontside.com>",
   "license": "MIT",
   "files": [
     "README.md",

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
   "repository": "https://github.com/thefrontside/effection.git",
-  "author": "Frontside Engineering <engineering@frontside.io>",
+  "author": "Frontside Engineering <engineering@frontside.com>",
   "license": "MIT",
   "files": [
     "dist/*",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/thefrontside/bigtest.git",
-  "author": "Frontside Engineering <engineering@frontside.io>",
+  "author": "Frontside Engineering <engineering@frontside.com>",
   "license": "MIT",
   "files": [
     "README.md",


### PR DESCRIPTION
`frontside.io` ➡️ `frontside.com`