### PR TITLE
Run yarn before changeset action in release

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v1
     - name: Publish PR Preview
       uses: thefrontside/actions/publish-pr-preview@v1.4
-      if: ${{ github.head_ref != 'changeset/release-master' }}
+      if: ${{ github.head_ref != 'changeset-release/master' }}
       with:
         before_all: yarn prepack
         npm_publish: yarn publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
+    - name: Install Dependencies
+      run: yarn
     - name: Create Release Pull Request
       uses: changesets/action@master
       env:


### PR DESCRIPTION
To fix #159.

Forgot to add `run: yarn` prior to running the changeset action.

And also fixed the typo on the preview filter.