### PR TITLE
Convert effection into normal dependency

### DIFF
--- a/.changeset/eliminate-peer-dependencies.md
+++ b/.changeset/eliminate-peer-dependencies.md
@@ -1,0 +1,8 @@
+---
+"@effection/events": patch
+"@effection/fetch": patch
+"@effection/node": patch
+"@effection/subscription": patch
+--
+
+convert `effection` dependency into normal, non-peer dependency

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -20,6 +20,7 @@
     "mocha": "mocha -r ts-node/register"
   },
   "dependencies": {
+    "effection": "^0.6.4",
     "@effection/subscription": "^0.7.1"
   },
   "devDependencies": {
@@ -30,9 +31,6 @@
     "ts-node": "^8.9.0",
     "tsdx": "0.13.2",
     "typescript": "^3.7.0"
-  },
-  "peerDependencies": {
-    "effection": "^0.6.4"
   },
   "volta": {
     "node": "12.16.0",

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -28,10 +28,8 @@
     "ts-node": "8.10.2",
     "tsdx": "0.13.2"
   },
-  "peerDependencies": {
-    "effection": "^0.6.4"
-  },
   "dependencies": {
+    "effection": "^0.6.4",
     "abort-controller": "^3.0.0",
     "cross-fetch": "^3.0.4",
     "node-fetch": "^2.6.0"

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -30,10 +30,8 @@
     "tsdx": "0.13.2",
     "typescript": "^3.7.0"
   },
-  "peerDependencies": {
-    "effection": "^0.6.4"
-  },
   "dependencies": {
+    "effection": "^0.6.4",
     "@effection/events": "^0.7.3"
   },
   "volta": {

--- a/packages/subscription/package.json
+++ b/packages/subscription/package.json
@@ -18,6 +18,9 @@
     "prepack": "tsdx build --tsconfig tsconfig.dist.json",
     "mocha": "mocha -r ts-node/register"
   },
+  "dependencies": {
+    "effection": "^0.6.4"
+  },
   "devDependencies": {
     "@frontside/tsconfig": "0.0.1",
     "expect": "^25.4.0",
@@ -25,9 +28,6 @@
     "ts-node": "^8.9.0",
     "tsdx": "0.13.2",
     "typescript": "^3.7.0"
-  },
-  "peerDependencies": {
-    "effection": "^0.6.4"
   },
   "volta": {
     "node": "12.16.0",


### PR DESCRIPTION
Motivation
----------

Whenever there is a minor change to a peer dependency, this causes changesets to want to release a new major version of the dependent, which isn't what we really want.

Now that we've made effection have a universal unique symbol, we should theoretically be allowed to have several versions of the library that are in-range kicking around in the runtime.

Approach
----------
In the interest of keeping things simple, this converts all peer dependencies on effection into regular dependencies. We can always convert back to peer dependencies in the event that problems do arise.