### PR TITLE
Add changeset action to automate release pull requests

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -3,7 +3,7 @@ name: Publish Preview
 on:
   pull_request:
     branches:
-      - master
+      - 'master'
 
 jobs:
   publish-previews:
@@ -13,6 +13,7 @@ jobs:
     - uses: actions/checkout@v1
     - name: Publish PR Preview
       uses: thefrontside/actions/publish-pr-preview@v1.4
+      if: ${{ github.head_ref != 'changeset/release-master' }}
       with:
         before_all: yarn prepack
         npm_publish: yarn publish

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -3,7 +3,7 @@ name: Publish Preview
 on:
   pull_request:
     branches:
-      - 'master'
+      - master
 
 jobs:
   publish-previews:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
+    - name: Create Release Pull Request
+      uses: changesets/action@master
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Publish Releases
       uses: thefrontside/actions/synchronize-with-npm@v1.7
       with:


### PR DESCRIPTION
## Motivation
Whenever we want to publish a release we need to manually checkout, run `yarn changeset version`, git add and push, and then create the pull request on Github. Not only do we need to run the command and create the pull request manually, we also need to update the release branch as more pull requests get merged to the main branch. Using the changeset action will mitigate all those inconveniences.

## Approach
- Added changeset action to release workflow. When a pull request gets merged it will see if changeset files exist on the repository and if it does it'll create a pull request (or push to a pre-existing release pull request).
  - The release action will run regardless of whether or not changesets files exist.
- Added conditional to the publish-preview action so that the action only runs if the head branch of the pull request is _not_ `changeset/release-master`.
<img width="955" alt="Screen Shot 2020-06-23 at 2 11 13 PM" src="https://user-images.githubusercontent.com/29791650/85440583-350ec300-b55c-11ea-9d9d-b1bebc6f228f.png">

## TODOs
- [ ] Should we create the same conditional on the test workflow so that we don't use resources on testing for the release pull request?