### PR TITLE
Make generators reentrant

### DIFF
--- a/.changeset/sixty-eels-cheat.md
+++ b/.changeset/sixty-eels-cheat.md
@@ -1,0 +1,6 @@
+---
+"@effection/core": patch
+"effection": patch
+---
+
+Make iterator controllers reentrant so they can e.g. halt themselves


### PR DESCRIPTION
A task may be currently running a generator, that is it has entered the generator and is currently inside the generator itself in between two yield points.

Since resume/reject and halting is now fundamentally synchronous, it could happen that the code in the generator itself causes the task to halt, either by explicitly halting itself, or by causing a sibling or parent task to fail and thereby being halted by the parent.

However, this poses a problem, since the iterator is already running, we cannot call `return()` on it. This will cause a `TypeError: Generator is already running`.

Effectively we cannot enter a generator if we have already entered the generator.

This fixes this problem by adding a cache of continuations and delaying their execution if we're already inside the generator.