### PR TITLE
Added CHANGELOGS and src to all packages for v2

### DIFF
--- a/.changeset/brave-dots-listen.md
+++ b/.changeset/brave-dots-listen.md
@@ -1,0 +1,11 @@
+---
+"@effection/channel": patch
+"@effection/core": patch
+"effection": patch
+"@effection/events": patch
+"@effection/fetch": patch
+"@effection/node": patch
+"@effection/subscription": patch
+---
+
+Include CHANGELOGS and src with all packages

--- a/packages/channel/package.json
+++ b/packages/channel/package.json
@@ -8,8 +8,10 @@
   "author": "Frontside Engineering <engineering@frontside.io>",
   "license": "MIT",
   "files": [
-    "dist/*",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md",
+    "dist/**/*",
+    "src/**/*"
   ],
   "scripts": {
     "lint": "eslint '{src,tests}/**/*.ts'",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,6 +10,11 @@
     "mocha": "mocha -r ts-node/register",
     "prepack": "tsdx build --tsconfig tsconfig.dist.json"
   },
+  "files": [
+    "CHANGELOG.md",
+    "dist/**/*",
+    "src/**/*"
+  ],
   "devDependencies": {
     "@types/mocha": "^7.0.2",
     "@types/node": "^13.13.5",

--- a/packages/effection/package.json
+++ b/packages/effection/package.json
@@ -10,7 +10,7 @@
   "main": "dist/index.js",
   "module": "dist/effection.esm.js",
   "files": [
-    "README.md",
+    "CHANGELOG.md",
     "dist/**/*",
     "src/**/*"
   ],

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -10,6 +10,7 @@
   "license": "MIT",
   "files": [
     "README.md",
+    "CHANGELOG.md",
     "dist/**/*",
     "src/**/*"
   ],

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -8,9 +8,10 @@
   "author": "Frontside Engineering <engineering@frontside.com>",
   "license": "MIT",
   "files": [
-    "dist/*",
     "README.md",
-    "src"
+    "CHANGELOG.md",
+    "dist/**/*",
+    "src/**/*"
   ],
   "scripts": {
     "lint": "eslint '{src,tests}/**/*.ts'",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -9,6 +9,7 @@
   "license": "MIT",
   "files": [
     "README.md",
+    "CHANGELOG.md",
     "dist/**/*",
     "src/**/*"
   ],

--- a/packages/subscription/package.json
+++ b/packages/subscription/package.json
@@ -9,6 +9,7 @@
   "license": "MIT",
   "files": [
     "README.md",
+    "CHANGELOG.md",
     "dist/**/*",
     "src/**/*"
   ],


### PR DESCRIPTION
## Motivation

I'm trying to see how big/small the new mini version of effection but I can't because the bundles seem to be missing necessary files. For example [@effection/core@2.0.0-preview.1](https://unpkg.com/browse/@effection/core@2.0.0-preview.1/) is missing bundled files in dist directory. Some packages that have bundled flies are missing `src` which is necessary for source maps to work. I want to correct these inconsistencies and make sure that packages have everything that's necessary for them to function.

## Approach

1. Make sure that every package includes CHANGELOG.md
2. Make sure that every package that references src in source maps includes src in the bundle
3. Make sure that every package includes everything in dist

## Result

You can see the result if you compare the [preview package created from this PR](https://www.jsdelivr.com/package/npm/@effection/core?version=2.0.0-preview.1-93ec0d6&path=dist) and [package published](https://www.jsdelivr.com/package/npm/@effection/core?path=dist) from #226 
