### PR TITLE
Add @effection/mocha package and use it in own test suite

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "workspaces": {
     "packages": [
       "packages/core",
+      "packages/mocha",
       "packages/subscription",
       "packages/events",
       "packages/channel",

--- a/packages/channel/package.json
+++ b/packages/channel/package.json
@@ -22,6 +22,7 @@
   "devDependencies": {
     "@frontside/tsconfig": "^0.0.1",
     "@types/node": "^12.7.11",
+    "@effection/mocha": "2.0.0-preview.2",
     "expect": "^25.4.0",
     "mocha": "^7.2.0",
     "ts-node": "^8.9.0",

--- a/packages/channel/test/channel.test.ts
+++ b/packages/channel/test/channel.test.ts
@@ -1,120 +1,70 @@
-import { describe, it, beforeEach } from 'mocha';
+import { describe, it, beforeEach } from '@effection/mocha';
 import * as expect from 'expect';
 
-import { sleep, run, Task, Effection } from '@effection/core';
-import { OperationIterator, subscribe } from '@effection/subscription';
-
+import { sleep } from '@effection/core';
 import { createChannel, Channel } from '../src/index';
 
 describe('Channel', () => {
-  beforeEach(async () => {
-    await Effection.reset();
-  });
-
   describe('subscribe', () => {
     let channel: Channel<string>;
-    let subscription: OperationIterator<string, undefined>;
 
-    beforeEach(async () => {
+    beforeEach(function*() {
       channel = createChannel();
-      subscription = channel.subscribe(Effection.root);
     });
 
     describe('sending a message', () => {
-      beforeEach(() => {
+      it('receives message on subscription', function*(task) {
+        let subscription = channel.subscribe(task);
         channel.send('hello');
-      });
-
-      it('receives message on subscription', async () => {
-        let result = await run(subscription.next());
+        let result = yield subscription.next();
         expect(result.done).toEqual(false);
         expect(result.value).toEqual('hello');
       });
     });
 
     describe('blocking on next', () => {
-      let result: Task<IteratorResult<string, undefined>>;
-
-      beforeEach(async () => {
-        result = run(subscription.next());
-        await run(sleep(10));
+      it('receives message on subscription done', function*(task) {
+        let subscription = channel.subscribe(task);
+        let result = task.spawn(subscription.next());
+        yield sleep(10);
         channel.send('hello');
-      });
-
-      it('receives message on subscription done', async () => {
-        await expect(result).resolves.toHaveProperty('value', 'hello');
+        expect(yield result).toHaveProperty('value', 'hello');
       });
     });
 
     describe('sending multiple messages', () => {
-      beforeEach(() => {
+      it('receives messages in order', function*(task) {
+        let subscription = channel.subscribe(task);
         channel.send('hello');
         channel.send('foo');
         channel.send('bar');
-      });
-
-      it('receives messages in order', async () => {
-        expect(await run(subscription.next())).toHaveProperty('value', 'hello');
-        expect(await run(subscription.next())).toHaveProperty('value', 'foo');
-        expect(await run(subscription.next())).toHaveProperty('value', 'bar');
-      });
-    });
-  });
-
-  describe('subscribe free function', () => {
-    let channel: Channel<string>;
-    let subscription: OperationIterator<string, undefined>;
-
-    beforeEach(async () => {
-      channel = createChannel();
-      subscription = subscribe(Effection.root, channel);
-    });
-
-    describe('sending a message', () => {
-      beforeEach(() => {
-        channel.send('hello');
-      });
-
-      it('receives message on subscription', async () => {
-        let result = await run(subscription.next());
-        expect(result.done).toEqual(false);
-        expect(result.value).toEqual('hello');
+        expect(yield subscription.next()).toHaveProperty('value', 'hello');
+        expect(yield subscription.next()).toHaveProperty('value', 'foo');
+        expect(yield subscription.next()).toHaveProperty('value', 'bar');
       });
     });
   });
 
   describe('close', () => {
     describe('without argument', () => {
-      let channel: Channel<string>;
-      let subscription: OperationIterator<string, undefined>;
-
-      beforeEach(async () => {
-        channel = createChannel();
-        subscription = subscribe(Effection.root, channel);
+      it('closes subscriptions', function*(task) {
+        let channel = createChannel();
+        let subscription = channel.subscribe(task);
         channel.send('foo');
         channel.close();
-      });
-
-      it('closes subscriptions', async () => {
-        await expect(run(subscription.next())).resolves.toEqual({ done: false, value: 'foo' });
-        await expect(run(subscription.next())).resolves.toEqual({ done: true, value: undefined });
+        expect(yield subscription.next()).toEqual({ done: false, value: 'foo' });
+        expect(yield subscription.next()).toEqual({ done: true, value: undefined });
       });
     });
 
     describe('with close argument', () => {
-      let channel: Channel<string, number>;
-      let subscription: OperationIterator<string, number>;
-
-      beforeEach(async () => {
-        channel = createChannel();
-        subscription = subscribe(Effection.root, channel);
+      it('closes subscriptions with the argument', function*(task) {
+        let channel = createChannel<string, number>();
+        let subscription = channel.subscribe(task);
         channel.send('foo');
         channel.close(12);
-      });
-
-      it('closes subscriptions with the argument', async () => {
-        await expect(run(subscription.next())).resolves.toEqual({ done: false, value: 'foo' });
-        await expect(run(subscription.next())).resolves.toEqual({ done: true, value: 12 });
+        expect(yield subscription.next()).toEqual({ done: false, value: 'foo' });
+        expect(yield subscription.next()).toEqual({ done: true, value: 12 });
       });
     });
   });

--- a/packages/core/src/effection.ts
+++ b/packages/core/src/effection.ts
@@ -12,5 +12,9 @@ export const Effection = {
   async reset() {
     await Effection.root.halt();
     Effection.root = createRootTask();
+  },
+
+  async halt() {
+    await Effection.root.halt();
   }
 }

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -27,6 +27,7 @@
   "devDependencies": {
     "@frontside/tsconfig": "0.0.1",
     "@types/node": "^12.7.11",
+    "@effection/mocha": "2.0.0-preview.2",
     "expect": "^25.4.0",
     "mocha": "^7.1.1",
     "ts-node": "^8.9.0",

--- a/packages/events/test/helpers.ts
+++ b/packages/events/test/helpers.ts
@@ -1,5 +1,0 @@
-import { Effection } from '@effection/core';
-
-beforeEach(async () => {
-  await Effection.reset();
-});

--- a/packages/events/test/on.test.ts
+++ b/packages/events/test/on.test.ts
@@ -1,9 +1,7 @@
-import './helpers';
-
-import { describe, it, beforeEach } from 'mocha';
+import { describe, it, beforeEach } from '@effection/mocha';
 import * as expect from 'expect'
 
-import { Effection, run, sleep } from '@effection/core';
+import { sleep } from '@effection/core';
 import { OperationIterator } from '@effection/subscription';
 import { EventEmitter } from 'events';
 
@@ -15,48 +13,44 @@ describe("on", () => {
     let emitter: EventEmitter;
     let iterator: OperationIterator<[string], void>;
 
-    beforeEach(async () => {
+    beforeEach(function*(task) {
       emitter = new EventEmitter();
-      iterator = on<[string]>(emitter, "thing").subscribe(Effection.root);
+      iterator = on<[string]>(emitter, "thing").subscribe(task);
     });
 
     describe('emitting an event', () => {
-      beforeEach(() => {
+      beforeEach(function*() {
         emitter.emit("thing", 123, true);
       });
 
-      it('receives event', async () => {
-        let { value } = await run(iterator.next());
+      it('receives event', function*() {
+        let { value } = yield iterator.next();
         expect(value).toEqual([123, true]);
       });
     });
 
     describe('emitting an event efter subscribing', () => {
-      beforeEach(() => {
-        run(function*() {
-          yield sleep(5);
-          emitter.emit("thing", 123, true);
-        });
+      beforeEach(function*() {
+        yield sleep(5);
+        emitter.emit("thing", 123, true);
       });
 
-      it('receives event', async () => {
-        let { value } = await run(iterator.next());
+      it('receives event', function*() {
+        let { value } = yield iterator.next();
         expect(value).toEqual([123, true]);
       });
     });
 
     describe('emitting multiple events', () => {
-      beforeEach(() => {
-        run(function*() {
-          yield sleep(5);
-          emitter.emit("thing", "foo");
-          emitter.emit("thing", "bar");
-        });
+      beforeEach(function*() {
+        yield sleep(5);
+        emitter.emit("thing", "foo");
+        emitter.emit("thing", "bar");
       });
 
-      it('receives all of them', async () => {
-        expect(await run(iterator.next())).toEqual({ done: false, value: ["foo"]});
-        expect(await run(iterator.next())).toEqual({done: false, value: ["bar"] });
+      it('receives all of them', function*() {
+        expect(yield iterator.next()).toEqual({ done: false, value: ["foo"]});
+        expect(yield iterator.next()).toEqual({done: false, value: ["bar"] });
       });
     });
   });
@@ -66,19 +60,19 @@ describe("on", () => {
     let iterator: OperationIterator<[string], void>;
     let thingEvent: FakeEvent;
 
-    beforeEach(async () => {
+    beforeEach(function*(task) {
       target = new FakeEventEmitter();
-      iterator = on<[string]>(target, "thing").subscribe(Effection.root);
+      iterator = on<[string]>(target, "thing").subscribe(task);
     });
 
     describe('emitting an event', () => {
-      beforeEach(() => {
+      beforeEach(function*() {
         thingEvent = new FakeEvent("thing");
         target.dispatchEvent(thingEvent);
       });
 
-      it('receives event', async () => {
-        let { value } = await run(iterator.next());
+      it('receives event', function*() {
+        let { value } = yield iterator.next();
         expect(value).toEqual([thingEvent]);
       });
     });
@@ -88,18 +82,18 @@ describe("on", () => {
     let emitter: EventEmitter;
     let iterator: OperationIterator<number, void>;
 
-    beforeEach(async () => {
+    beforeEach(function*(task) {
       emitter = new EventEmitter();
-      iterator = on<[number]>(emitter, "thing").map(([value]) => value * 2).subscribe(Effection.root);
+      iterator = on<[number]>(emitter, "thing").map(([value]) => value * 2).subscribe(task);
     });
 
     describe('emitting an event', () => {
-      beforeEach(() => {
+      beforeEach(function*() {
         emitter.emit("thing", 12);
       });
 
-      it('receives event', async () => {
-        let { value } = await run(iterator.next());
+      it('receives event', function*() {
+        let { value } = yield iterator.next();
         expect(value).toEqual(24);
       });
     });

--- a/packages/events/test/once.test.ts
+++ b/packages/events/test/once.test.ts
@@ -1,9 +1,7 @@
-import './helpers';
-
-import { describe, it, beforeEach } from 'mocha';
+import { describe, it, beforeEach } from '@effection/mocha';
 import * as expect from 'expect'
 
-import { sleep, run, Task } from '@effection/core';
+import { sleep, Task } from '@effection/core';
 import { EventEmitter } from 'events';
 
 import { once } from '../src/index';
@@ -12,44 +10,43 @@ describe("once()", () => {
   let task: Task;
   let source: EventEmitter;
 
-  beforeEach(() => {
+  beforeEach(function*(t) {
     source = new EventEmitter();
-    task = run(function*() {
-      return yield once(source, 'event');
-    });
+    task = t.spawn(once(source, 'event'));
   });
 
-  it('pauses before the event is received', () => {
+  it('pauses before the event is received', function*() {
     expect(task.state).toEqual("running");
   });
 
   describe('emitting the event on which it is waiting', () => {
-    beforeEach(() => {
+    beforeEach(function*() {
       source.emit('event', 1,2,10);
     });
 
-    it('returs the parameters of the event', async () => {
-      await expect(task).resolves.toEqual([1,2,10]);
+    it('returs the parameters of the event', function*() {
+      expect(yield task).toEqual([1,2,10]);
     });
   });
 
   describe('emitting an event on which it is not waiting', () => {
-    beforeEach(async () => {
+    beforeEach(function*() {
       source.emit('non-event', 1, 2, 10);
-      await run(sleep(10)); });
+      yield sleep(10);
+    });
 
-    it('remains paused', () => {
+    it('remains paused', function*() {
       expect(task.state).toEqual('running');
     });
   });
 
   describe('shutting down the task and then emitting the event on which it is waiting', () => {
-    beforeEach(() => {
-      task.halt();
+    beforeEach(function*() {
+      yield task.halt();
       source.emit('event', 1, 2, 10);
     });
 
-    it('never returns', () => {
+    it('never returns', function*() {
       expect(task.result).toBeUndefined();
     });
   });

--- a/packages/events/test/throw-on-error-event.test.ts
+++ b/packages/events/test/throw-on-error-event.test.ts
@@ -1,9 +1,7 @@
-import './helpers';
-
-import { describe, it, beforeEach } from 'mocha';
+import { describe, it, beforeEach, captureError } from '@effection/mocha';
 import * as expect from 'expect'
 
-import { Effection, Task } from '@effection/core';
+import { Task } from '@effection/core';
 import { EventEmitter } from 'events';
 
 import { throwOnErrorEvent } from '../src/index';
@@ -13,22 +11,22 @@ describe("throwOnErrorEvent", () => {
   let task: Task;
   let error: Error;
 
-  beforeEach(async () => {
+  beforeEach(function*(t) {
     emitter = new EventEmitter();
-    task = Effection.root.spawn(function*(task) {
-      throwOnErrorEvent(task, emitter);
+    task = t.spawn(captureError(function*(inner) {
+      throwOnErrorEvent(inner, emitter);
       yield;
-    });
+    }));
   });
 
   describe('throws an error when the event occurs', () => {
-    beforeEach(() => {
+    beforeEach(function*() {
       error = new Error("moo");
       emitter.emit("error", error);
     });
 
-    it('throws error', async () => {
-      await expect(task).rejects.toEqual(error);
+    it('throws error', function*() {
+      expect(yield task).toEqual(error);
     });
   });
 });

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -20,6 +20,7 @@
     "mocha": "mocha -r ts-node/register"
   },
   "devDependencies": {
+    "@effection/mocha": "2.0.0-preview.2",
     "@frontside/tsconfig": "^0.0.1",
     "@types/node": "^13.13.4",
     "expect": "26.0.1",

--- a/packages/fetch/test/helpers.ts
+++ b/packages/fetch/test/helpers.ts
@@ -1,18 +1,9 @@
 import { performance } from 'perf_hooks';
-import { Effection } from '@effection/core';
 
 let mochaTimeout: number;
 
 before(function() {
   mochaTimeout = this.timeout(50).timeout();
-});
-
-beforeEach(async () => {
-  await Effection.reset();
-});
-
-afterEach(async () => {
-  await Effection.root.halt();
 });
 
 export async function when<T>(fn: () => T, timeout = mochaTimeout): Promise<T> {

--- a/packages/mocha/README.md
+++ b/packages/mocha/README.md
@@ -1,0 +1,3 @@
+# @effection/mocha
+
+Mocha integration for effection

--- a/packages/mocha/package.json
+++ b/packages/mocha/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@effection/subscription",
-  "version": "2.0.0-preview.3",
+  "name": "@effection/mocha",
+  "version": "2.0.0-preview.2",
   "description": "Effection Subscriptions",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -20,14 +20,13 @@
     "mocha": "mocha -r ts-node/register"
   },
   "dependencies": {
-    "@effection/core": "^2.0.0-preview.3"
+    "@effection/core": "^2.0.0-preview.2",
+    "mocha": "^7.1.1"
   },
   "devDependencies": {
-    "@effection/mocha": "2.0.0-preview.2",
-    "@frontside/tsconfig": "0.0.1",
     "@types/mocha": "^8.0.3",
+    "@frontside/tsconfig": "0.0.1",
     "expect": "^25.4.0",
-    "mocha": "^7.1.1",
     "ts-node": "^8.9.0",
     "tsdx": "0.13.2",
     "typescript": "^3.7.0"

--- a/packages/mocha/src/index.ts
+++ b/packages/mocha/src/index.ts
@@ -1,0 +1,50 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion,@typescript-eslint/no-explicit-any */
+import * as mocha from 'mocha';
+import { run, Task, Effection, Operation } from '@effection/core';
+
+let world: Task | undefined;
+
+type TestFunction = (this: mocha.Context, world: Task, scope: Task) => Generator<Operation<any>, any, any>;
+
+mocha.beforeEach(async function() {
+  await Effection.reset();
+  world = run();
+});
+
+mocha.afterEach(async function() {
+  world!.halt();
+  await world!.catchHalt();
+  world = undefined;
+  await Effection.halt();
+});
+
+export const describe = mocha.describe;
+
+export function it(title: string, fn: TestFunction) {
+  return mocha.it(title, async function() {
+    await run((task) => fn.call(this, world!, task))
+  });
+}
+
+export function beforeEach(fn: TestFunction) {
+  return mocha.beforeEach(async function() {
+    await run((task) => fn.call(this, world!, task))
+  });
+}
+
+export function afterEach(fn: TestFunction) {
+  return mocha.afterEach(async function() {
+    await run((task) => fn.call(this, world!, task))
+  });
+}
+
+export function captureError(op: Operation<any>): Operation<Error> {
+  return function*() {
+    try {
+      yield op;
+    } catch(error) {
+      return error;
+    }
+    throw new Error('expected operation to throw an error, but it did not!');
+  }
+}

--- a/packages/mocha/test/mocha.test.ts
+++ b/packages/mocha/test/mocha.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, beforeEach, captureError } from '../src/index';
+import * as expect from 'expect';
+
+import { Task, sleep } from '@effection/core';
+
+let captured: Task;
+
+function* boom() {
+  throw new Error('boom');
+}
+
+describe('@effection/mocha', () => {
+  // TODO: how can we test that a test should fail? Spawn external mocha process?
+  // it('throws error', function*(task) {
+  //   task.spawn(function*() {
+  //     try {
+  //       yield sleep(3);
+  //     } finally {
+  //       throw new Error('boom');
+  //     }
+  //   });
+  //   yield sleep(10);
+  // });
+
+  describe('accessing mocha API', () => {
+    it('works', function*() {
+      this.timeout(100);
+    });
+  });
+
+  describe('cleaning up tasks', () => {
+    it('sets up task', function*(task) {
+      captured = task.spawn();
+    });
+
+    it('and cleans it up', function*() {
+      expect(captured.state).toEqual('halted');
+    });
+  });
+
+  describe('captureError', () => {
+    it('returns error thrown by given operation', function*() {
+      expect(yield captureError(boom)).toHaveProperty('message', 'boom');
+    });
+
+    it('throws an error if given operation does not throw an error', function*() {
+      expect(yield captureError(captureError(function*() {}))).toHaveProperty('message', 'expected operation to throw an error, but it did not!');
+    });
+  });
+
+  describe('spawning in world', () => {
+    beforeEach(function*(world) {
+      captured = world.spawn();
+    });
+
+    it('does not halt the spawned task before it block', function*() {
+      expect(captured.state).toEqual('running');
+    });
+  });
+
+  describe('spawning in scope', () => {
+    beforeEach(function*(world, scope) {
+      captured = scope.spawn();
+    });
+
+    it('halts the spawned task before it block', function*() {
+      expect(captured.state).toEqual('halted');
+    });
+  });
+});

--- a/packages/mocha/tsconfig.dist.json
+++ b/packages/mocha/tsconfig.dist.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "module": "esnext"
+  },
+  "exclude": ["./test/*"]
+}

--- a/packages/mocha/tsconfig.json
+++ b/packages/mocha/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "@frontside/tsconfig",
+  "include": [
+    "src/**/*.ts",
+    "test/**/*.ts"
+  ]
+}

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -20,6 +20,7 @@
     "mocha": "mocha -r ts-node/register"
   },
   "devDependencies": {
+    "@effection/mocha": "2.0.0-preview.2",
     "@frontside/tsconfig": "0.0.1",
     "@types/cross-spawn": "^6.0.2",
     "@types/node": "^13.13.2",

--- a/packages/node/test/helpers.ts
+++ b/packages/node/test/helpers.ts
@@ -1,15 +1,10 @@
 import { performance } from 'perf_hooks';
 import { beforeEach } from 'mocha';
 import * as expect from 'expect';
-import { run, Effection, Task } from '@effection/core';
+import { run, Task } from '@effection/core';
 import { Channel } from '@effection/channel';
-import { subscribe } from '@effection/subscription';
 import { ctrlc } from 'ctrlc-windows';
 import { exec, Process } from '../src/exec';
-
-beforeEach(async () => {
-  await Effection.reset();
-});
 
 export class TestProcess {
   isWin32 = global.process.platform === 'win32';

--- a/packages/node/test/main.test.ts
+++ b/packages/node/test/main.test.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import * as expect from 'expect';
-import { describe, it, beforeEach } from 'mocha';
+import { describe, it, beforeEach } from '@effection/mocha';
 
 import { Effection } from '@effection/core';
 import { TestProcess } from './helpers';
@@ -9,47 +9,47 @@ describe('main', () => {
   let child: TestProcess;
 
   describe('with successful process', () => {
-    beforeEach(async () => {
+    beforeEach(function*() {
       child = TestProcess.exec(Effection.root, `ts-node ./fixtures/text-writer.ts`);
 
-      await child.stdout.detect("started");
+      yield child.stdout.detect("started");
     });
 
     describe('interrupting the process', () => {
-      beforeEach(async () => {
+      beforeEach(function*() {
         child.interrupt();
-        await child.join();
+        yield child.join();
       });
 
-      it('shuts down gracefully', async () => {
-        await child.stdout.detect("stopped");
+      it('shuts down gracefully', function*() {
+        yield child.stdout.detect("stopped");
       });
     });
 
     describe('terminating the process', () => {
-      beforeEach(async () => {
+      beforeEach(function*() {
         child.terminate();
-        await child.join();
+        yield child.join();
       });
 
-      it('shuts down gracefully', async () => {
-        await child.stdout.detect("stopped");
+      it('shuts down gracefully', function*() {
+        yield child.stdout.detect("stopped");
       });
     });
   });
 
   describe('with failing process', () => {
-    it('sets exit code and prints error', async () => {
+    it('sets exit code and prints error', function*() {
       let child = TestProcess.exec(Effection.root, `ts-node ./fixtures/main-failed.ts`);
-      let status = await child.join();
+      let status = yield child.join();
 
       expect(child.stderr.output).toContain('Error: moo');
       expect(status.code).toEqual(1);
     });
 
-    it('sets custom exit code and hides error', async () => {
+    it('sets custom exit code and hides error', function*() {
       let child = TestProcess.exec(Effection.root, `ts-node ./fixtures/main-failed-custom.ts`);
-      let status = await child.join();
+      let status = yield child.join();
 
       expect(child.stderr.output).toContain('It all went horribly wrong');
       expect(child.stderr.output).not.toContain('EffectionMainError');

--- a/packages/subscription/test/helpers.ts
+++ b/packages/subscription/test/helpers.ts
@@ -1,5 +1,0 @@
-import { Effection } from '@effection/core';
-
-beforeEach(async () => {
-  await Effection.reset();
-});

--- a/packages/subscription/test/stream.test.ts
+++ b/packages/subscription/test/stream.test.ts
@@ -1,9 +1,7 @@
-import './helpers';
 import * as expect from 'expect';
-import { describe, it, beforeEach } from 'mocha';
+import { describe, it, captureError } from '@effection/mocha';
 
-import { run, Task, Effection } from '@effection/core';
-import { createStream, Stream, OperationIterator } from '../src/index';
+import { createStream, Stream } from '../src/index';
 
 interface Thing {
   name: string;
@@ -23,9 +21,9 @@ const emptyStream: Stream<Thing, number> = createStream(() => function*() {
 
 describe('chaining subscribable', () => {
   describe('forEach', () => {
-    it('iterates through all members of the subscribable', async () => {
+    it('iterates through all members of the subscribable', function*() {
       let values: Thing[] = [];
-      await run(stuff.forEach((item) => function*() { values.push(item); }));
+      yield stuff.forEach((item) => function*() { values.push(item); });
       expect(values).toEqual([
         {name: 'bob', type: 'person' },
         {name: 'alice', type: 'person' },
@@ -33,9 +31,9 @@ describe('chaining subscribable', () => {
       ])
     });
 
-    it('can iterate with regular function', async () => {
+    it('can iterate with regular function', function*() {
       let values: Thing[] = [];
-      await run(stuff.forEach((item) => { values.push(item); }));
+      yield stuff.forEach((item) => { values.push(item); });
       expect(values).toEqual([
         {name: 'bob', type: 'person' },
         {name: 'alice', type: 'person' },
@@ -43,15 +41,15 @@ describe('chaining subscribable', () => {
       ])
     });
 
-    it('returns the original result', async () => {
-      let result = await run(stuff.forEach(() => function*() { /* no op */ }));
+    it('returns the original result', function*() {
+      let result = yield stuff.forEach(() => function*() { /* no op */ });
       expect(result).toEqual(3);
     });
   });
 
   describe('collect', () => {
-    it('collects values into a synchronous iterator', async () => {
-      let iterator = await run(stuff.collect());
+    it('collects values into a synchronous iterator', function*() {
+      let iterator: Iterator<Thing, number> = yield stuff.collect();
       expect(iterator.next()).toEqual({ done: false, value: { name: 'bob', type: 'person' } });
       expect(iterator.next()).toEqual({ done: false, value: { name: 'alice', type: 'person' } });
       expect(iterator.next()).toEqual({ done: false, value: { name: 'world', type: 'planet' } });
@@ -60,8 +58,8 @@ describe('chaining subscribable', () => {
   });
 
   describe('toArray', () => {
-    it('collects values into an array', async () => {
-      let result = await run(stuff.toArray());
+    it('collects values into an array', function*() {
+      let result = yield stuff.toArray();
       expect(result).toEqual([
         { name: 'bob', type: 'person' },
         { name: 'alice', type: 'person' },
@@ -71,8 +69,8 @@ describe('chaining subscribable', () => {
   });
 
   describe('map', () => {
-    it('maps over the values', async () => {
-      let mapped = await run(stuff.map(item => `hello ${item.name}`).collect());
+    it('maps over the values', function*() {
+      let mapped = yield stuff.map(item => `hello ${item.name}`).collect();
       expect(mapped.next()).toEqual({ done: false, value: 'hello bob' });
       expect(mapped.next()).toEqual({ done: false, value: 'hello alice' });
       expect(mapped.next()).toEqual({ done: false, value: 'hello world' });
@@ -81,8 +79,8 @@ describe('chaining subscribable', () => {
   });
 
   describe('filter', () => {
-    it('filters the values', async () => {
-      let filtered = await run(stuff.filter(item => item.type === 'person').collect());
+    it('filters the values', function*() {
+      let filtered = yield stuff.filter(item => item.type === 'person').collect();
       expect(filtered.next()).toEqual({ done: false, value: { name: 'bob', type: 'person' } });
       expect(filtered.next()).toEqual({ done: false, value: { name: 'alice', type: 'person' } });
       expect(filtered.next()).toEqual({ done: true, value: 3 });
@@ -90,15 +88,15 @@ describe('chaining subscribable', () => {
   });
 
   describe('match', () => {
-    it('filters the values based on the given pattern', async () => {
-      let matched = await run(stuff.match({ type: 'person' }).collect());
+    it('filters the values based on the given pattern', function*() {
+      let matched = yield stuff.match({ type: 'person' }).collect();
       expect(matched.next()).toEqual({ done: false, value: { name: 'bob', type: 'person' } });
       expect(matched.next()).toEqual({ done: false, value: { name: 'alice', type: 'person' } });
       expect(matched.next()).toEqual({ done: true, value: 3 });
     });
 
-    it('can work on nested items', async () => {
-      let matched = await run(stuff.map(item => ({ thing: item })).match({ thing: { type: 'person' } }).collect());
+    it('can work on nested items', function*() {
+      let matched = yield stuff.map(item => ({ thing: item })).match({ thing: { type: 'person' } }).collect();
       expect(matched.next()).toEqual({ done: false, value: { thing: { name: 'bob', type: 'person' } } });
       expect(matched.next()).toEqual({ done: false, value: { thing: { name: 'alice', type: 'person' } } });
       expect(matched.next()).toEqual({ done: true, value: 3 });
@@ -106,22 +104,22 @@ describe('chaining subscribable', () => {
   });
 
   describe('first', () => {
-    it('returns the first item in the subscription', async () => {
-      await expect(run(stuff.first())).resolves.toEqual({ name: 'bob', type: 'person' });
+    it('returns the first item in the subscription', function*() {
+      expect(yield stuff.first()).toEqual({ name: 'bob', type: 'person' });
     });
 
-    it('returns undefined if the subscription is empty', async () => {
-      await expect(run(emptyStream.first())).resolves.toEqual(undefined);
+    it('returns undefined if the subscription is empty', function*() {
+      expect(yield emptyStream.first()).toEqual(undefined);
     });
   });
 
   describe('expect', () => {
-    it('returns the first item in the subscription', async () => {
-      await expect(run(stuff.expect())).resolves.toEqual({ name: 'bob', type: 'person' });
+    it('returns the first item in the subscription', function*() {
+      expect(yield stuff.expect()).toEqual({ name: 'bob', type: 'person' });
     });
 
-    it('throws an error if the subscription is empty', async () => {
-      await expect(run(emptyStream.expect())).rejects.toHaveProperty('message', 'expected subscription to contain a value');
+    it('throws an error if the subscription is empty', function*() {
+      expect(yield captureError(emptyStream.expect())).toHaveProperty('message', 'expected subscription to contain a value');
     });
   });
 });

--- a/packages/subscription/test/subscribe.test.ts
+++ b/packages/subscription/test/subscribe.test.ts
@@ -1,8 +1,6 @@
-import './helpers';
 import * as expect from 'expect';
-import { describe, it } from 'mocha';
-
-import { run, Effection, Task } from '@effection/core';
+import { describe, it } from '@effection/mocha';
+import { Task } from '@effection/core';
 
 import { subscribe, createOperationIterator, OperationIterator, SymbolOperationIterable } from '../src/index';
 
@@ -22,18 +20,18 @@ const subscribableThing = {
 };
 
 describe('subscribe', () => {
-  it('iterates through all members of the subscribable', async () => {
-    let subscription = subscribe(Effection.root, subscribableThing);
-    await expect(run(subscription.next())).resolves.toEqual({ done: false, value: { name: 'bob', type: 'person' } });
-    await expect(run(subscription.next())).resolves.toEqual({ done: false, value: { name: 'alice', type: 'person' } });
-    await expect(run(subscription.next())).resolves.toEqual({ done: false, value: { name: 'world', type: 'planet' } });
-    await expect(run(subscription.next())).resolves.toEqual({ done: true, value: 3 });
+  it('iterates through all members of the subscribable', function*(task) {
+    let subscription = subscribe(task, subscribableThing);
+    expect(yield subscription.next()).toEqual({ done: false, value: { name: 'bob', type: 'person' } });
+    expect(yield subscription.next()).toEqual({ done: false, value: { name: 'alice', type: 'person' } });
+    expect(yield subscription.next()).toEqual({ done: false, value: { name: 'world', type: 'planet' } });
+    expect(yield subscription.next()).toEqual({ done: true, value: 3 });
   });
 
-  it('is chainable', async () => {
-    let subscription = subscribe(Effection.root, subscribableThing).filter((t) => t.type === 'person');
-    await expect(run(subscription.next())).resolves.toEqual({ done: false, value: { name: 'bob', type: 'person' } });
-    await expect(run(subscription.next())).resolves.toEqual({ done: false, value: { name: 'alice', type: 'person' } });
-    await expect(run(subscription.next())).resolves.toEqual({ done: true, value: 3 });
+  it('is chainable', function*(task) {
+    let subscription = subscribe(task, subscribableThing).filter((t) => t.type === 'person');
+    expect(yield subscription.next()).toEqual({ done: false, value: { name: 'bob', type: 'person' } });
+    expect(yield subscription.next()).toEqual({ done: false, value: { name: 'alice', type: 'person' } });
+    expect(yield subscription.next()).toEqual({ done: true, value: 3 });
   });
 });


### PR DESCRIPTION
Closes #247

In order to effectively test effection code, it is much easier to write the entire test in an operation context, rather than delegating to some world object. This adds proper integration with the mocha test runner.