### PR TITLE
Eliminate child process from tests

### DIFF
--- a/packages/node/test/helpers.ts
+++ b/packages/node/test/helpers.ts
@@ -1,8 +1,11 @@
 import { performance } from 'perf_hooks';
 import { beforeEach } from 'mocha';
-import { main, resource, Context, Controls } from 'effection';
-import { on, once } from '@effection/events';
-import { Readable } from 'stream';
+import * as expect from 'expect';
+import { main, Context, Controls } from 'effection';
+import { Channel } from '@effection/channel';
+import { subscribe } from '@effection/subscription';
+
+import { exec, Process } from '../src/exec';
 
 export let World: Context & Controls;
 
@@ -17,29 +20,64 @@ afterEach(() => {
   World.halt();
 })
 
+export class TestProcess {
+  private isWin32 = false;
+  stdout: TestStream;
+  stderr: TestStream;
+
+  static async exec(cmd: string) {
+    return new TestProcess(await World.spawn(exec(cmd)));
+  }
+
+  constructor(public process: Process) {
+    this.stdout = TestStream.of(process.stdout);
+    this.stderr = TestStream.of(process.stderr);
+  }
+
+  async join() {
+    return await World.spawn(this.process.join());
+  }
+
+  // cross platform graceful shutdown request. What would
+  // be sent to the process by the Operating system when
+  // a users requests a terminate.
+  terminate() {
+    if (this.isWin32) {
+      //TODO:
+    } else {
+      process.kill(this.process.pid, 'SIGTERM');
+    }
+  }
+
+  // cross platform user initiated graceful shutdown request. What would
+  // be sent to the process by the Operating system when
+  // a users requests an interrupt via CTRL-C or equivalent.
+  interrupt() {
+    if (this.isWin32) {
+      //TODO:
+    } else {
+      process.kill(this.process.pid, 'SIGINT');
+    }
+  }
+}
+
 export class TestStream {
   public output = "";
 
-  static *of(value: Readable) {
-    let testStream = new TestStream(value);
-    return yield resource(testStream, testStream.run());
+  static of(channel: Channel<string>) {
+    let testStream = new TestStream();
+    World.spawn(function*() {
+      yield subscribe(channel).forEach(function*(chunk) {
+        testStream.output += chunk.toString();
+      });
+    });
+    return testStream;
   }
 
-  constructor(private stream: Readable) {};
+  constructor() {};
 
-  *run() {
-    let events = yield on(this.stream, "data");
-    while(true) {
-      let { value: chunk } = yield events.next();
-      this.output += chunk;
-    }
-  }
-
-  *waitFor(text: string) {
-    while(!this.output.match(text)) {
-      yield once(this.stream, "data");
-      yield Promise.resolve();
-    }
+  async detect(text: string) {
+    return converge(() => expect(this.output).toContain(text));
   }
 }
 

--- a/packages/node/test/helpers.ts
+++ b/packages/node/test/helpers.ts
@@ -76,19 +76,19 @@ export class TestStream {
 
   constructor() {};
 
-  async detect(text: string) {
-    return converge(() => expect(this.output).toContain(text));
+  async detect(text: string, timeout = 5000) {
+    return converge(() => expect(this.output).toContain(text), timeout);
   }
 }
 
-export async function converge<T>(fn: () => T): Promise<T> {
+export async function converge<T>(fn: () => T, timeout = 2000): Promise<T> {
   let startTime = performance.now();
   while(true) {
     try {
       return fn();
     } catch(e) {
       let diff = performance.now() - startTime;
-      if(diff > 2000) {
+      if(diff > timeout) {
         throw e;
       } else {
         await new Promise((resolve) => setTimeout(resolve, 1));


### PR DESCRIPTION
In order to test the functionality of `main()` cross platform, we need to make our tests themselves cross platform.

In order to accomplish this we do two things:

1) start the test process with the `exec()` function
2) "terminate" it from the outside in using a platform agnostic termination strategy. `SIGTERM` and `SIGINT` are used on posix, but a stub has been left in place for windows. This outside in should make whatever system calls would simulate these types of shutdowns.