### PR TITLE
use effection as dependency

### DIFF
--- a/.changeset/fix-channel-deps.md
+++ b/.changeset/fix-channel-deps.md
@@ -1,0 +1,4 @@
+---
+"@effection/channel": patch
+---
+use effection as dependency, not peer dependency

--- a/packages/channel/package.json
+++ b/packages/channel/package.json
@@ -26,14 +26,12 @@
     "tsdx": "^0.13.2",
     "typescript": "^3.7.0"
   },
-  "peerDependencies": {
-    "effection": "^0.6.0"
-  },
   "volta": {
     "node": "12.16.0",
     "yarn": "1.19.1"
   },
   "dependencies": {
+    "effection": "^0.7.0",
     "@effection/events": "^0.7.5",
     "@effection/subscription": "^0.8.0"
   }


### PR DESCRIPTION
Motivation
-----------

We want to keep our dependencies simple if we can.

Approach
----------

We take the same tack that we have in other packages and use effection as a simple dependency. And since we fixed the effection resources to use `Symbol.for()` to retrieve the effection symbol this has worked out great.