### PR TITLE
Use a single, unique symbol for resources

### DIFF
--- a/.changeset/universal-symbol.md
+++ b/.changeset/universal-symbol.md
@@ -1,0 +1,5 @@
+---
+"effection": minor
+---
+
+Use unique symbol for effection resources

--- a/packages/effection/src/resource.js
+++ b/packages/effection/src/resource.js
@@ -1,6 +1,6 @@
 import { ExecutionContext } from './context';
 
-let symbol = Symbol("resource");
+const symbol = Symbol.for("@effection.resource");
 
 export function contextOf(resource) {
   if(resource instanceof ExecutionContext) {


### PR DESCRIPTION
Motivation
-----------
When installing bigtest into an existing codebase, we ended up with multiple versions of effection. That meant that resources created with one version were not being recognized by another. An example was when we created a ParceProcess to build the manifest. Because the calling context (@bigtest/server) did not recognize the child resource that was returned by @bigtest/parcel as a resource. As a result, the child process was shutdown immediately.

Approach
----------
This uses the [Symbol.for][1] method to always return the same symbol no matter which version of effection that it is imported from.

Note that this will only work for all versions of effection that include this specific change. Previous versions will continue to have the same problem.

[1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/for