### PR TITLE
Preserve order of events when closing channel

### DIFF
--- a/.changeset/channel-close-event-order.md
+++ b/.changeset/channel-close-event-order.md
@@ -1,0 +1,4 @@
+---
+"@effection/channel": "patch"
+---
+Preserve order of events when closing channel

--- a/packages/channel/src/channel.ts
+++ b/packages/channel/src/channel.ts
@@ -1,6 +1,6 @@
-import { Operation, spawn } from 'effection';
-import { Subscribable, Subscription, SymbolSubscribable, createSubscription, forEach } from '@effection/subscription';
-import { on, once } from '@effection/events';
+import { Operation } from 'effection';
+import { Subscribable, Subscription, SymbolSubscribable, createSubscription } from '@effection/subscription';
+import { on } from '@effection/events';
 import { EventEmitter } from 'events';
 
 export class Channel<T, TClose = undefined> implements Subscribable<T, TClose> {
@@ -15,21 +15,25 @@ export class Channel<T, TClose = undefined> implements Subscribable<T, TClose> {
   }
 
   send(message: T) {
-    this.bus.emit('message', message);
+    this.bus.emit('event', { done: false, value: message });
   }
 
   subscribe(): Operation<Subscription<T, TClose>> {
     let { bus } = this;
     return createSubscription(function*(publish) {
-      yield spawn(forEach(on(bus, 'message'), function*([message]) {
-        publish(message as T);
-      }));
-      let [closeValue] = yield once(bus, 'close');
-      return closeValue;
+      let subscription = yield on(bus, 'event');
+      while(true) {
+        let [event] = yield subscription.expect();
+        if(event.done) {
+          return event.value;
+        } else {
+          publish(event.value);
+        }
+      }
     });
   }
 
   close(...args: TClose extends undefined ? [] : [TClose]) {
-    this.bus.emit('close', args[0]);
+    this.bus.emit('event', { done: true, value: args[0] });
   }
 }

--- a/packages/channel/test/channel.test.ts
+++ b/packages/channel/test/channel.test.ts
@@ -89,13 +89,13 @@ describe('Channel', () => {
       beforeEach(async () => {
         channel = new Channel();
         subscription = await World.spawn(channel.subscribe());
+        channel.send('foo');
         channel.close();
       });
 
       it('closes subscriptions', async () => {
-        let result = await World.spawn(subscription.next());
-        expect(result.done).toEqual(true);
-        expect(result.value).toEqual(undefined);
+        await expect(World.spawn(subscription.next())).resolves.toEqual({ done: false, value: 'foo' });
+        await expect(World.spawn(subscription.next())).resolves.toEqual({ done: true, value: undefined });
       });
     });
 
@@ -106,13 +106,13 @@ describe('Channel', () => {
       beforeEach(async () => {
         channel = new Channel();
         subscription = await World.spawn(channel.subscribe());
+        channel.send('foo');
         channel.close(12);
       });
 
       it('closes subscriptions with the argument', async () => {
-        let result = await World.spawn(subscription.next());
-        expect(result.done).toEqual(true);
-        expect(result.value).toEqual(12);
+        await expect(World.spawn(subscription.next())).resolves.toEqual({ done: false, value: 'foo' });
+        await expect(World.spawn(subscription.next())).resolves.toEqual({ done: true, value: 12 });
       });
     });
   });


### PR DESCRIPTION
When synchronously sending messages and closing a channel, we still want all of the previously sent messages to arrive in the subscription before the channel is closed.