### PR TITLE
Add Subscribable and use it in subpackages

### DIFF
--- a/.changeset/bright-terms-rescue.md
+++ b/.changeset/bright-terms-rescue.md
@@ -1,0 +1,6 @@
+---
+"@effection/events": minor
+"effection": minor
+---
+
+Change `on` to return subscribable, rather than taking scope

--- a/.changeset/sharp-penguins-check.md
+++ b/.changeset/sharp-penguins-check.md
@@ -1,0 +1,6 @@
+---
+"@effection/subscription": minor
+"effection": minor
+---
+
+Add `createSubscribable` and `Subscribable` interface

--- a/.changeset/shiny-terms-talk.md
+++ b/.changeset/shiny-terms-talk.md
@@ -1,0 +1,6 @@
+---
+"@effection/channel": minor
+"effection": minor
+---
+
+Make Channel subscribable and add all subscribable methods

--- a/.changeset/smooth-gorillas-wash.md
+++ b/.changeset/smooth-gorillas-wash.md
@@ -1,0 +1,6 @@
+---
+"@effection/channel": patch
+"@effection/node": patch
+---
+
+Use new channel and subscription interfaces internally

--- a/.changeset/violet-dancers-fail.md
+++ b/.changeset/violet-dancers-fail.md
@@ -1,0 +1,6 @@
+---
+"@effection/channel": minor
+"effection": minor
+---
+
+Change channel interface from `new Channel()` to `createChannel()`

--- a/packages/channel/src/index.ts
+++ b/packages/channel/src/index.ts
@@ -1,1 +1,1 @@
-export { Channel } from './channel';
+export * from './channel';

--- a/packages/channel/test/channel.test.ts
+++ b/packages/channel/test/channel.test.ts
@@ -2,9 +2,9 @@ import { describe, it, beforeEach } from 'mocha';
 import * as expect from 'expect';
 
 import { sleep, run, Task, Effection } from '@effection/core';
-import { Subscription, subscribe } from '@effection/subscription';
+import { OperationIterator, subscribe } from '@effection/subscription';
 
-import { Channel } from '../src/index';
+import { createChannel, Channel } from '../src/index';
 
 describe('Channel', () => {
   beforeEach(async () => {
@@ -13,10 +13,10 @@ describe('Channel', () => {
 
   describe('subscribe', () => {
     let channel: Channel<string>;
-    let subscription: Subscription<string, undefined>;
+    let subscription: OperationIterator<string, undefined>;
 
     beforeEach(async () => {
-      channel = new Channel();
+      channel = createChannel();
       subscription = channel.subscribe(Effection.root);
     });
 
@@ -63,10 +63,10 @@ describe('Channel', () => {
 
   describe('subscribe free function', () => {
     let channel: Channel<string>;
-    let subscription: Subscription<string, undefined>;
+    let subscription: OperationIterator<string, undefined>;
 
     beforeEach(async () => {
-      channel = new Channel();
+      channel = createChannel();
       subscription = subscribe(Effection.root, channel);
     });
 
@@ -86,10 +86,10 @@ describe('Channel', () => {
   describe('close', () => {
     describe('without argument', () => {
       let channel: Channel<string>;
-      let subscription: Subscription<string, undefined>;
+      let subscription: OperationIterator<string, undefined>;
 
       beforeEach(async () => {
-        channel = new Channel();
+        channel = createChannel();
         subscription = subscribe(Effection.root, channel);
         channel.send('foo');
         channel.close();
@@ -103,10 +103,10 @@ describe('Channel', () => {
 
     describe('with close argument', () => {
       let channel: Channel<string, number>;
-      let subscription: Subscription<string, number>;
+      let subscription: OperationIterator<string, number>;
 
       beforeEach(async () => {
-        channel = new Channel();
+        channel = createChannel();
         subscription = subscribe(Effection.root, channel);
         channel.send('foo');
         channel.close(12);

--- a/packages/events/src/on.ts
+++ b/packages/events/src/on.ts
@@ -1,10 +1,9 @@
-import { Task } from '@effection/core';
-import { Subscription } from '@effection/subscription';
+import { createSubscribable, Subscribable } from '@effection/subscription';
 
 import { EventSource, addListener, removeListener } from './event-source';
 
-export function on<T extends Array<unknown> = unknown[]>(task: Task, source: EventSource, name: string): Subscription<T, void> {
-  return Subscription.create(task, (publish) => function*() {
+export function on<T extends Array<unknown> = unknown[]>(source: EventSource, name: string): Subscribable<T, void> {
+  return createSubscribable((publish) => function*() {
     let listener = (...args: T) => publish(args);
     try {
       addListener(source, name, listener);

--- a/packages/events/test/on.test.ts
+++ b/packages/events/test/on.test.ts
@@ -4,7 +4,7 @@ import { describe, it, beforeEach } from 'mocha';
 import * as expect from 'expect'
 
 import { Effection, run, sleep } from '@effection/core';
-import { Subscription } from '@effection/subscription';
+import { OperationIterator } from '@effection/subscription';
 import { EventEmitter } from 'events';
 
 import { on } from '../src/index';
@@ -13,11 +13,11 @@ import { FakeEventEmitter, FakeEvent } from './fake-event-target';
 describe("on", () => {
   describe('subscribe to an EventEmitter', () => {
     let emitter: EventEmitter;
-    let subscription: Subscription<[string], void>;
+    let iterator: OperationIterator<[string], void>;
 
     beforeEach(async () => {
       emitter = new EventEmitter();
-      subscription = on(Effection.root, emitter, "thing");
+      iterator = on<[string]>(emitter, "thing").subscribe(Effection.root);
     });
 
     describe('emitting an event', () => {
@@ -26,7 +26,7 @@ describe("on", () => {
       });
 
       it('receives event', async () => {
-        let { value } = await run(subscription.next());
+        let { value } = await run(iterator.next());
         expect(value).toEqual([123, true]);
       });
     });
@@ -40,7 +40,7 @@ describe("on", () => {
       });
 
       it('receives event', async () => {
-        let { value } = await run(subscription.next());
+        let { value } = await run(iterator.next());
         expect(value).toEqual([123, true]);
       });
     });
@@ -55,20 +55,20 @@ describe("on", () => {
       });
 
       it('receives all of them', async () => {
-        expect(await run(subscription.next())).toEqual({ done: false, value: ["foo"]});
-        expect(await run(subscription.next())).toEqual({done: false, value: ["bar"] });
+        expect(await run(iterator.next())).toEqual({ done: false, value: ["foo"]});
+        expect(await run(iterator.next())).toEqual({done: false, value: ["bar"] });
       });
     });
   });
 
   describe('subscribing to an EventTarget', () => {
     let target: FakeEventEmitter;
-    let subscription: Subscription<[string], void>;
+    let iterator: OperationIterator<[string], void>;
     let thingEvent: FakeEvent;
 
     beforeEach(async () => {
       target = new FakeEventEmitter();
-      subscription = on(Effection.root, target, "thing");
+      iterator = on<[string]>(target, "thing").subscribe(Effection.root);
     });
 
     describe('emitting an event', () => {
@@ -78,7 +78,7 @@ describe("on", () => {
       });
 
       it('receives event', async () => {
-        let { value } = await run(subscription.next());
+        let { value } = await run(iterator.next());
         expect(value).toEqual([thingEvent]);
       });
     });
@@ -86,11 +86,11 @@ describe("on", () => {
 
   describe('chaining', () => {
     let emitter: EventEmitter;
-    let subscription: Subscription<number, void>;
+    let iterator: OperationIterator<number, void>;
 
     beforeEach(async () => {
       emitter = new EventEmitter();
-      subscription = on(Effection.root, emitter, "thing").map(([value]) => (value as number) * 2);
+      iterator = on<[number]>(emitter, "thing").map(([value]) => value * 2).subscribe(Effection.root);
     });
 
     describe('emitting an event', () => {
@@ -99,7 +99,7 @@ describe("on", () => {
       });
 
       it('receives event', async () => {
-        let { value } = await run(subscription.next());
+        let { value } = await run(iterator.next());
         expect(value).toEqual(24);
       });
     });

--- a/packages/node/src/exec/posix.ts
+++ b/packages/node/src/exec/posix.ts
@@ -65,17 +65,17 @@ export const createPosixProcess: CreateOSProcess = (scope, command, options) => 
     try {
       childProcess.on('error', onError);
 
-      task.spawn(on<[string]>(childProcess.stdout, 'data').forEach(([data]) => function*() {
+      task.spawn(on<[string]>(childProcess.stdout, 'data').forEach(([data]) => {
         addToTail(data);
         stdout.send(data);
       }));
 
-      task.spawn(on<[string]>(childProcess.stderr, 'data').forEach(([data]) => function*() {
+      task.spawn(on<[string]>(childProcess.stderr, 'data').forEach(([data]) => {
         addToTail(data);
         stderr.send(data);
       }));
 
-      task.spawn(stdin.forEach((data) => function*() {
+      task.spawn(stdin.forEach((data) => {
         childProcess.stdin.write(data);
       }))
 

--- a/packages/node/src/exec/posix.ts
+++ b/packages/node/src/exec/posix.ts
@@ -1,16 +1,15 @@
 import { Operation, Deferred } from '@effection/core';
-import { Channel } from '@effection/channel';
+import { createChannel } from '@effection/channel';
 import { on, once } from '@effection/events';
 import { spawn as spawnProcess } from 'child_process';
-import { subscribe } from '@effection/subscription';
 import { ExitStatus, CreateOSProcess, stringifyExitStatus } from './api';
 
 type Result = { type: 'error'; value: unknown } | { type: 'status'; value: [number?, string?] };
 
 export const createPosixProcess: CreateOSProcess = (scope, command, options) => {
-  let stdin = new Channel<string>();
-  let stdout = new Channel<string>();
-  let stderr = new Channel<string>();
+  let stdin = createChannel<string>();
+  let stdout = createChannel<string>();
+  let stderr = createChannel<string>();
   let tail: string[] = [];
 
   let getResult = Deferred<Result>();
@@ -66,17 +65,17 @@ export const createPosixProcess: CreateOSProcess = (scope, command, options) => 
     try {
       childProcess.on('error', onError);
 
-      task.spawn(on<[string]>(task, childProcess.stdout, 'data').forEach(([data]) => function*() {
+      task.spawn(on<[string]>(childProcess.stdout, 'data').forEach(([data]) => function*() {
         addToTail(data);
         stdout.send(data);
       }));
 
-      task.spawn(on<[string]>(task, childProcess.stderr, 'data').forEach(([data]) => function*() {
+      task.spawn(on<[string]>(childProcess.stderr, 'data').forEach(([data]) => function*() {
         addToTail(data);
         stderr.send(data);
       }));
 
-      task.spawn(subscribe(task, stdin).forEach((data) => function*() {
+      task.spawn(stdin.forEach((data) => function*() {
         childProcess.stdin.write(data);
       }))
 

--- a/packages/node/src/exec/win32.ts
+++ b/packages/node/src/exec/win32.ts
@@ -1,9 +1,8 @@
 import { platform } from "os";
 import { Operation, Deferred } from "@effection/core";
-import { Channel } from "@effection/channel";
+import { createChannel } from "@effection/channel";
 import { on, once } from "@effection/events";
 import { spawn as spawnProcess } from "cross-spawn";
-import { subscribe } from "@effection/subscription";
 import { ctrlc } from "ctrlc-windows";
 import { ExitStatus, CreateOSProcess, stringifyExitStatus } from "./api";
 
@@ -12,9 +11,9 @@ type Result =
   | { type: "status"; value: [number?, string?] };
 
 export const createWin32Process: CreateOSProcess = (scope, command, options) => {
-  let stdin = new Channel<string>();
-  let stdout = new Channel<string>();
-  let stderr = new Channel<string>();
+  let stdin = createChannel<string>();
+  let stdout = createChannel<string>();
+  let stderr = createChannel<string>();
   let tail: string[] = [];
 
   let getResult = Deferred<Result>();
@@ -76,21 +75,21 @@ export const createWin32Process: CreateOSProcess = (scope, command, options) => 
       childProcess.on("error", onError);
 
       task.spawn(
-        on<[string]>(task, childProcess.stdout, "data").forEach(([data]) => function*() {
+        on<[string]>(childProcess.stdout, "data").forEach(([data]) => function*() {
           addToTail(data);
           stdout.send(data);
         })
       );
 
       task.spawn(
-        on<[string]>(task, childProcess.stderr, "data").forEach(([data]) => function*() {
+        on<[string]>(childProcess.stderr, "data").forEach(([data]) => function*() {
           addToTail(data);
           stderr.send(data);
         })
       );
 
       task.spawn(
-        subscribe(task, stdin).forEach((data) => function*() {
+        stdin.forEach((data) => function*() {
           childProcess.stdin.write(data);
         })
       );

--- a/packages/node/src/exec/win32.ts
+++ b/packages/node/src/exec/win32.ts
@@ -75,21 +75,21 @@ export const createWin32Process: CreateOSProcess = (scope, command, options) => 
       childProcess.on("error", onError);
 
       task.spawn(
-        on<[string]>(childProcess.stdout, "data").forEach(([data]) => function*() {
+        on<[string]>(childProcess.stdout, "data").forEach(([data]) => {
           addToTail(data);
           stdout.send(data);
         })
       );
 
       task.spawn(
-        on<[string]>(childProcess.stderr, "data").forEach(([data]) => function*() {
+        on<[string]>(childProcess.stderr, "data").forEach(([data]) => {
           addToTail(data);
           stderr.send(data);
         })
       );
 
       task.spawn(
-        stdin.forEach((data) => function*() {
+        stdin.forEach((data) => {
           childProcess.stdin.write(data);
         })
       );

--- a/packages/node/test/daemon.test.ts
+++ b/packages/node/test/daemon.test.ts
@@ -25,11 +25,11 @@ describe('daemon()', () => {
         cwd: __dirname,
       });
 
-      task.spawn(io.stdout.forEach((chunk) => function*() {
+      task.spawn(io.stdout.forEach((chunk) => {
         output += chunk;
       }))
 
-      task.spawn(io.stderr.forEach((chunk) => function*() {
+      task.spawn(io.stderr.forEach((chunk) => {
         errput += chunk;
       }));
 

--- a/packages/node/test/daemon.test.ts
+++ b/packages/node/test/daemon.test.ts
@@ -25,11 +25,11 @@ describe('daemon()', () => {
         cwd: __dirname,
       });
 
-      task.spawn(subscribe(task, io.stdout).forEach((chunk) => function*() {
+      task.spawn(io.stdout.forEach((chunk) => function*() {
         output += chunk;
       }))
 
-      task.spawn(subscribe(task, io.stderr).forEach((chunk) => function*() {
+      task.spawn(io.stderr.forEach((chunk) => function*() {
         errput += chunk;
       }));
 

--- a/packages/node/test/helpers.ts
+++ b/packages/node/test/helpers.ts
@@ -61,11 +61,9 @@ export class TestStream {
 
   static of(channel: Channel<string>) {
     let testStream = new TestStream();
-    run(function*(task) {
-      yield subscribe(task, channel).forEach((chunk) => function*() {
-        testStream.output += chunk.toString();
-      });
-    });
+    run(channel.forEach((chunk) => function*() {
+      testStream.output += chunk.toString();
+    }));
     return testStream;
   }
 

--- a/packages/subscription/src/index.ts
+++ b/packages/subscription/src/index.ts
@@ -3,4 +3,5 @@ export { SymbolOperationIterable } from './symbol-operation-iterable';
 export { OperationIterable } from './operation-iterable';
 export { OperationIterator } from './operation-iterator';
 export { Subscription } from './subscription';
+export { createSubscribable, Subscribable } from './subscribable';
 export { subscribe } from './subscribe';

--- a/packages/subscription/src/operation-iterable.ts
+++ b/packages/subscription/src/operation-iterable.ts
@@ -2,6 +2,10 @@ import { Task } from '@effection/core';
 import { OperationIterator } from './operation-iterator';
 import { SymbolOperationIterable } from './symbol-operation-iterable';
 
+export interface ToOperationIterator<T, TReturn = undefined> {
+  (task: Task): OperationIterator<T, TReturn>;
+}
+
 export interface OperationIterable<T, TReturn = undefined> {
-  [SymbolOperationIterable](task: Task<unknown>): OperationIterator<T,TReturn>;
+  [SymbolOperationIterable]: ToOperationIterator<T, TReturn>;
 }

--- a/packages/subscription/src/subscribable.ts
+++ b/packages/subscription/src/subscribable.ts
@@ -1,0 +1,112 @@
+import { Operation, Task } from '@effection/core';
+import { DeepPartial, matcher } from './match';
+import { OperationIterator } from './operation-iterator';
+import { OperationIterable, ToOperationIterator } from './operation-iterable';
+import { SymbolOperationIterable } from './symbol-operation-iterable';
+import { Callback, createOperationIterator } from './create-operation-iterator';
+
+export interface Subscribable<T, TReturn = undefined> extends OperationIterable<T, TReturn> {
+  filter(predicate: (value: T) => boolean): Subscribable<T, TReturn>;
+  match(reference: DeepPartial<T>): Subscribable<T,TReturn>;
+  map<R>(mapper: (value: T) => R): Subscribable<R, TReturn>;
+
+  first(): Operation<T | undefined>;
+  expect(): Operation<T>;
+  forEach(visit: (value: T) => Operation<void>): Operation<TReturn>;
+  collect(): Operation<Iterator<T, TReturn>>;
+  toArray(): Operation<T[]>;
+  subscribe(task: Task): OperationIterator<T, TReturn>;
+}
+
+export function createSubscribable<T, TReturn = undefined>(callback: Callback<T, TReturn>): Subscribable<T, TReturn> {
+  let iterable: ToOperationIterator<T, TReturn> = (task) => createOperationIterator(task, callback);
+
+  let subscribable = {
+    filter(predicate: (value: T) => boolean): Subscribable<T, TReturn> {
+      return createSubscribable((publish) => {
+        return subscribable.forEach((value) => function*() {
+          if(predicate(value)) {
+            publish(value);
+          }
+        });
+      });
+    },
+
+    match(reference: DeepPartial<T>): Subscribable<T,TReturn> {
+      return subscribable.filter(matcher(reference));
+    },
+
+    map<R>(mapper: (value: T) => R): Subscribable<R, TReturn> {
+      return createSubscribable((publish) => {
+        return subscribable.forEach((value: T) => function*() {
+          publish(mapper(value));
+        });
+      });
+    },
+
+    first(): Operation<T | undefined> {
+      return function*(task) {
+        let iterator = iterable(task);
+        let result: IteratorResult<T,TReturn> = yield iterator.next();
+        if(result.done) {
+          return undefined;
+        } else {
+          return result.value;
+        }
+      }
+    },
+
+    expect(): Operation<T> {
+      return function*(task) {
+        let iterator = iterable(task);
+        let result: IteratorResult<T,TReturn> = yield iterator.next();
+        if(result.done) {
+          throw new Error('expected subscription to contain a value');
+        } else {
+          return result.value;
+        }
+      }
+    },
+
+    forEach(visit: (value: T) => Operation<void>): Operation<TReturn> {
+      return function*(task) {
+        let iterator = iterable(task);
+        while (true) {
+          let result: IteratorResult<T,TReturn> = yield iterator.next();
+          if(result.done) {
+            return result.value;
+          } else {
+            yield visit(result.value);
+          }
+        }
+      }
+    },
+
+    collect(): Operation<Iterator<T, TReturn>> {
+      return function*() {
+        let items: T[] = [];
+        let result = yield subscribable.forEach((item) => function*() { items.push(item); });
+        return (function*() {
+          yield *items;
+          return result;
+        })();
+      }
+    },
+
+    toArray(): Operation<T[]> {
+      return function*() {
+        return Array.from<T>(yield subscribable.collect());
+      }
+    },
+
+    subscribe(task: Task): OperationIterator<T, TReturn> {
+      return iterable(task);
+    },
+
+    get [SymbolOperationIterable](): ToOperationIterator<T, TReturn> {
+      return iterable;
+    },
+  };
+
+  return subscribable;
+}

--- a/packages/subscription/src/subscribable.ts
+++ b/packages/subscription/src/subscribable.ts
@@ -12,7 +12,7 @@ export interface Subscribable<T, TReturn = undefined> extends OperationIterable<
 
   first(): Operation<T | undefined>;
   expect(): Operation<T>;
-  forEach(visit: (value: T) => Operation<void>): Operation<TReturn>;
+  forEach(visit: (value: T) => (Operation<void> | void)): Operation<TReturn>;
   collect(): Operation<Iterator<T, TReturn>>;
   toArray(): Operation<T[]>;
   subscribe(task: Task): OperationIterator<T, TReturn>;
@@ -68,7 +68,7 @@ export function createSubscribable<T, TReturn = undefined>(callback: Callback<T,
       }
     },
 
-    forEach(visit: (value: T) => Operation<void>): Operation<TReturn> {
+    forEach(visit: (value: T) => (Operation<void> | void)): Operation<TReturn> {
       return function*(task) {
         let iterator = iterable(task);
         while (true) {
@@ -76,7 +76,10 @@ export function createSubscribable<T, TReturn = undefined>(callback: Callback<T,
           if(result.done) {
             return result.value;
           } else {
-            yield visit(result.value);
+            let operation = visit(result.value);
+            if(operation) {
+              yield operation;
+            }
           }
         }
       }

--- a/packages/subscription/test/subscribable.test.ts
+++ b/packages/subscription/test/subscribable.test.ts
@@ -23,14 +23,9 @@ const emptySubscribable: Subscribable<Thing, number> = createSubscribable(() => 
 
 describe('chaining subscribable', () => {
   describe('forEach', () => {
-    let values: Thing[];
-    let result: number;
-    beforeEach(async () => {
-      values = [];
-      result = await run(stuff.forEach((item) => function*() { values.push(item); }));
-    });
-
-    it('iterates through all members of the subscribable', () => {
+    it('iterates through all members of the subscribable', async () => {
+      let values: Thing[] = [];
+      await run(stuff.forEach((item) => function*() { values.push(item); }));
       expect(values).toEqual([
         {name: 'bob', type: 'person' },
         {name: 'alice', type: 'person' },
@@ -38,7 +33,18 @@ describe('chaining subscribable', () => {
       ])
     });
 
-    it('returns the original result', () => {
+    it('can iterate with regular function', async () => {
+      let values: Thing[] = [];
+      await run(stuff.forEach((item) => { values.push(item); }));
+      expect(values).toEqual([
+        {name: 'bob', type: 'person' },
+        {name: 'alice', type: 'person' },
+        {name: 'world', type: 'planet' },
+      ])
+    });
+
+    it('returns the original result', async () => {
+      let result = await run(stuff.forEach(() => function*() { /* no op */ }));
       expect(result).toEqual(3);
     });
   });

--- a/packages/subscription/test/subscribable.test.ts
+++ b/packages/subscription/test/subscribable.test.ts
@@ -1,0 +1,121 @@
+import './helpers';
+import * as expect from 'expect';
+import { describe, it, beforeEach } from 'mocha';
+
+import { run, Task, Effection } from '@effection/core';
+import { createSubscribable, Subscribable, OperationIterator } from '../src/index';
+
+interface Thing {
+  name: string;
+  type: string;
+}
+
+const stuff: Subscribable<Thing, number> = createSubscribable((publish) => function*() {
+  publish({name: 'bob', type: 'person' });
+  publish({name: 'alice', type: 'person' });
+  publish({name: 'world', type: 'planet' });
+  return 3;
+});
+
+const emptySubscribable: Subscribable<Thing, number> = createSubscribable(() => function*() {
+  return 12;
+});
+
+describe('chaining subscribable', () => {
+  describe('forEach', () => {
+    let values: Thing[];
+    let result: number;
+    beforeEach(async () => {
+      values = [];
+      result = await run(stuff.forEach((item) => function*() { values.push(item); }));
+    });
+
+    it('iterates through all members of the subscribable', () => {
+      expect(values).toEqual([
+        {name: 'bob', type: 'person' },
+        {name: 'alice', type: 'person' },
+        {name: 'world', type: 'planet' },
+      ])
+    });
+
+    it('returns the original result', () => {
+      expect(result).toEqual(3);
+    });
+  });
+
+  describe('collect', () => {
+    it('collects values into a synchronous iterator', async () => {
+      let iterator = await run(stuff.collect());
+      expect(iterator.next()).toEqual({ done: false, value: { name: 'bob', type: 'person' } });
+      expect(iterator.next()).toEqual({ done: false, value: { name: 'alice', type: 'person' } });
+      expect(iterator.next()).toEqual({ done: false, value: { name: 'world', type: 'planet' } });
+      expect(iterator.next()).toEqual({ done: true, value: 3 });
+    });
+  });
+
+  describe('toArray', () => {
+    it('collects values into an array', async () => {
+      let result = await run(stuff.toArray());
+      expect(result).toEqual([
+        { name: 'bob', type: 'person' },
+        { name: 'alice', type: 'person' },
+        { name: 'world', type: 'planet' },
+      ]);
+    });
+  });
+
+  describe('map', () => {
+    it('maps over the values', async () => {
+      let mapped = await run(stuff.map(item => `hello ${item.name}`).collect());
+      expect(mapped.next()).toEqual({ done: false, value: 'hello bob' });
+      expect(mapped.next()).toEqual({ done: false, value: 'hello alice' });
+      expect(mapped.next()).toEqual({ done: false, value: 'hello world' });
+      expect(mapped.next()).toEqual({ done: true, value: 3 });
+    });
+  });
+
+  describe('filter', () => {
+    it('filters the values', async () => {
+      let filtered = await run(stuff.filter(item => item.type === 'person').collect());
+      expect(filtered.next()).toEqual({ done: false, value: { name: 'bob', type: 'person' } });
+      expect(filtered.next()).toEqual({ done: false, value: { name: 'alice', type: 'person' } });
+      expect(filtered.next()).toEqual({ done: true, value: 3 });
+    });
+  });
+
+  describe('match', () => {
+    it('filters the values based on the given pattern', async () => {
+      let matched = await run(stuff.match({ type: 'person' }).collect());
+      expect(matched.next()).toEqual({ done: false, value: { name: 'bob', type: 'person' } });
+      expect(matched.next()).toEqual({ done: false, value: { name: 'alice', type: 'person' } });
+      expect(matched.next()).toEqual({ done: true, value: 3 });
+    });
+
+    it('can work on nested items', async () => {
+      let matched = await run(stuff.map(item => ({ thing: item })).match({ thing: { type: 'person' } }).collect());
+      expect(matched.next()).toEqual({ done: false, value: { thing: { name: 'bob', type: 'person' } } });
+      expect(matched.next()).toEqual({ done: false, value: { thing: { name: 'alice', type: 'person' } } });
+      expect(matched.next()).toEqual({ done: true, value: 3 });
+    });
+  });
+
+  describe('first', () => {
+    it('returns the first item in the subscription', async () => {
+      await expect(run(stuff.first())).resolves.toEqual({ name: 'bob', type: 'person' });
+    });
+
+    it('returns undefined if the subscription is empty', async () => {
+      await expect(run(emptySubscribable.first())).resolves.toEqual(undefined);
+    });
+  });
+
+  describe('expect', () => {
+    it('returns the first item in the subscription', async () => {
+      await expect(run(stuff.expect())).resolves.toEqual({ name: 'bob', type: 'person' });
+    });
+
+    it('throws an error if the subscription is empty', async () => {
+      await expect(run(emptySubscribable.expect())).rejects.toHaveProperty('message', 'expected subscription to contain a value');
+    });
+  });
+});


### PR DESCRIPTION
Depends on #231 

This adds a `Subscribable` class, and uses it for `on` and `Channel`. It also adapts the other packages to use this new interface.

## Motivation

We noticed that in effection v2, working with subscriptions directly is somewhat cumbersome. The normal case is that the subscriptions will be "drained" through either `forEach` or `first` or similar. Since `forEach` uses internal iteration, the scope of the iterator can be constrained to the task that the `forEach` runs into. However, creating an iterator requires a task. If we create the iterator and then drain it, we need to pass in a task. If we do this all in one step we don't need to pass in this task. This makes the API much cleaner and easier to understand.

## Approach

We add a `Subscribable` interface and a `createSubscribable` function which creates subscribables. The hypothesis is that manually creating subscribables is rare, and that it should usually only be done for primitive structures (e.g. Channel). Therefore the user will get a convenient interface without having to think too much about the intrecacies of this system.

Here's an example of what the current API looks like:

``` typescript
task.spawn(on<[string]>(task, childProcess.stdout, 'data').forEach(([data]) => function*() {
  // ...
}));
```

Note the `task` passed to `on`. Here is the same code with the new API:

``` typescript
task.spawn(on<[string]>(childProcess.stdout, 'data').forEach(([data]) => {
  // ...
}));
```

### Alternate Designs

The status quo is an alternative, where we double down on working with `Subscription` rather than `Subscribable`, but for reasons explained above this feels inconvenient.

### Possible Drawbacks or Risks

Subscriptions are naturally race condition proof, whereas subscribables are not. Some care needs to be taken that no events/messages are lost before subscribing. However, this risk is lessened in effection v2, since task spawning no longer is an operation.

### TODOs and Open Questions

- [ ] Should we still have `Subscription` at all? That is should we have some object with higher level operations like `map` and `filter` for an actual subscription object, rather than a subscribable object? At the moment we feel that having such an object is probably *not* necessary, but more real-world experience is necessary.