### PR TITLE
Only require the event listener methods we use

### DIFF
--- a/.changeset/narrow-event-target-interface.md
+++ b/.changeset/narrow-event-target-interface.md
@@ -1,0 +1,7 @@
+---
+"@effection/events": patch
+---
+
+Only require EventTarget-like objects for the `on()` method to
+implement the `addEventListener` and `removeEventlistener` functions,
+not `dispatchEvent`

--- a/packages/events/src/event-source.ts
+++ b/packages/events/src/event-source.ts
@@ -1,9 +1,9 @@
 import { EventEmitter } from 'events';
 
-export type EventSource = EventEmitter | EventTarget
+export type EventSource = EventEmitter | DOMEventTarget
 
-function isEventTarget(target: EventSource): target is EventTarget {
-  return typeof (target as EventTarget).addEventListener === 'function';
+function isEventTarget(target: EventSource): target is DOMEventTarget {
+  return typeof (target as DOMEventTarget).addEventListener === 'function';
 }
 
 export function addListener(source: EventSource, name: string, listener: () => void) {
@@ -20,4 +20,9 @@ export function removeListener(source: EventSource, name: string, listener: () =
   } else {
     source.off(name, listener);
   }
+}
+
+interface DOMEventTarget {
+  addEventListener: EventTarget["addEventListener"];
+  removeEventListener: EventTarget["removeEventListener"];
 }


### PR DESCRIPTION
Motivation
-----------
In [BigTest][1], we're settling on using the `ws` websocket library across the board, but sockets from that library don't implement the full `EventTarget` api, only `{add,remove}EventListener`. This means that we can't use those sockets easily because they cannot be passed to the underlying subscription mechanism which is `on()` from '@effection/events'.

Approach
----------
This relaxes the requirement of what can constitute an EventSource to just things that have the `addEventListener` and `removeEventListener` methods, since those are the only ones we use.

[1]: https://github.com/thefrontside/bigtest