### PR TITLE
Migrate to 'v*' from 'master' branch

### DIFF
--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -3,7 +3,7 @@ name: Changeset
 on:
   push:
     branches:
-      - master
+      - 'v[0-9]+'
 
 jobs:
   create-release-pr:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,9 +1,9 @@
-name: Publish Preview
+name: Preview
 
 on:
   pull_request:
     branches:
-      - master
+      - 'v[0-9]+'
 
 jobs:
   publish-previews:
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v1
     - name: Publish PR Preview
       uses: thefrontside/actions/publish-pr-preview@v1.4
-      if: ${{ github.head_ref != 'changeset-release/master' }}
+      if: ${{ !startsWith(github.head_ref, 'changeset-release/') }}
       with:
         before_all: yarn prepack
         npm_publish: yarn publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,9 @@
-name: Publish Release
+name: Release
 
 on:
   push:
     branches:
-      - master
+      - 'v[0-9]+'
 
 jobs:
   publish-releases:


### PR DESCRIPTION
Closes #157.

## Motivation
We're moving away from using `master` as the default branch.

## Approach
- Update workflows to run on `v[0-9]+`.
- Complete the TODOs below.

## TODOs
- [x] Create and push `v0` branch.
- [x] Set `v0` as default.
- [x] Update all PRs' base branch to `v0`.
- [x] Update branch protection rules.
- [x] Delete `master` branch.
### 👋👋👋
![Screen Shot 2020-07-01 at 5 44 17 PM](https://user-images.githubusercontent.com/29791650/86294502-a258ce80-bbc2-11ea-8ee2-2266e82ef8d4.png)