### PR TITLE
Update dependency of ctrlc-windows in node (for v2 branch)

### DIFF
--- a/.changeset/nervous-fireants-flow.md
+++ b/.changeset/nervous-fireants-flow.md
@@ -1,0 +1,5 @@
+---
+"@effection/node": patch
+---
+
+Upgrade ctrlc-windows to 1.0.3

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -37,7 +37,7 @@
     "@effection/events": "^2.0.0-preview.2",
     "@effection/subscription": "^2.0.0-preview.2",
     "cross-spawn": "^7.0.3",
-    "ctrlc-windows": "^1.0.2",
+    "ctrlc-windows": "^1.0.3",
     "shellwords": "^0.1.1"
   },
   "volta": {


### PR DESCRIPTION
## Motivation

Same PR as #238 but for `v2`.

## Approach

Bump `ctrlc-windows` from 1.0.2 to 1.0.3 and add changeset.