### PR TITLE
Override exit handler for main

### DIFF
--- a/.changeset/on-error.md
+++ b/.changeset/on-error.md
@@ -1,0 +1,5 @@
+---
+"@effection/node": "minor"
+---
+
+Can set onError handler for main, allowing maximum control over how to handle errors.

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -1,5 +1,5 @@
-export { main, MainError } from './main';
-export *  from './exec';
+export { main, exitOnError, isMainError, MainError } from './main';
+export * from './exec';
 export { daemon } from './daemon';
 
 export * as ChildProcess from './child_process';

--- a/packages/node/test/fixtures/main-failed-on-error.ts
+++ b/packages/node/test/fixtures/main-failed-on-error.ts
@@ -1,0 +1,10 @@
+import { Operation, timeout } from 'effection';
+import { main } from '../../src/main';
+
+main(function*(): Operation<void> {
+  yield timeout(10);
+  throw new Error('moo');
+}, (error) => {
+  console.error('GOT ERROR:', error.message);
+  process.exit(47);
+})

--- a/packages/node/test/main.test.ts
+++ b/packages/node/test/main.test.ts
@@ -54,5 +54,13 @@ describe('main', () => {
       expect(child.stderr.output).not.toContain('EffectionMainError');
       expect(status.code).toEqual(23);
     });
+
+    it('can override error handler', async () => {
+      let child = await TestProcess.exec(`ts-node ${[path.join(__dirname, 'fixtures/main-failed-on-error.ts')]}`);
+      let status = await child.join();
+
+      expect(child.stderr.output).toContain('GOT ERROR: moo');
+      expect(status.code).toEqual(47);
+    });
   });
 });


### PR DESCRIPTION
Makes it possible to set a custom error handler for `main`, allowing ultimate flexibility in how to handle errors.

I went with a slightly different approach here, instead of handling the error via `catch`, I added a callback instead. This felt simpler to me, and the behaviour is a little more predictable IMO.

Closes #203