### PR TITLE
Simplify sleep

### DIFF
--- a/.changeset/simpler-sleep.md
+++ b/.changeset/simpler-sleep.md
@@ -1,0 +1,5 @@
+---
+"@effection/core": patch
+---
+
+Simplify sleep method

--- a/packages/core/src/sleep.ts
+++ b/packages/core/src/sleep.ts
@@ -1,16 +1,12 @@
 import { Operation } from './operation';
 
 export function sleep(duration: number): Operation<void> {
-  return function*() {
-    let timeoutId;
-    try {
-      yield new Promise((resolve) => {
-        setTimeout(resolve, duration);
-      });
-    } finally {
+  return (task) => (resolve) => {
+    let timeoutId = setTimeout(resolve, duration);
+    task.ensure(() => {
       if(timeoutId) {
         clearTimeout(timeoutId);
       }
-    }
+    });
   }
 }


### PR DESCRIPTION
Makes the `sleep` operation a bit simpler by using a resolution primitive, rather than a promise.