### PR TITLE
Enable ESLint on all packages

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,29 +1,3 @@
 {
-  "extends": ["eslint:recommended"],
-  "env": {
-    "browser": true,
-    "commonjs": true,
-    "es6": true,
-    "node": true
-  },
-  "parser": "babel-eslint",
-  "parserOptions": {
-    "experimentalDecorators": true,
-    "sourceType": "module"
-  },
-  "rules": {
-    "indent": ["error", 2, {
-      "SwitchCase": 1
-    }],
-    "no-console": "error",
-    "no-unused-vars": "error",
-    "prefer-let/prefer-let": 2,
-    "semi": ["error", "always"],
-    "space-before-function-paren": ["error", {
-      "anonymous": "never",
-      "named": "never",
-      "asyncArrow": "always"
-    }]
-  },
-  "plugins": ["prefer-let"]
+  "extends": "@frontside/eslint-config"
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "yarn": "1.22.4"
   },
   "devDependencies": {
+    "@frontside/eslint-config": "^1.0.0",
     "patch-package": "6.2.2"
   },
   "dependencies": {

--- a/packages/effection/.eslintrc.json
+++ b/packages/effection/.eslintrc.json
@@ -1,0 +1,44 @@
+{
+  "extends": [
+    "eslint:recommended"
+  ],
+  "env": {
+    "browser": true,
+    "commonjs": true,
+    "es6": true,
+    "node": true
+  },
+  "parser": "babel-eslint",
+  "parserOptions": {
+    "experimentalDecorators": true,
+    "sourceType": "module"
+  },
+  "root": true,
+  "rules": {
+    "indent": [
+      "error",
+      2,
+      {
+        "SwitchCase": 1
+      }
+    ],
+    "no-console": "error",
+    "no-unused-vars": "error",
+    "prefer-let/prefer-let": 2,
+    "semi": [
+      "error",
+      "always"
+    ],
+    "space-before-function-paren": [
+      "error",
+      {
+        "anonymous": "never",
+        "named": "never",
+        "asyncArrow": "always"
+      }
+    ]
+  },
+  "plugins": [
+    "prefer-let"
+  ]
+}

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -14,7 +14,7 @@
     "src/**/*"
   ],
   "scripts": {
-    "lint": "echo [skip @effection/events]",
+    "lint": "eslint '{src,tests}/**/*.ts'",
     "test": "mocha -r ts-node/register test/**/*.test.ts",
     "prepack": "tsdx build --tsconfig tsconfig.dist.json",
     "mocha": "mocha -r ts-node/register"

--- a/packages/events/src/once.ts
+++ b/packages/events/src/once.ts
@@ -6,6 +6,7 @@ import { EventSource, addListener, removeListener } from './event-source';
  * operation which resumes when the event occurs.
  */
 export function *once(source: EventSource, eventName: string): Operation {
+   // eslint-disable-next-line @typescript-eslint/no-empty-function
   let onceListener = () => {};
   try {
     return yield new Promise((resolve) => {

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -13,7 +13,7 @@
     "src"
   ],
   "scripts": {
-    "lint": "echo 'skip'",
+    "lint": "eslint '{src,tests}/**/*.ts'",
     "prepack": "tsdx build --tsconfig tsconfig.dist.json",
     "test": "mocha -r ts-node/register test/**/*.test.ts",
     "mocha": "mocha -r ts-node/register"

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -13,7 +13,7 @@
     "src/**/*"
   ],
   "scripts": {
-    "lint": "echo [skip @effection/node]",
+    "lint": "eslint '{src,tests}/**/*.ts'",
     "test": "mocha -r ts-node/register --timeout 5000 test/**/*.test.ts",
     "prepack": "tsdx build --target node --format cjs --tsconfig tsconfig.dist.json",
     "mocha": "mocha -r ts-node/register"

--- a/packages/subscription/package.json
+++ b/packages/subscription/package.json
@@ -13,7 +13,7 @@
     "src/**/*"
   ],
   "scripts": {
-    "lint": "echo 'skip'",
+    "lint": "eslint '{src,tests}/**/*.ts'",
     "test": "mocha -r ts-node/register --timeout 5000 test/**/*.test.ts",
     "prepack": "tsdx build --tsconfig tsconfig.dist.json",
     "mocha": "mocha -r ts-node/register"

--- a/packages/subscription/src/match.ts
+++ b/packages/subscription/src/match.ts
@@ -5,7 +5,9 @@ export type DeepPartial<T> = {
 export function matcher<T>(reference: unknown): (value: T) => boolean {
   return (value: unknown) => {
     if(typeof(value) === 'object' && typeof(reference) === 'object') {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       let castedValue = value as Record<string, any>;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       let castedReference = reference as Record<string, any>;
       return Object.entries(castedReference).every(([key, ref]) => matcher(ref)(castedValue[key]));
     } else {

--- a/packages/subscription/src/subscribable.ts
+++ b/packages/subscription/src/subscribable.ts
@@ -89,6 +89,7 @@ function isSubscribable<T,TReturn>(value: unknown): value is Subscribable<T,TRet
   return !!getSubscriber<T,TReturn>(value);
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function getSubscriber<T,TReturn>(source: any): undefined | (() => Operation<Subscription<T,TReturn>>) {
   return source[SymbolSubscribable] as () => Operation<Subscription<T,TReturn>>;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1127,6 +1127,11 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@frontside/eslint-config@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@frontside/eslint-config/-/eslint-config-1.0.0.tgz#d4db29f1cceafc6ad3735d339964160c96e19b3d"
+  integrity sha512-R3Wu9zVb34GaeDB1AKf1MulnkI+HKdejr0dGLPkWhD5dpwo4FJyDESmil1Bc5/uSn1Gq0zBWzM2QzjmvhLydlA==
+
 "@frontside/tsconfig@0.0.1", "@frontside/tsconfig@^0.0.1":
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/@frontside/tsconfig/-/tsconfig-0.0.1.tgz#f7481d8681fed3d2274991271e6f36fa5e3ed32f"


### PR DESCRIPTION
## Motivation
As mentioned in issue #145, `yarn lint` is just echoing out "skip" for all packages except `packages/effection`.

## Approach
- Added `@frontside/eslint-config` to the monorepo and replaced the echo scripts to run `eslint '{src/test}/**/*.ts'` instead.
- Since `packages/effection` is a javascript package, I've moved the preexisting `.eslintrc.json` file to the effection package directory and added `"root": true` so that it does not combine the conflicting configurations from `@frontside/eslint-config`.
- Fixed some of the warnings and errors from running eslint. Please see TODOs below to confirm it's okay.

## TODOs
- `no explicit any` 
  - [subscription/match](https://github.com/thefrontside/effection/compare/mk/lint?expand=1#diff-047df50d38a88785b69e55fcbc36a6c8)
  - [subscription/subscribable](https://github.com/thefrontside/effection/compare/mk/lint?expand=1#diff-be2624661fda2e0fd160406bff7d615d)
- `no empty function`
  - [events/once](https://github.com/thefrontside/effection/compare/mk/lint?expand=1#diff-5c42d73a03e5a3f1436dee8bb7d647d2)