### PR TITLE
make type of SymbolSubscribable global

### DIFF
--- a/.changeset/global-subscribable-symbol-type.md
+++ b/.changeset/global-subscribable-symbol-type.md
@@ -1,0 +1,4 @@
+---
+"@effection/subscription": minor
+---
+make the type of SymbolSubscribable global, not just the value

--- a/packages/subscription/src/index.ts
+++ b/packages/subscription/src/index.ts
@@ -1,5 +1,6 @@
 export { Subscription, createSubscription } from './subscription';
-export { SymbolSubscribable, SubscriptionSource, forEach, Subscribable } from './subscribable';
+export { SymbolSubscribable } from './symbol-subscribable';
+export { SubscriptionSource, forEach, Subscribable } from './subscribable';
 export { ChainableSubscription } from './chainable-subscription';
 
 import { Operation } from 'effection';

--- a/packages/subscription/src/subscribable.ts
+++ b/packages/subscription/src/subscribable.ts
@@ -1,8 +1,7 @@
 import { Operation } from 'effection';
 import { Subscription, createSubscription, Subscriber } from './subscription';
 import { DeepPartial, matcher } from './match';
-
-export const SymbolSubscribable: unique symbol = Symbol.for('Symbol.subscription');
+import { SymbolSubscribable } from './symbol-subscribable';
 
 export interface Subscribable<T,TReturn> {
   [SymbolSubscribable](): Operation<Subscription<T,TReturn>>;

--- a/packages/subscription/src/symbol-subscribable.ts
+++ b/packages/subscription/src/symbol-subscribable.ts
@@ -1,0 +1,23 @@
+/**
+ * Hack Zone!
+ *
+ * tl;dr not only the symbol value, but also the symbol type must be
+ * global.
+ *
+ * In order to satisfy TypeScript that the SymbolSubscribable
+ * represents the same value across different versions of the same
+ * package, we need to declare a "fake" global variable that does not
+ * actually exist, but has a theoretical type. Since it is global,
+ * TypeScript will see it as the same type everywhere, and so we can
+ * use the `typeof` for the value, as the type of of our local symbol
+ * subscribable, and TypeScript will think that all of the types are
+ * the same.
+ *
+ * See https://github.com/microsoft/TypeScript/issues/8099#issuecomment-210134773
+ * for details.
+ */
+declare global {
+  const __global_variable_to_hold_type_of_global_subscribable_symbol: unique symbol;
+}
+
+export const SymbolSubscribable: typeof __global_variable_to_hold_type_of_global_subscribable_symbol = Symbol.for('Symbol.subscription') as any;

--- a/packages/subscription/src/symbol-subscribable.ts
+++ b/packages/subscription/src/symbol-subscribable.ts
@@ -16,6 +16,8 @@
  * See https://github.com/microsoft/TypeScript/issues/8099#issuecomment-210134773
  * for details.
  */
+
+/* eslint-disable */
 declare global {
   const __global_variable_to_hold_type_of_global_subscribable_symbol: unique symbol;
 }


### PR DESCRIPTION
Motivation
-----------
While the value of SymbolSubscribable was global, the type was not, and so TypeScript did not recognize the different versions of `SymbolSubscribable` from different package version as being the same type. As a result, the `Subscribable` interface:

```ts
interface Subscribable<T,TResult> {
  [SymbolSubscribable]): Operation<Subscription<T,TResult>;
}
```

while sharing a name, had a different structure and so TypeScript effectively recognized them as a different interface from different package versions. So a subscribable defined with "@effection/subscription" 0.8.0 and a function that consumed subscribables using the definion in 0.8.1 did not type-match.

Approach
----------

This allocates a totally fake global variable whose unique type can be used as the type of `SymbolSubscribable`. That way, TypeScript will always use that global type no matter which version of the package it is using and so it will recognie interfaces that reference that symbol as being the same.

Learning
---------

Using a symbol to define interfaces is not all that common, but does happen when defining library interop such as with `Observable` See https://github.com/microsoft/TypeScript/issues/8099#issuecomment-210134773

The approach taken by Observable is to declare the global symbol `Symbol.observable`, but we've opted for a name-mangled global since there aren't (currently) any aspirations to push for the effection subscription API to be adopted into JavaScript proper as in the case of Observable. However, the basic strategy is still the same.
