### PR TITLE
Add `buffer` method to Stream

### DIFF
--- a/.changeset/warm-emus-flow.md
+++ b/.changeset/warm-emus-flow.md
@@ -1,0 +1,6 @@
+---
+"@effection/subscription": minor
+"effection": minor
+---
+
+Add a `buffer` method on Stream to buffer stream contents for later replay


### PR DESCRIPTION
This method can be used to buffer a stream and returns a new stream which replays all messages from the point in time that the stream was created. This is useful for ensuring that messages are not missed if the moment of subscription is not tightly controller. In BigTest we're aiming to replace the mailbox pattern used in the result aggregator with this.