### PR TITLE
Make channel ends splittable

### DIFF
--- a/.changeset/mighty-snakes-shop.md
+++ b/.changeset/mighty-snakes-shop.md
@@ -1,0 +1,6 @@
+---
+"@effection/channel": minor
+"effection": minor
+---
+
+Make channel splittable into send and stream ends

--- a/packages/channel/src/channel.ts
+++ b/packages/channel/src/channel.ts
@@ -9,6 +9,7 @@ export type ChannelOptions = {
 export interface Channel<T, TClose = undefined> extends Stream<T, TClose> {
   send(message: T): void;
   close(...args: TClose extends undefined ? [] : [TClose]): void;
+  stream: Stream<T, TClose>;
 }
 
 export function createChannel<T, TClose = undefined>(options: ChannelOptions = {}): Channel<T, TClose> {
@@ -30,7 +31,9 @@ export function createChannel<T, TClose = undefined>(options: ChannelOptions = {
     }
   });
 
-  return Object.assign(subscribable, {
+  return Object.assign({
+    stream: subscribable,
+
     send(message: T) {
       bus.emit('event', { done: false, value: message });
     },
@@ -38,5 +41,5 @@ export function createChannel<T, TClose = undefined>(options: ChannelOptions = {
     close(...args: TClose extends undefined ? [] : [TClose]) {
       bus.emit('event', { done: true, value: args[0] });
     }
-  });
+  }, subscribable);
 }

--- a/packages/channel/test/channel.test.ts
+++ b/packages/channel/test/channel.test.ts
@@ -45,6 +45,18 @@ describe('Channel', () => {
     });
   });
 
+  describe('with split ends', () => {
+    it('receives message on subscribable end', function*(task) {
+      let { send, stream } = createChannel();
+
+      let subscription = stream.subscribe(task);
+
+      send('hello');
+
+      expect(yield subscription.next()).toEqual({ done: false, value: 'hello' });
+    });
+  });
+
   describe('close', () => {
     describe('without argument', () => {
       it('closes subscriptions', function*(task) {


### PR DESCRIPTION
Depends on #233 

## Motivation

We have often had a need for a channel where the sending and receiving ends are separate. Often an API will want to expose the sending end but keep the receiving end private, or vice versa.

## Approach

A very minimal solution where we add a property called `receive` which only returns the subscribable. This allows us then to do this:

``` typescript
let { send, receive } = createChannel();
```

Giving us a very simple way of splitting the ends.

### Alternate Designs

We could add a separate thing for this e.g. `splitChannel`. We could also always split the ends like this:

``` typescript
let [send, receive] = createChannel();
```

But this solution feels both more general and more flexible.

### Possible Drawbacks or Risks

None