### PR TITLE
Make event emitter api more convenient.

### DIFF
--- a/.changeset/emmitter-stream.md
+++ b/.changeset/emmitter-stream.md
@@ -1,0 +1,11 @@
+---
+"@effection/events": patch
+"effection": patch
+---
+`once()` only yields the first argument passed to `emit()` which
+accounts for 99.9% of the use cases. For the cases where all the
+arguments are required, use `onceEmit()`
+
+`on()` produces a stream of the first arguments passed to `emit()`
+which accounts for 99.9% of the use cases. For the cases where all the
+arguments are required, use `onEmit()`.

--- a/packages/channel/src/channel.ts
+++ b/packages/channel/src/channel.ts
@@ -21,7 +21,7 @@ export function createChannel<T, TClose = undefined>(options: ChannelOptions = {
   let subscribable = createStream<T, TClose>((publish) => function*(task) {
     let subscription = on(bus, 'event').subscribe(task);
     while(true) {
-      let { value: [next] } = yield subscription.next();
+      let { value: next } = yield subscription.next();
       if(next.done) {
         return next.value;
       } else {

--- a/packages/events/src/index.ts
+++ b/packages/events/src/index.ts
@@ -1,4 +1,4 @@
-export { once } from './once';
-export { on } from './on';
+export { once, onceEmit } from './once';
+export { on, onEmit } from './on';
 export { throwOnErrorEvent } from './throw-on-error-event';
 export { EventSource } from './event-source';

--- a/packages/events/src/on.ts
+++ b/packages/events/src/on.ts
@@ -2,6 +2,66 @@ import { createStream, Stream } from '@effection/subscription';
 
 import { EventSource, addListener, removeListener } from './event-source';
 
+
+/**
+ * Creates a {@link Stream} from an event source and event name that
+ * produces the event as its next value every time that the source
+ * raises it. Streams created in this way are infinite.
+ *
+ * Both {@link EventTarget} and {@link EventEmitter}
+ * are supported.
+ *
+ * ### Example
+ *
+ * log every click in a web page:
+ *
+ * ```javascript
+ * task.spawn(on(document, 'click').forEach(event => {
+ *   console.log(`click at (${event.pageX}, ${event.pageY})`);
+ * }));
+ * ```
+ *
+ * ### Example
+ *
+ * buffer a node process's stdin into a single string:
+ *
+ * ```javascript
+ * let buffer = '';
+ * task.spawn(on(process.stdin, 'data').forEach(data => {
+ *   buffer += data;
+ * }));
+ */
+export function on<T = unknown>(source: EventSource, name: string): Stream<T, void> {
+  return onEmit<[T]>(source, name).map(([event]) => event)
+}
+
+/**
+ * Exactly like {@link on | on()} except each value produced by the
+ * stream is an {@link Array} of all the arguments passed when the event was
+ * dispatched.
+ *
+ * This should rarely be needed, and never with {@link EventTarget}s
+ * which always invoke their event listeners with a single argument.
+ *
+ * ### Example
+ *
+ * stream an odd-ball event emitter that passes multiple arguments to
+ * its handers. Most event emitters do not act this way:
+ *
+ * ```javascript
+ * let emitter = new EventEmitter();
+ *
+ * task.spawn(onEmit(emitter, 'multiplication').forEach(([left, right]) => {
+ *   console.log(`${left} times ${right} = ${left * right}!`);
+ * }));
+ *
+ * yield sleep(10);
+ *
+ * emitter.emit('multiplication', 7, 6);
+ * //=> 7 times 6 = 42!
+ * ```
+ *
+ */
 export function onEmit<T extends Array<unknown> = unknown[]>(source: EventSource, name: string): Stream<T, void> {
   return createStream((publish) => function*() {
     let listener = (...args: T) => publish(args);
@@ -12,9 +72,4 @@ export function onEmit<T extends Array<unknown> = unknown[]>(source: EventSource
       removeListener(source, name, listener);
     }
   });
-}
-
-
-export function on<T = unknown>(source: EventSource, name: string): Stream<T, void> {
-  return onEmit<[T]>(source, name).map(([event]) => event)
 }

--- a/packages/events/src/on.ts
+++ b/packages/events/src/on.ts
@@ -2,7 +2,7 @@ import { createStream, Stream } from '@effection/subscription';
 
 import { EventSource, addListener, removeListener } from './event-source';
 
-export function on<T extends Array<unknown> = unknown[]>(source: EventSource, name: string): Stream<T, void> {
+export function onEmit<T extends Array<unknown> = unknown[]>(source: EventSource, name: string): Stream<T, void> {
   return createStream((publish) => function*() {
     let listener = (...args: T) => publish(args);
     try {
@@ -12,4 +12,9 @@ export function on<T extends Array<unknown> = unknown[]>(source: EventSource, na
       removeListener(source, name, listener);
     }
   });
+}
+
+
+export function on<T = unknown>(source: EventSource, name: string): Stream<T, void> {
+  return onEmit<[T]>(source, name).map(([event]) => event)
 }

--- a/packages/events/src/once.ts
+++ b/packages/events/src/once.ts
@@ -5,12 +5,19 @@ import { EventSource, addListener, removeListener } from './event-source';
  * Takes an event source and event name and returns a yieldable
  * operation which resumes when the event occurs.
  */
-export function once<TArgs extends unknown[] = unknown[]>(source: EventSource, eventName: string): Operation<TArgs> {
+export function onceEmit<TArgs extends unknown[] = unknown[]>(source: EventSource, eventName: string): Operation<TArgs> {
   return (task) => (resolve) => {
     let listener = (...args: unknown[]) => { resolve(args as TArgs) };
     task.ensure(() => {
       removeListener(source, eventName, listener);
     });
     addListener(source, eventName, listener);
+  }
+}
+
+export function once<T = unknown>(source: EventSource, eventName: string): Operation<T> {
+  return function*() {
+    let [event]: [T] = yield onceEmit<[T]>(source, eventName);
+    return event;
   }
 }

--- a/packages/events/src/once.ts
+++ b/packages/events/src/once.ts
@@ -1,9 +1,58 @@
 import { Operation } from '@effection/core';
 import { EventSource, addListener, removeListener } from './event-source';
 
+
 /**
- * Takes an event source and event name and returns a yieldable
- * operation which resumes when the event occurs.
+ * Takes an event source and event name and returns an
+ * {@link effection:Operation} that produces the value emitted by that
+ * event. Both {@link EventTarget} and {@link EventEmitter} are
+ * supported.
+ *
+ * ### Example
+ *
+ * ``` javascript
+ * let start = yield once(document, 'dragstart');
+ * console.log(`drag started at (${start.pageX}, ${start.pageY})`);
+ *
+ * let end = yield once(document, 'dragend');
+ * console.log(`drag ended at (${end.pageX}, ${end.pageY})`);
+ * ```
+ *
+ * ### Example
+ *
+ * ``` javascript
+ * let src = yield once(stream, 'pipe');
+ * ```
+ */
+export function once<T = unknown>(source: EventSource, eventName: string): Operation<T> {
+  return function*() {
+    let [event]: [T] = yield onceEmit<[T]>(source, eventName);
+    return event;
+  }
+}
+
+/**
+ * Exactly like {@link once | once()} except the value produced is an
+ * {@link Array} of all the arguments passed when the event was
+ * dispatched.
+ *
+ * In very rare cases, some event emitters pass multiple arguments to
+ * their event handlers. For example the {@link ChildProcess} in
+ * NodeJS emits both a status code _and_ a signal to the 'exit'
+ * event. It would not be possible to read the signal from the `exit`
+ * event using just the `once()` operation, so you would need to use
+ * the `onceEmit()` operation to get all the arguments sent to the
+ * event handler as an array.
+ *
+ * While it is supported, you should never need to use `onceEmit()` on
+ * an {@link EventTarget} since only a single argument is ever passed
+ * to its event handler. In those cases, always use {@link once | once()}
+ *
+ * ### Example
+ *
+ * ```javascript
+ * let [exitCode, signal] = yield onEmit(childProcess, 'exit');
+ * ```
  */
 export function onceEmit<TArgs extends unknown[] = unknown[]>(source: EventSource, eventName: string): Operation<TArgs> {
   return (task) => (resolve) => {
@@ -12,12 +61,5 @@ export function onceEmit<TArgs extends unknown[] = unknown[]>(source: EventSourc
       removeListener(source, eventName, listener);
     });
     addListener(source, eventName, listener);
-  }
-}
-
-export function once<T = unknown>(source: EventSource, eventName: string): Operation<T> {
-  return function*() {
-    let [event]: [T] = yield onceEmit<[T]>(source, eventName);
-    return event;
   }
 }

--- a/packages/events/src/throw-on-error-event.ts
+++ b/packages/events/src/throw-on-error-event.ts
@@ -4,7 +4,7 @@ import { EventSource } from './event-source';
 
 export function throwOnErrorEvent(task: Task, source: EventSource): Task {
   return task.spawn(function*() {
-    let [error]: [Error] = yield once(source, 'error');
+    let error: Error = yield once(source, 'error');
     throw error;
   });
 }

--- a/packages/events/test/once.test.ts
+++ b/packages/events/test/once.test.ts
@@ -4,7 +4,7 @@ import * as expect from 'expect'
 import { sleep, Task } from '@effection/core';
 import { EventEmitter } from 'events';
 
-import { once } from '../src/index';
+import { once, onceEmit } from '../src/index';
 
 describe("once()", () => {
   let task: Task;
@@ -21,17 +21,17 @@ describe("once()", () => {
 
   describe('emitting the event on which it is waiting', () => {
     beforeEach(function*() {
-      source.emit('event', 1,2,10);
+      source.emit('event', 1);
     });
 
-    it('returs the parameters of the event', function*() {
-      expect(yield task).toEqual([1,2,10]);
+    it('returns the first parameter of the event', function*() {
+      expect(yield task).toEqual(1);
     });
   });
 
   describe('emitting an event on which it is not waiting', () => {
     beforeEach(function*() {
-      source.emit('non-event', 1, 2, 10);
+      source.emit('non-event', 1);
       yield sleep(10);
     });
 
@@ -43,11 +43,26 @@ describe("once()", () => {
   describe('shutting down the task and then emitting the event on which it is waiting', () => {
     beforeEach(function*() {
       yield task.halt();
-      source.emit('event', 1, 2, 10);
+      source.emit('event', 1);
     });
 
     it('never returns', function*() {
       expect(task.result).toBeUndefined();
     });
+  });
+});
+
+describe('onceEmit()', () => {
+  let task: Task;
+  let source: EventEmitter;
+
+  beforeEach(function*(t) {
+    source = new EventEmitter();
+    task = t.spawn(onceEmit(source, 'event'))
+    source.emit('event', 1,2,3);
+  });
+
+  it('returns all parameters of the event as an array', function*() {
+    expect(yield task).toEqual([1,2,3]);
   });
 });

--- a/packages/node/src/exec/posix.ts
+++ b/packages/node/src/exec/posix.ts
@@ -1,6 +1,6 @@
 import { Operation, Deferred } from '@effection/core';
 import { createChannel } from '@effection/channel';
-import { on, once } from '@effection/events';
+import { on, onceEmit } from '@effection/events';
 import { spawn as spawnProcess } from 'child_process';
 import { ExitStatus, CreateOSProcess, stringifyExitStatus } from './api';
 
@@ -65,12 +65,12 @@ export const createPosixProcess: CreateOSProcess = (scope, command, options) => 
     try {
       childProcess.on('error', onError);
 
-      task.spawn(on<[string]>(childProcess.stdout, 'data').forEach(([data]) => {
+      task.spawn(on<string>(childProcess.stdout, 'data').forEach((data) => {
         addToTail(data);
         stdout.send(data);
       }));
 
-      task.spawn(on<[string]>(childProcess.stderr, 'data').forEach(([data]) => {
+      task.spawn(on<string>(childProcess.stderr, 'data').forEach((data) => {
         addToTail(data);
         stderr.send(data);
       }));
@@ -79,7 +79,7 @@ export const createPosixProcess: CreateOSProcess = (scope, command, options) => 
         childProcess.stdin.write(data);
       }))
 
-      let value = yield once(childProcess, 'exit')
+      let value = yield onceEmit(childProcess, 'exit')
       getResult.resolve({ type: 'status', value });
 
     } finally {

--- a/packages/node/src/exec/win32.ts
+++ b/packages/node/src/exec/win32.ts
@@ -1,7 +1,7 @@
 import { platform } from "os";
 import { Operation, Deferred } from "@effection/core";
 import { createChannel } from "@effection/channel";
-import { on, once } from "@effection/events";
+import { on, onceEmit } from "@effection/events";
 import { spawn as spawnProcess } from "cross-spawn";
 import { ctrlc } from "ctrlc-windows";
 import { ExitStatus, CreateOSProcess, stringifyExitStatus } from "./api";
@@ -75,14 +75,14 @@ export const createWin32Process: CreateOSProcess = (scope, command, options) => 
       childProcess.on("error", onError);
 
       task.spawn(
-        on<[string]>(childProcess.stdout, "data").forEach(([data]) => {
+        on<string>(childProcess.stdout, "data").forEach((data) => {
           addToTail(data);
           stdout.send(data);
         })
       );
 
       task.spawn(
-        on<[string]>(childProcess.stderr, "data").forEach(([data]) => {
+        on<string>(childProcess.stderr, "data").forEach((data) => {
           addToTail(data);
           stderr.send(data);
         })
@@ -94,7 +94,7 @@ export const createWin32Process: CreateOSProcess = (scope, command, options) => 
         })
       );
 
-      let value = yield once(childProcess, "exit");
+      let value = yield onceEmit(childProcess, "exit");
       getResult.resolve({ type: "status", value });
     } finally {
       stdout.close();

--- a/packages/node/test/exec.test.ts
+++ b/packages/node/test/exec.test.ts
@@ -2,8 +2,6 @@ import { describe, it, beforeEach } from '@effection/mocha';
 import * as expect from 'expect';
 import fetch from 'node-fetch';
 
-import { subscribe } from '@effection/subscription';
-
 import { converge } from './helpers';
 
 import { exec, Process } from '../src';


### PR DESCRIPTION
## Motivation

99.9% of the time when you use the `once()` method, or the `on()` method, you're just looking to get the first argument passed to the `EventEmitter#emit()` method. This is because 99.9% of the time, there is only ever one argument. That means that almost everywhere in our codebase, you see something like:

```ts
on<string[]>(source, 'data').map(function*([chunk]) { return chunk }).forEach(...)`
````

or

```ts
let [event]: [Event] = yield once(source, 'event');
```

This current API requires insta-cruft be attached to  almost every single usage.

## Approach

This changes the `on()` stream and `once()` operation to only work on the first argument to `EventEmitter#emit()` which makes the mapping functions that appear everywhere and the de-structuring syntax that appears alongside every usage unnecessary. So the above examples become:

```ts
on<string>(source, 'data').forEach(...)`
````

and

```ts
let event: Event = yield once(source, 'event');
```

Not only is it less code, the type parameters are far less confusing.

For those cases where you do actually need the arguments (I actually can't think of any). There is the `onceEmit()` and `onEmit()`operations which behave the same as before.