### PR TITLE
Tm/cancel timeout

### DIFF
--- a/.changeset/angry-cycles-check.md
+++ b/.changeset/angry-cycles-check.md
@@ -1,0 +1,5 @@
+---
+"@effection/core": patch
+---
+
+Make sure timeout is cleared when sleep operation is cancelled

--- a/packages/core/src/sleep.ts
+++ b/packages/core/src/sleep.ts
@@ -5,7 +5,7 @@ export function sleep(duration: number): Operation<void> {
     let timeoutId;
     try {
       yield new Promise((resolve) => {
-        setTimeout(resolve, duration);
+        timeoutId = setTimeout(resolve, duration);
       });
     } finally {
       if(timeoutId) {


### PR DESCRIPTION
## Motivation

@wKich noticed that timeoutId is not set when setTimeout is called. So, cancel is never called as a result.

## Approach

Assign timeoutId when setTimeout is called
