### PR TITLE
Remove clearTimeout() condition from sleep.

### DIFF
--- a/packages/core/src/sleep.ts
+++ b/packages/core/src/sleep.ts
@@ -3,10 +3,6 @@ import { Operation } from './operation';
 export function sleep(duration: number): Operation<void> {
   return (task) => (resolve) => {
     let timeoutId = setTimeout(resolve, duration);
-    task.ensure(() => {
-      if(timeoutId) {
-        clearTimeout(timeoutId);
-      }
-    });
+    task.ensure(() => clearTimeout(timeoutId));
   }
 }


### PR DESCRIPTION
## Motivation

simple code cleanup

## Approach

Remove clearTimeout() condition from sleep.

there's no codepath in which `timeoutId` isn't defined, so the `if` check is redundant. In the event that the `setTimeout()` call raises an exception, then the `ensure()` block will never be registered anyway.