### PR TITLE
✨Make deprecation warnings more helpful

### DIFF
--- a/.changeset/helpful-deprecations.md
+++ b/.changeset/helpful-deprecations.md
@@ -1,0 +1,5 @@
+---
+"@effection/subscription": patch
+---
+Deprecated functions only emit a single warning, and print out the
+line from which they were invoked

--- a/packages/subscription/src/deprecated.ts
+++ b/packages/subscription/src/deprecated.ts
@@ -1,0 +1,16 @@
+export function deprecated<F extends Function>(message: string, fn: F): F {
+  let impl: F = function(this: unknown, ...args: unknown[]) {
+    try {
+      throw new Error('trace');
+    } catch (trace) {
+      let [ line ] = trace.stack.split("\n").slice(3,4)
+      console.warn(message, "\n" + line);
+    }
+    impl = fn;
+    return fn.call(this, ...args);
+  } as unknown as F;
+
+  return function(this: unknown, ...args: unknown[]) {
+    return impl.call(this, ...args);
+  } as unknown as F;
+}

--- a/packages/subscription/src/index.ts
+++ b/packages/subscription/src/index.ts
@@ -11,8 +11,11 @@ import { Operation } from 'effection';
 import { SubscriptionSource } from './subscription-source';
 import { subscribe } from './subscribe';
 
-export function* forEach<T,TReturn>(source: SubscriptionSource<T,TReturn>, visit: (value: T) => Operation<void>): Operation<TReturn> {
-  console.warn('`forEach(source, ...)` is deprecated, use `subscribe(source).forEach(...)` instead');
-  return yield subscribe<T, TReturn>(source).forEach(visit);
-}
+import { deprecated } from './deprecated';
 
+export const forEach = deprecated(
+  '`forEach(source, ...)` is deprecated, use `subscribe(source).forEach(...)` instead',
+  function* forEach<T,TReturn>(source: SubscriptionSource<T,TReturn>, visit: (value: T) => Operation<void>): Operation<TReturn> {
+    return yield subscribe<T, TReturn>(source).forEach(visit);
+  }
+);

--- a/packages/subscription/src/subscribable.ts
+++ b/packages/subscription/src/subscribable.ts
@@ -3,14 +3,17 @@ import { Subscription } from './subscription';
 import { SymbolSubscribable } from './symbol-subscribable';
 import { subscribe } from './subscribe';
 import { SubscriptionSource } from './subscription-source';
+import { deprecated } from './deprecated';
 
 export interface Subscribable<T,TReturn> {
   [SymbolSubscribable](): Operation<Subscription<T,TReturn>>;
 }
 
 export const Subscribable = {
-  from<T,TReturn>(source: SubscriptionSource<T,TReturn>) {
-    console.warn('`Subscribable.from(source)` is deprecated, use `subscribe(source).map(...)` instead');
-    return subscribe(source)
-  }
+  from: deprecated(
+    '`Subscribable.from(source)` is deprecated, use `subscribe(source).map(...)` instead',
+      <T,TReturn>(source: SubscriptionSource<T,TReturn>) => {
+        return subscribe(source)
+      }
+  )
 }


### PR DESCRIPTION
Motivation
-----------
In a codebase that uses deprecated code (in this case `forEach` and `Subscribable.from` specifically) it causes sometimes hundreds of warnings to be spewed to the console, but little clue from whence the warnings came. This means its super painful to have a deprecation, and to boot, it is also super difficult to diagnose where to go fix it.

Approach
----------
This enhances deprecation in two ways. The first is that it will only ever print out a deprecation warning once per deprecated function. The second enhancement is that it prints the line number where the deprecated.

Before:

```
  subscribable objects
    forEach
`forEach(source, ...)` is deprecated, use `subscribe(source).forEach(...)` instead
      ✓ iterates through all members of the subscribable
`forEach(source, ...)` is deprecated, use `subscribe(source).forEach(...)` instead
      ✓ returns the original result
    map
`Subscribable.from(source)` is deprecated, use `subscribe(source).map(...)` instead
`forEach(source, ...)` is deprecated, use `subscribe(source).forEach(...)` instead
      ✓ maps the values
`Subscribable.from(source)` is deprecated, use `subscribe(source).map(...)` instead
`forEach(source, ...)` is deprecated, use `subscribe(source).forEach(...)` instead
      ✓ preserves the return type
    filter
`Subscribable.from(source)` is deprecated, use `subscribe(source).map(...)` instead
      ✓ filters the items
`Subscribable.from(source)` is deprecated, use `subscribe(source).map(...)` instead
      ✓ preserves the return type
    match
      with simple filter
`Subscribable.from(source)` is deprecated, use `subscribe(source).map(...)` instead
        ✓ filters the items
`Subscribable.from(source)` is deprecated, use `subscribe(source).map(...)` instead
        ✓ preserves the return type
      with deep filter
`Subscribable.from(source)` is deprecated, use `subscribe(source).map(...)` instead
        ✓ filters the items
`Subscribable.from(source)` is deprecated, use `subscribe(source).map(...)` instead
        ✓ preserves the return type
    first
      on a subscription with at least one element
`Subscribable.from(source)` is deprecated, use `subscribe(source).map(...)` instead
        ✓ returns the thing
      on an empty subscription
`Subscribable.from(source)` is deprecated, use `subscribe(source).map(...)` instead
        ✓ returns undefined
```

After:

```
subscribable objects
    forEach
`forEach(source, ...)` is deprecated, use `subscribe(source).forEach(...)` instead
    at Context.<anonymous> (./test/subscribable.test.ts:33:28)
      ✓ iterates through all members of the subscribable
      ✓ returns the original result
    map
`Subscribable.from(source)` is deprecated, use `subscribe(source).map(...)` instead
    at Context.<anonymous> (./test/subscribable.test.ts:56:34)
      ✓ maps the values
      ✓ preserves the return type
    filter
      ✓ filters the items
      ✓ preserves the return type
    match
      with simple filter
        ✓ filters the items
        ✓ preserves the return type
      with deep filter
        ✓ filters the items
        ✓ preserves the return type
    first
      on a subscription with at least one element
        ✓ returns the thing
      on an empty subscription
        ✓ returns undefined
```