### PR TITLE
Run changeset action in separate workflow

### DIFF
--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -1,0 +1,19 @@
+name: Changeset
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  create-release-pr:
+    name: Create Changeset PR
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install Dependencies
+      run: yarn
+    - name: Create Release Pull Request
+      uses: changesets/action@master
+      env:
+        GITHUB_TOKEN: ${{ secrets.FRONTSIDEJACK_GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,12 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Install Dependencies
-      run: yarn
-    - name: Create Release Pull Request
-      uses: changesets/action@master
-      env:
-        GITHUB_TOKEN: ${{ secrets.FRONTSIDEJACK_GITHUB_TOKEN }}
     - name: Publish Releases
       uses: thefrontside/actions/synchronize-with-npm@v1.7
       with:


### PR DESCRIPTION
Fixing some of the hiccups of using changeset action and our synchronize-with-npm action by separating them into two workflows. Based on the most recent merge to master on [bigtest](https://github.com/thefrontside/bigtest/runs/806517072) we can see that they're both functioning as intended. You can see the PR that fixed the issue [here](https://github.com/thefrontside/bigtest/pull/361).