### PR TITLE
Add duplex channels

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,6 +113,7 @@ workflows:
                 - subscription
                 - events
                 - channel
+                - duplex-channel
                 - fetch
                 - process
                 - atom

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
       "packages/subscription",
       "packages/events",
       "packages/channel",
+      "packages/duplex-channel",
       "packages/atom",
       "packages/process",
       "packages/node",

--- a/packages/duplex-channel/.gitignore
+++ b/packages/duplex-channel/.gitignore
@@ -1,0 +1,4 @@
+/node_modules
+/yarn-error.log
+.node-version
+.cache

--- a/packages/duplex-channel/README.md
+++ b/packages/duplex-channel/README.md
@@ -1,0 +1,4 @@
+# @effection/duplex-channel
+
+A bidirectional channel for sending messages back and forth with two ends which
+are tied to each other.

--- a/packages/duplex-channel/package.json
+++ b/packages/duplex-channel/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@effection/duplex-channel",
+  "version": "2.0.0-beta.1",
+  "description": "A bidirectional channel for effection",
+  "main": "dist-cjs/index.js",
+  "module": "dist-esm/index.js",
+  "types": "dist-esm/index.d.ts",
+  "typeDocEntry": "src/index.ts",
+  "sideEffects": false,
+  "homepage": "https://github.com/thefrontside/effection",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/thefrontside/effection.git",
+    "directory": "packages/channel"
+  },
+  "author": "Frontside Engineering <engineering@frontside.io>",
+  "license": "MIT",
+  "files": [
+    "README.md",
+    "CHANGELOG.md",
+    "dist-*/**/*",
+    "src/**/*"
+  ],
+  "scripts": {
+    "lint": "eslint '{src,tests}/**/*.ts'",
+    "test": "mocha -r ts-node/register test/**/*.test.ts",
+    "prepack": "tsc --build tsconfig.esm.json && tsc --build tsconfig.esm.json && tsc --build tsconfig.cjs.json",
+    "mocha": "mocha -r ts-node/register"
+  },
+  "devDependencies": {
+    "@effection/mocha": "^2.0.0-beta.9",
+    "@frontside/tsconfig": "^1.2.0",
+    "@types/mocha": "^7.0.1",
+    "@types/node": "^13.13.4",
+    "expect": "^25.4.0",
+    "mocha": "^8.3.1",
+    "ts-node": "^10.1.0",
+    "typescript": "^4.3.5"
+  },
+  "dependencies": {
+    "@effection/core": "^2.0.0-beta.10",
+    "@effection/channel": "^2.0.0-beta.12",
+    "@effection/subscription": "^2.0.0-beta.12"
+  },
+  "volta": {
+    "extends": "../../package.json"
+  }
+}

--- a/packages/duplex-channel/src/duplex-channel.ts
+++ b/packages/duplex-channel/src/duplex-channel.ts
@@ -1,0 +1,27 @@
+import { Stream } from '@effection/subscription';
+import { createChannel, ChannelOptions } from '@effection/channel';
+
+type Close<T> = (...args: T extends undefined ? [] : [T]) => void;
+
+export interface DuplexChannel<TReceive, TSend, TClose = undefined> extends Stream<TReceive, TClose> {
+  send(message: TSend): void;
+  close: Close<TClose>;
+  stream: Stream<TReceive, TClose>;
+}
+
+export type DuplexChannelPair<TLeft, TRight, TClose = undefined> = [DuplexChannel<TLeft, TRight, TClose>, DuplexChannel<TRight, TLeft, TClose>]
+
+export function createDuplexChannel<TLeft, TRight, TClose = undefined>(options: ChannelOptions = {}): DuplexChannelPair<TLeft, TRight, TClose> {
+  let leftChannel = createChannel<TLeft, TClose>(options);
+  let rightChannel = createChannel<TRight, TClose>(options);
+
+  let close: Close<TClose> = (...args) => {
+    leftChannel.close(...args);
+    rightChannel.close(...args);
+  };
+
+  return [
+    { send: rightChannel.send, stream: leftChannel.stream, close, ...leftChannel.stream },
+    { send: leftChannel.send, stream: rightChannel.stream, close, ...rightChannel.stream },
+  ];
+}

--- a/packages/duplex-channel/src/index.ts
+++ b/packages/duplex-channel/src/index.ts
@@ -1,0 +1,1 @@
+export { createDuplexChannel, DuplexChannel, DuplexChannelPair } from './duplex-channel';

--- a/packages/duplex-channel/test/duplex-channel.test.ts
+++ b/packages/duplex-channel/test/duplex-channel.test.ts
@@ -1,0 +1,73 @@
+import { describe, beforeEach, it } from '@effection/mocha';
+import expect from 'expect'
+
+import { OperationIterator } from 'effection';
+import { createDuplexChannel, DuplexChannel } from '../src/index';
+
+describe("createDuplexChannel", () => {
+  let left: DuplexChannel<number, string>;
+  let right: DuplexChannel<string, number>;
+
+  beforeEach(function*() {
+    [left, right] = createDuplexChannel<number, string>();
+  });
+
+  it('can destructure channels as a record', function*(world) {
+    let [{ send }, { stream }] = createDuplexChannel<number, string>();
+    let subscription = stream.subscribe(world);
+    send("hello");
+    expect(yield subscription.next()).toEqual({ done: false, value: "hello" })
+  });
+
+  describe('sending a message to left', () => {
+    let subscription: OperationIterator<string, undefined>;
+
+    beforeEach(function*(world) {
+      subscription = right.subscribe(world);
+      left.send("hello");
+    });
+
+    it('is received on right', function*() {
+      expect(yield subscription.next()).toEqual({ done: false, value: "hello" })
+    });
+  });
+
+  describe('sending a message to right', () => {
+    let subscription: OperationIterator<number, undefined>;
+
+    beforeEach(function*(world) {
+      subscription = left.subscribe(world);
+      right.send(123);
+    });
+
+    it('is received on right', function*() {
+      expect(yield subscription.next()).toEqual({ done: false, value: 123 })
+    });
+  });
+
+  describe('closing the channel', () => {
+    let txSubscription: OperationIterator<number, undefined>;
+    let rxSubscription: OperationIterator<string, undefined>;
+
+    beforeEach(function*(world) {
+      txSubscription = left.subscribe(world);
+      rxSubscription = right.subscribe(world);
+    });
+
+    describe('on right', () => {
+      it('closes both ends', function*() {
+        right.close();
+        expect(yield rxSubscription.next()).toEqual({ done: true, value: undefined })
+        expect(yield txSubscription.next()).toEqual({ done: true, value: undefined })
+      });
+    });
+
+    describe('on left', () => {
+      it('closes both ends', function*() {
+        left.close();
+        expect(yield rxSubscription.next()).toEqual({ done: true, value: undefined })
+        expect(yield txSubscription.next()).toEqual({ done: true, value: undefined })
+      });
+    });
+  });
+});

--- a/packages/duplex-channel/tsconfig.cjs.json
+++ b/packages/duplex-channel/tsconfig.cjs.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist-cjs",
+    "noEmit": false
+  },
+  "references": [
+    { "path": "../core/tsconfig.cjs.json" },
+    { "path": "../events/tsconfig.cjs.json" },
+    { "path": "../subscription/tsconfig.cjs.json" }
+  ],
+  "exclude": ["./test/*"]
+}

--- a/packages/duplex-channel/tsconfig.esm.json
+++ b/packages/duplex-channel/tsconfig.esm.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.cjs.json",
+  "compilerOptions": {
+    "outDir": "./dist-esm",
+    "module": "ESNext"
+  },
+  "references": [
+    { "path": "../core/tsconfig.esm.json" },
+    { "path": "../events/tsconfig.esm.json" },
+    { "path": "../subscription/tsconfig.esm.json" }
+  ],
+  "exclude": ["./test/*"]
+}

--- a/packages/duplex-channel/tsconfig.json
+++ b/packages/duplex-channel/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "noEmit": true
+  },
+  "references": [
+    { "path": "../core/tsconfig.cjs.json" },
+    { "path": "../events/tsconfig.cjs.json" },
+    { "path": "../subscription/tsconfig.cjs.json" }
+  ],
+  "include": [
+    "src/**/*.ts",
+    "test/**/*.ts"
+  ]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -8,6 +8,7 @@
     "paths": {
       "@effection/atom": ["packages/atom/src"],
       "@effection/channel": ["packages/channel/src"],
+      "@effection/duplex-channel": ["packages/duplex-channel/src"],
       "@effection/core": ["packages/core/src"],
       "effection": ["packages/effection/src"],
       "@effection/events": ["packages/events/src"],


### PR DESCRIPTION
Depends on #235 

## Motivation

It is pretty useful to have channel pairs that are tied to each other. We are already using this pattern inside bigtest, and it is pretty simple to implement on top of our new channels.

## Approach

Since we can destructure channels, we can create two channels and mix and match their methods.

### Alternate Designs

We could have separate `TClose` types for either ends? I can't see a usecase for that though.

### Possible Drawbacks or Risks

Adds complexity and another thing to maintain