### PR TITLE
Chaining subscriptions via `subscribe(...)`

### DIFF
--- a/.changeset/subscribable-cake.md
+++ b/.changeset/subscribable-cake.md
@@ -1,0 +1,4 @@
+---
+"@effection/subscription": "minor"
+---
+Chain via `subscribe` instead of `Subscribable.from` which is now deprecated.

--- a/packages/subscription/README.md
+++ b/packages/subscription/README.md
@@ -64,45 +64,64 @@ method in order to be turned into a subscription. This follows the
 pattern of `Symbol.iterator`, and `Symbol.observable`. Any object that
 implements this method can be consumed as a subscription.
 
-### Subscribable.from(source)
+### subscribe(source)
 
-In order to lift functions into the context of a subscription, you can
-use `Subscribable.from` which will return an instance of
-`Subscribable` that allows you to transform a subscription produced
+In order to lift functions into the context of a subscription, you can use
+`subscribe` which can be used to transform subscriptions via combinators.
 
-### Subscribable#map(fn)
+### map(fn)
 
 Returns a new subscribable whose items are transformed by `fn`. For
 example:
 
 ``` javascript
-Subscribable.from(websocket).map(message => JSON.parse(message));
+subscribe(websocket).map(message => JSON.parse(message));
 ```
 
-### Subscribable#filter(predicate)
+### filter(predicate)
 
 Return a new `Subscribable` that only produces items from its source
 that match `predicate`.
 
 ``` javascript
-Subscribable.from(websocket).filter(message => message.type === 'command');
+subscribe(websocket).filter(message => message.type === 'command');
 ```
 
-### Subscribable#match(reference)
+### match(reference)
 
 Return a new `Subscribable` that only produces items from its source that match
 `reference` in the sense that the produced items have the same properties and
 values as `reference`.
 
 ``` javascript
-Subscribable.from(websocket).match({ type: 'command' });
+subscribe(websocket).match({ type: 'command' });
 ```
 
-### Subscribable#first()
+### first()
 
 An operation that produces the first item in a subscription or
 undefined if the subscription has no items.
 
 ``` javascript
-let message = yield Subscribable.from(websocket).first();
+let message = yield subscribe(websocket).first();
+```
+
+### expect()
+
+An operation that produces the first item in a subscription or
+throws an error if the subscription has no items.
+
+``` javascript
+let message = yield subscribe(websocket).expect();
+```
+
+### forEach()
+
+Calls the given operation function with each item in the subscription. Returns
+the return value of the subscriopion when done.
+
+``` javascript
+let exitCode = yield subscribe(websocket).forEach(function*(message) {
+  // ...
+});
 ```

--- a/packages/subscription/src/chainable-subscribable.ts
+++ b/packages/subscription/src/chainable-subscribable.ts
@@ -1,0 +1,62 @@
+import { Operation } from 'effection';
+import { ChainableSubscription } from './chainable-subscription';
+import { DeepPartial } from './match';
+import { Subscribable } from './subscribable';
+import { SymbolSubscribable } from './symbol-subscribable';
+import { Subscription } from './subscription';
+
+export interface ChainableSubscribableMethods<T,TReturn> extends Subscribable<T,TReturn> {
+  filter(predicate: (value: T) => boolean): ChainableSubscribable<T, TReturn>;
+  match(reference: DeepPartial<T>): ChainableSubscribable<T,TReturn>;
+  map<R>(mapper: (value: T) => R): ChainableSubscribable<R, TReturn>;
+  first(): Operation<T | undefined>;
+  expect(): Operation<T>;
+  forEach(visit: (value: T) => Operation<void>): Operation<TReturn>;
+  next(): Operation<IteratorResult<T, TReturn>>;
+}
+
+export type ChainableSubscribable<T, TReturn> = Operation<ChainableSubscription<T, TReturn>> & ChainableSubscribableMethods<T, TReturn>;
+
+export function makeChainable<T, TReturn>(
+  operation: Operation<ChainableSubscription<T, TReturn>>
+): ChainableSubscribable<T, TReturn> {
+  return Object.assign(operation, {
+    *[SymbolSubscribable](): Operation<Subscription<T,TReturn>> {
+      return yield operation;
+    },
+
+    filter(predicate: (value: T) => boolean): ChainableSubscribable<T, TReturn> {
+      return makeChainable(function*() {
+        return yield ChainableSubscription.wrap<T, TReturn>(operation, (inner) => inner.filter(predicate));
+      });
+    },
+
+    match(reference: DeepPartial<T>): ChainableSubscribable<T,TReturn> {
+      return makeChainable(function*() {
+        return yield ChainableSubscription.wrap<T, TReturn>(operation, (inner) => inner.match(reference));
+      });
+    },
+
+    map<R>(mapper: (value: T) => R): ChainableSubscribable<R, TReturn> {
+      return makeChainable(function*() {
+        return yield ChainableSubscription.wrap<T, TReturn, R>(operation, (inner) => inner.map(mapper));
+      });
+    },
+
+    *first(): Operation<T | undefined> {
+      return yield (yield operation).first();
+    },
+
+    *expect(): Operation<T> {
+      return yield (yield operation).expect();
+    },
+
+    *forEach(visit: (value: T) => Operation<void>): Operation<TReturn> {
+      return yield (yield operation).forEach(visit);
+    },
+
+    *next(): Operation<IteratorResult<T, TReturn>> {
+      return yield (yield operation).next();
+    }
+  });
+};

--- a/packages/subscription/src/index.ts
+++ b/packages/subscription/src/index.ts
@@ -1,12 +1,17 @@
 export { Subscription, createSubscription } from './subscription';
 export { SymbolSubscribable } from './symbol-subscribable';
-export { SubscriptionSource, forEach, Subscribable } from './subscribable';
+export { Subscribable } from './subscribable';
+export { SubscriptionSource } from './subscription-source';
 export { ChainableSubscription } from './chainable-subscription';
+export { ChainableSubscribable } from './chainable-subscribable';
+export { subscribe } from './subscribe';
 
 import { Operation } from 'effection';
-import { ChainableSubscription } from './chainable-subscription';
-import { SubscriptionSource } from './subscribable';
+import { SubscriptionSource } from './subscription-source';
+import { subscribe } from './subscribe';
 
-export function* subscribe<T, TReturn>(source: SubscriptionSource<T,TReturn>): Operation<ChainableSubscription<T,TReturn>> {
-  return yield ChainableSubscription.of(source);
+export function* forEach<T,TReturn>(source: SubscriptionSource<T,TReturn>, visit: (value: T) => Operation<void>): Operation<TReturn> {
+  console.warn('`forEach(source, ...)` is deprecated, use `subscribe(source).forEach(...)` instead');
+  return yield subscribe<T, TReturn>(source).forEach(visit);
 }
+

--- a/packages/subscription/src/subscribable.ts
+++ b/packages/subscription/src/subscribable.ts
@@ -1,83 +1,16 @@
 import { Operation } from 'effection';
-import { Subscription, createSubscription, Subscriber } from './subscription';
-import { DeepPartial, matcher } from './match';
+import { Subscription } from './subscription';
 import { SymbolSubscribable } from './symbol-subscribable';
+import { subscribe } from './subscribe';
+import { SubscriptionSource } from './subscription-source';
 
 export interface Subscribable<T,TReturn> {
   [SymbolSubscribable](): Operation<Subscription<T,TReturn>>;
 }
 
-export type SubscriptionSource<T,TReturn> = Subscribable<T,TReturn> | Operation<Subscription<T,TReturn>>;
-
-export function* forEach<T,TReturn>(source: SubscriptionSource<T,TReturn>, visit: (value: T) => Operation<void>): Operation<TReturn> {
-  let subscription: Subscription<T,TReturn> = yield subscribe(source);
-  while (true) {
-    let result: IteratorResult<T,TReturn> = yield subscription.next();
-    if (result.done) {
-      return result.value;
-    } else {
-      yield visit(result.value);
-    }
-  }
-}
-
 export const Subscribable = {
-  from: <T,TReturn>(source: SubscriptionSource<T,TReturn>) => new Chain(source)
-}
-
-export class Chain<T, TReturn> implements Subscribable<T,TReturn> {
-  constructor(private source: SubscriptionSource<T,TReturn>) {}
-
-  [SymbolSubscribable](): Operation<Subscription<T,TReturn>> {
-    return subscribe(this.source)
+  from<T,TReturn>(source: SubscriptionSource<T,TReturn>) {
+    console.warn('`Subscribable.from(source)` is deprecated, use `subscribe(source).map(...)` instead');
+    return subscribe(source)
   }
-
-  map<X>(fn: (value: T) => X): Chain<X,TReturn> {
-    return this.chain(source => publish => forEach(source, function*(item) {
-      publish(fn(item));
-    }));
-  }
-
-  filter(predicate: (value: T) => boolean): Chain<T,TReturn> {
-    return this.chain(source => publish => forEach(source, function*(item) {
-      if (predicate(item)) {
-        publish(item);
-      }
-    }))
-  }
-
-  match(reference: DeepPartial<T>): Chain<T,TReturn> {
-    return this.filter(matcher(reference));
-  }
-
-  chain<X = T,XReturn = TReturn>(next: (source: SubscriptionSource<T,TReturn>) => Subscriber<X,XReturn>): Chain<X,XReturn> {
-    return new Chain(createSubscription(next(this.source)));
-  }
-
-  forEach(visit: (value: T) => Operation<void>): Operation<TReturn> {
-    return forEach(this.source, visit);
-  }
-
-  *first(): Operation<T | undefined> {
-    let subscription: Subscription<T, TReturn> = yield subscribe(this.source);
-    let { done, value } = yield subscription.next();
-    if (done) {
-      return undefined;
-    } else {
-      return value;
-    }
-  }
-}
-
-export function subscribe<T, TReturn>(source: SubscriptionSource<T,TReturn>): Operation<Subscription<T,TReturn>> {
-  if (isSubscribable<T,TReturn>(source)) {
-    return source[SymbolSubscribable]()
-  } else {
-    return source;
-  }
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function isSubscribable<T,TReturn>(value: any): value is Subscribable<T,TReturn> {
-  return !!value[SymbolSubscribable];
 }

--- a/packages/subscription/src/subscribe.ts
+++ b/packages/subscription/src/subscribe.ts
@@ -1,0 +1,8 @@
+import { Operation } from 'effection';
+import { ChainableSubscription } from './chainable-subscription';
+import { SubscriptionSource } from './subscription-source';
+import { makeChainable, ChainableSubscribable } from './chainable-subscribable';
+
+export function subscribe<T, TReturn>(source: SubscriptionSource<T,TReturn>): Operation<ChainableSubscription<T, TReturn>> & ChainableSubscribable<T,TReturn> {
+  return makeChainable(function*() { return yield ChainableSubscription.of(source) });
+}

--- a/packages/subscription/src/subscription-source.ts
+++ b/packages/subscription/src/subscription-source.ts
@@ -1,0 +1,22 @@
+import { Operation } from 'effection';
+import { Subscribable } from './subscribable';
+import { Subscription } from './subscription';
+import { SymbolSubscribable } from './symbol-subscribable';
+import { ChainableSubscription } from './chainable-subscription';
+
+// We have to add Subscription and ChainableSubscription separately here, even
+// though ChainableSubscription is a subtype of Subscription because the
+// `Operation<T>` type is invariant.
+export type SubscriptionSource<T,TReturn> = Subscribable<T,TReturn> | Operation<Subscription<T,TReturn>> | Operation<ChainableSubscription<T,TReturn>>;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function isSubscribable<T,TReturn>(value: any): value is Subscribable<T,TReturn> {
+  return !!value[SymbolSubscribable];
+}
+
+export function rawSubscribe<T, TReturn>(source: SubscriptionSource<T,TReturn>): Operation<Subscription<T,TReturn>> {
+  if (isSubscribable<T,TReturn>(source)) {
+    return source[SymbolSubscribable]()
+  } else {
+    return source as Operation<Subscription<T, TReturn>>;
+  }
+}

--- a/packages/subscription/test/chainable-subscribable.test.ts
+++ b/packages/subscription/test/chainable-subscribable.test.ts
@@ -3,7 +3,7 @@ import { describe, it, beforeEach } from 'mocha';
 import { spawn } from './helpers';
 
 import { Operation } from 'effection';
-import { createSubscription, ChainableSubscription, Subscribable, SymbolSubscribable, forEach } from '../src/index';
+import { subscribe, createSubscription, ChainableSubscription, Subscribable, SymbolSubscribable, forEach } from '../src/index';
 
 interface Thing {
   name: string;
@@ -20,24 +20,18 @@ function* stuff(): Operation<ChainableSubscription<Thing, number>> {
 }
 
 function* emptySubscription(): Operation<ChainableSubscription<Thing, number>> {
-  return yield createSubscription(function*(publish) {
+  return yield createSubscription(function*() {
     return 12;
   })
 }
 
 describe('chaining subscriptions', () => {
-  let subscription: ChainableSubscription<Thing, number>;
-
-  beforeEach(async () => {
-    subscription = await spawn(stuff);
-  });
-
   describe('forEach', () => {
     let values: Thing[];
     let result: number;
     beforeEach(async () => {
       values = [];
-      result = await spawn(subscription.forEach(function*(item) { values.push(item); }));
+      result = await spawn(subscribe(stuff).forEach(function*(item) { values.push(item); }));
     });
 
     it('iterates through all members of the subscribable', () => {
@@ -55,7 +49,7 @@ describe('chaining subscriptions', () => {
 
   describe('map', () => {
     it('maps over the values', async () => {
-      let mapped = subscription.map(item => `hello ${item.name}`);
+      let mapped = await spawn(subscribe(stuff).map(item => `hello ${item.name}`));
       await expect(spawn(mapped.next())).resolves.toEqual({ done: false, value: 'hello bob' });
       await expect(spawn(mapped.next())).resolves.toEqual({ done: false, value: 'hello alice' });
       await expect(spawn(mapped.next())).resolves.toEqual({ done: false, value: 'hello world' });
@@ -65,7 +59,7 @@ describe('chaining subscriptions', () => {
 
   describe('filter', () => {
     it('filters the values', async () => {
-      let filtered = subscription.filter(item => item.type === 'person');
+      let filtered = await spawn(subscribe(stuff).filter(item => item.type === 'person'));
       await expect(spawn(filtered.next())).resolves.toEqual({ done: false, value: { name: 'bob', type: 'person' } });
       await expect(spawn(filtered.next())).resolves.toEqual({ done: false, value: { name: 'alice', type: 'person' } });
       await expect(spawn(filtered.next())).resolves.toEqual({ done: true, value: 3 });
@@ -74,14 +68,14 @@ describe('chaining subscriptions', () => {
 
   describe('match', () => {
     it('filters the values based on the given pattern', async () => {
-      let matched = subscription.match({ type: 'person' });
+      let matched = await spawn(subscribe(stuff).match({ type: 'person' }));
       await expect(spawn(matched.next())).resolves.toEqual({ done: false, value: { name: 'bob', type: 'person' } });
       await expect(spawn(matched.next())).resolves.toEqual({ done: false, value: { name: 'alice', type: 'person' } });
       await expect(spawn(matched.next())).resolves.toEqual({ done: true, value: 3 });
     });
 
     it('can work on nested items', async () => {
-      let matched = subscription.map(item => ({ thing: item })).match({ thing: { type: 'person' } });
+      let matched = await spawn(subscribe(stuff).map(item => ({ thing: item })).match({ thing: { type: 'person' } }));
       await expect(spawn(matched.next())).resolves.toEqual({ done: false, value: { thing: { name: 'bob', type: 'person' } } });
       await expect(spawn(matched.next())).resolves.toEqual({ done: false, value: { thing: { name: 'alice', type: 'person' } } });
       await expect(spawn(matched.next())).resolves.toEqual({ done: true, value: 3 });
@@ -90,25 +84,23 @@ describe('chaining subscriptions', () => {
 
   describe('first', () => {
     it('returns the first item in the subscription', async () => {
-      await expect(spawn(subscription.first())).resolves.toEqual({ name: 'bob', type: 'person' });
+      await expect(spawn(subscribe(stuff).first())).resolves.toEqual({ name: 'bob', type: 'person' });
     });
 
     it('returns undefined if the subscription is empty', async () => {
-      let subscription = await spawn(emptySubscription);
-      await expect(spawn(subscription.first())).resolves.toEqual(undefined);
+      await expect(spawn(subscribe(emptySubscription).first())).resolves.toEqual(undefined);
     });
   });
 
   describe('expect', () => {
     it('returns the first item in the subscription', async () => {
-      await expect(spawn(subscription.expect())).resolves.toEqual({ name: 'bob', type: 'person' });
+      await expect(spawn(subscribe(stuff).expect())).resolves.toEqual({ name: 'bob', type: 'person' });
     });
 
     it('throws an error if the subscription is empty', async () => {
-      let subscription = await spawn(emptySubscription);
       await spawn(function*() {
         try {
-          yield subscription.expect();
+          yield subscribe(emptySubscription).expect();
           throw new Error('unreachable');
         } catch(e) {
           expect(e.message).toEqual('expected subscription to contain a value');

--- a/packages/subscription/test/subscription.test.ts
+++ b/packages/subscription/test/subscription.test.ts
@@ -2,7 +2,7 @@ import * as expect from 'expect';
 import { timeout } from 'effection';
 import { spawn } from './helpers';
 
-import { Subscription, Subscribable, createSubscription } from '../src/index';
+import { subscribe, Subscription, createSubscription } from '../src/index';
 
 import { Semaphore } from '../src/semaphore';
 
@@ -97,7 +97,7 @@ describe('subscriptions', () => {
     it('dispatches results independently', async () => {
       let doSubscribe = () => createSubscription<number,void>(function*(publish) { yield timeout(2); publish(1) })
 
-      let subscribable = Subscribable.from(doSubscribe());
+      let subscribable = subscribe(doSubscribe());
 
       let one = spawn(subscribable.first())
       let two = spawn(subscribable.first())


### PR DESCRIPTION
The distinction between ChainableSubscription and Subscribable.from is pretty odd and hard to understand. What if we could have our cake and eat it too? This allows us to do:

``` typescript
yield subscribe(people).map((s) => s.name).expect();
```

AND

``` typescript
let subscription = yield subscribe(people).map((s) => s.name)
yield subscription.expect();
```

AND

``` typescript
let subscription = yield subscribe(people);
yield subscription.map((s) => s.name).expect();
```

Why do we want all three of them? Because their semantics are slightly different when it comes to consumption of the subscription, and because we don't always have an actual subscribable object.

This is all also very easy to understand, because even though there is a lot of trickery involved in making this actually work, it *looks* very simple.

This also deprecates `Subscribable.from` and `forEach` since they are no longer needed.