### PR TITLE
✨add pid to Process interface

### DIFF
--- a/.changeset/add-pid.md
+++ b/.changeset/add-pid.md
@@ -1,0 +1,4 @@
+---
+"@effection/node": minor
+---
+add `pid` field to the `Process` API

--- a/packages/node/src/exec/api.ts
+++ b/packages/node/src/exec/api.ts
@@ -6,6 +6,9 @@ import { Channel } from '@effection/channel';
  * standard io handles, and methods for synchronizing on return.
  */
 export interface Process extends StdIO {
+
+  readonly pid: number;
+
   /**
    * Completes once the process has finished regardless of whether it was
    * successful or not.

--- a/packages/node/test/exec.test.ts
+++ b/packages/node/test/exec.test.ts
@@ -83,6 +83,11 @@ describe('exec()', () => {
       await converge(() => expect(output).toContain("listening"));
     });
 
+    it('has a pid', () => {
+      expect(typeof proc.pid).toBe('number');
+      expect(proc.pid).not.toBeNaN();
+    });
+
     describe('when it succeeds', () => {
       beforeEach(async () => {
         await fetch('http://localhost:29000', { method: "POST", body: "exit" });


### PR DESCRIPTION
Motivation
-----------
In order to make our test cases cross platform, we need to be able to, from the outside in, send a signal to the process (or kill it using acustom windows module) In both of those cases, we need a process id.

Approach
----------
This adds the `pid` to the Process api and into the posix implementation. This did mean that the process had to be created outside of the resource body, but that should be ok.