### PR TITLE
Update dependency of ctrlc-windows in node

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,6 +4,6 @@
   "commit": false,
   "linked": [],
   "access": "restricted",
-  "baseBranch": "v0",
+  "baseBranch": "v1",
   "updateInternalDependencies": "patch"
 }

--- a/.changeset/red-goats-greet.md
+++ b/.changeset/red-goats-greet.md
@@ -1,0 +1,5 @@
+---
+"@effection/node": patch
+---
+
+Bump ctrlc-windows to 1.0.3 to include not-windows.js

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -35,7 +35,7 @@
     "@effection/events": "^1.0.0",
     "@effection/subscription": "^1.0.0",
     "cross-spawn": "^7.0.3",
-    "ctrlc-windows": "^1.0.2",
+    "ctrlc-windows": "^1.0.3",
     "effection": "^1.0.0",
     "shellwords": "^0.1.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3172,10 +3172,10 @@ csv@^5.3.1:
     csv-stringify "^5.3.6"
     stream-transform "^2.0.1"
 
-ctrlc-windows@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/ctrlc-windows/-/ctrlc-windows-1.0.2.tgz#4fd723f3611bd0760277689f8daef9ceed73d92d"
-  integrity sha512-TbJhs5FhoJSMSP3V8MbV19L34/DX8GZAlKJ5ttgTi8PuycY+NAy+hc73QoqJSav3e1lE8SUggAS6q10J2M0DFA==
+ctrlc-windows@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/ctrlc-windows/-/ctrlc-windows-1.0.3.tgz#ab00c48393a1ea2052cd6b7723025e29231709ff"
+  integrity sha512-Ld3g7vKQ9V5xWHYllbB+7k9bUy+MBAaVPGgUzLWsCY9S4UBj/rpGyf2ojRYgITe/1TccK2rXcNHr54kS90d5yA==
   dependencies:
     neon-cli "^0.5.0"
     node-pre-gyp "^0.16.0"


### PR DESCRIPTION
## Motivation

[ctrlc-windows #22](https://github.com/thefrontside/ctrlc-windows/pull/22). The `not-windows.js` file was not being included in the release so installing `@effection/node` would output windows-related errors on non-windows systems.

## Approach

- Bump `ctrlc-windows` from `1.0.2` to `1.0.3`
- Added changeset