### PR TITLE
Make `createSubscription` chainable

### DIFF
--- a/.changeset/create-subscription-chainable.md
+++ b/.changeset/create-subscription-chainable.md
@@ -1,0 +1,7 @@
+---
+"@effection/subscription": minor
+"@effection/events": patch
+"@effection/channel": patch
+---
+
+Subscriptions created via `createSubscription` are chainable on both sides of the yield

--- a/packages/channel/src/channel.ts
+++ b/packages/channel/src/channel.ts
@@ -6,8 +6,8 @@ import { EventEmitter } from 'events';
 export class Channel<T, TClose = undefined> implements Subscribable<T, TClose> {
   private bus = new EventEmitter();
 
-  [SymbolSubscribable](): Operation<Subscription<T, TClose>> {
-    return this.subscribe();
+  *[SymbolSubscribable](): Operation<Subscription<T, TClose>> {
+    return yield this.subscribe();
   }
 
   setMaxListeners(value: number) {
@@ -18,7 +18,7 @@ export class Channel<T, TClose = undefined> implements Subscribable<T, TClose> {
     this.bus.emit('event', { done: false, value: message });
   }
 
-  subscribe(): Operation<Subscription<T, TClose>> {
+  subscribe() {
     let { bus } = this;
     return createSubscription(function*(publish) {
       let subscription = yield on(bus, 'event');

--- a/packages/channel/test/channel.test.ts
+++ b/packages/channel/test/channel.test.ts
@@ -15,7 +15,7 @@ describe('Channel', () => {
 
     beforeEach(async () => {
       channel = new Channel();
-      subscription = await World.spawn(channel.subscribe());
+      subscription = await World.spawn(subscribe(channel));
     });
 
     describe('sending a message', () => {
@@ -88,7 +88,7 @@ describe('Channel', () => {
 
       beforeEach(async () => {
         channel = new Channel();
-        subscription = await World.spawn(channel.subscribe());
+        subscription = await World.spawn(subscribe(channel));
         channel.send('foo');
         channel.close();
       });
@@ -105,7 +105,7 @@ describe('Channel', () => {
 
       beforeEach(async () => {
         channel = new Channel();
-        subscription = await World.spawn(channel.subscribe());
+        subscription = await World.spawn(subscribe(channel));
         channel.send('foo');
         channel.close(12);
       });

--- a/packages/events/test/on.test.ts
+++ b/packages/events/test/on.test.ts
@@ -83,4 +83,25 @@ describe("on", () => {
       });
     });
   });
+
+  describe('chaining', () => {
+    let emitter: EventEmitter;
+    let subscription: Subscription<number, void>;
+
+    beforeEach(async () => {
+      emitter = new EventEmitter();
+      subscription = await World.spawn(on(emitter, "thing").map(([value]) => (value as number) * 2));
+    });
+
+    describe('emitting an event', () => {
+      beforeEach(() => {
+        emitter.emit("thing", 12);
+      });
+
+      it('receives event', async () => {
+        let { value } = await World.spawn(subscription.next());
+        expect(value).toEqual(24);
+      });
+    });
+  });
 });

--- a/packages/subscription/src/create-subscription.ts
+++ b/packages/subscription/src/create-subscription.ts
@@ -1,0 +1,46 @@
+import { Operation, resource } from 'effection';
+
+import { ChainableSubscription } from './chainable-subscription';
+import { makeChainable, ChainableSubscribable } from './chainable-subscribable';
+import { Semaphore } from './semaphore';
+
+export type Subscriber<T,TReturn> = (publish: (value: T) => void) => Operation<TReturn>;
+
+export function createSubscription<T, TReturn>(subscribe: Subscriber<T,TReturn>): ChainableSubscribable<T,TReturn> {
+  return makeChainable(function*() {
+    let results: IteratorResult<T,TReturn>[] = [];
+
+    let semaphore = new Semaphore<void>();
+
+    let publish = (value: T) => {
+      results.push({ done: false, value });
+      semaphore.signal();
+    };
+
+    let next = async (): Promise<IteratorResult<T,TReturn>> => {
+      let wait = semaphore.wait();
+      if (results.length > 0) {
+        semaphore.signal();
+      }
+      return wait.then(() => results.shift() as IteratorResult<T,TReturn>);
+    };
+
+    let subscription = yield resource(new ChainableSubscription({ next }), function*() {
+      try {
+        let value = yield subscribe((value: T) => publish(value));
+        results.push({ done: true, value });
+        semaphore.signal();
+      } finally {
+        publish = value => { throw InvalidPublication(value); }
+      }
+    });
+
+    return subscription;
+  });
+}
+
+function InvalidPublication(value: unknown) {
+  let error = new Error(`tried to publish a value: ${value} on an already finished subscription`);
+  error.name = 'TypeError';
+  return error;
+}

--- a/packages/subscription/src/index.ts
+++ b/packages/subscription/src/index.ts
@@ -1,4 +1,5 @@
-export { Subscription, createSubscription } from './subscription';
+export { Subscription } from './subscription';
+export { createSubscription } from './create-subscription';
 export { SymbolSubscribable } from './symbol-subscribable';
 export { Subscribable } from './subscribable';
 export { SubscriptionSource } from './subscription-source';

--- a/packages/subscription/src/subscription.ts
+++ b/packages/subscription/src/subscription.ts
@@ -1,49 +1,7 @@
-import { Operation, resource } from 'effection';
-
-import { ChainableSubscription } from './chainable-subscription';
-import { Semaphore } from './semaphore';
+import { Operation } from 'effection';
 
 export type Subscriber<T,TReturn> = (publish: (value: T) => void) => Operation<TReturn>;
 
 export interface Subscription<T,TReturn> {
   next(): Operation<IteratorResult<T,TReturn>>;
-}
-
-export function createSubscription<T, TReturn>(subscribe: Subscriber<T,TReturn>): Operation<Subscription<T,TReturn>> {
-  return function*() {
-    let results: IteratorResult<T,TReturn>[] = [];
-
-    let semaphore = new Semaphore<void>();
-
-    let publish = (value: T) => {
-      results.push({ done: false, value });
-      semaphore.signal();
-    };
-
-    let next = async (): Promise<IteratorResult<T,TReturn>> => {
-      let wait = semaphore.wait();
-      if (results.length > 0) {
-        semaphore.signal();
-      }
-      return wait.then(() => results.shift() as IteratorResult<T,TReturn>);
-    };
-
-    let subscription = yield resource(new ChainableSubscription({ next }), function*() {
-      try {
-        let value = yield subscribe((value: T) => publish(value));
-        results.push({ done: true, value });
-        semaphore.signal();
-      } finally {
-        publish = value => { throw InvalidPublication(value); }
-      }
-    });
-
-    return subscription;
-  }
-}
-
-function InvalidPublication(value: unknown) {
-  let error = new Error(`tried to publish a value: ${value} on an already finished subscription`);
-  error.name = 'TypeError';
-  return error;
 }

--- a/packages/subscription/test/subscribable.test.ts
+++ b/packages/subscription/test/subscribable.test.ts
@@ -14,12 +14,14 @@ describe('subscribable objects', () => {
 
   beforeEach(() => {
     source = {
-      [SymbolSubscribable]: () => createSubscription(function*(publish) {
-        publish({name: 'bob', type: 'person' });
-        publish({name: 'alice', type: 'person' });
-        publish({name: 'world', type: 'planet' });
-        return 3;
-      })
+      *[SymbolSubscribable]() {
+        return yield createSubscription(function*(publish) {
+          publish({name: 'bob', type: 'person' });
+          publish({name: 'alice', type: 'person' });
+          publish({name: 'world', type: 'planet' });
+          return 3;
+        })
+      }
     }
   });
 

--- a/packages/subscription/test/subscribe.test.ts
+++ b/packages/subscription/test/subscribe.test.ts
@@ -13,8 +13,8 @@ interface Thing {
   type: string;
 }
 const subscribableWithSymbol = {
-  [SymbolSubscribable](): Operation<Subscription<Thing, number>> {
-    return createSubscription(function*(publish) {
+  *[SymbolSubscribable](): Operation<Subscription<Thing, number>> {
+    return yield createSubscription(function*(publish) {
       publish({name: 'bob', type: 'person' });
       publish({name: 'alice', type: 'person' });
       publish({name: 'world', type: 'planet' });
@@ -34,8 +34,8 @@ function* subscribableAsOperation(): Operation<Subscription<Thing, number>> {
 let emitter = new EventEmitter();
 
 const subscribableWithResource = {
-  [SymbolSubscribable](): Operation<Subscription<[number], void>> {
-    return on(emitter, 'message');
+  *[SymbolSubscribable](): Operation<Subscription<[number], void>> {
+    return yield on(emitter, 'message');
   }
 };
 

--- a/packages/subscription/test/subscription.test.ts
+++ b/packages/subscription/test/subscription.test.ts
@@ -106,4 +106,17 @@ describe('subscriptions', () => {
       expect(await two).toEqual(1);
     });
   });
+
+  describe('when chaining on createSubscription', () => {
+    it('handles the chain', async () => {
+      let doSubscribe = createSubscription<number,void>(function*(publish) {
+        yield timeout(2);
+        publish(12)
+      }).map((value) => value * 2);
+
+      let subscription = await spawn(doSubscribe);
+
+      await expect(spawn(subscription.expect())).resolves.toEqual(24);
+    });
+  });
 });


### PR DESCRIPTION
Subscriptions created via `createSubscription` are chainable on both sides of the yield statement. This enables patterns like:

``` typescript
yield on(window, "message").filter((m) => ...).forEach(...)
```

There is a subtle downside and backwards incompatibility with this, which is that due to `Operation` being invariant over its type parameter. Since we return a `Operation<ChainableSubscription<T>>` but we sometimes expect a `Operation<Subscription<T>>` and while...

```
ChainableSubscription <: Subscription
```

...really *should* imply that...

```
Operation<ChainableSubscription> <: Operation<Subscription>
```

...this is currently not (always) the case, so some subtle type errors might occur.