### PR TITLE
Add `stringBuffer` method to `Stream`

### DIFF
--- a/.changeset/two-bees-sort.md
+++ b/.changeset/two-bees-sort.md
@@ -1,0 +1,6 @@
+---
+"@effection/subscription": minor
+"effection": minor
+---
+
+Add `stringBuffer` method to stream which buffers stream to a string

--- a/packages/subscription/src/index.ts
+++ b/packages/subscription/src/index.ts
@@ -3,5 +3,5 @@ export { SymbolOperationIterable } from './symbol-operation-iterable';
 export { OperationIterable } from './operation-iterable';
 export { OperationIterator } from './operation-iterator';
 export { Subscription } from './subscription';
-export { createStream, Stream } from './stream';
+export { createStream, Stream, StringBufferStream } from './stream';
 export { subscribe } from './subscribe';

--- a/packages/subscription/src/stream.ts
+++ b/packages/subscription/src/stream.ts
@@ -18,6 +18,7 @@ export interface Stream<T, TReturn = undefined> extends OperationIterable<T, TRe
   toArray(): Operation<T[]>;
   subscribe(scope: Task): OperationIterator<T, TReturn>;
   buffer(scope: Task): Stream<T, TReturn>;
+  stringBuffer(scope: Task): Stream<string, TReturn>;
 }
 
 export function createStream<T, TReturn = undefined>(callback: Callback<T, TReturn>): Stream<T, TReturn> {
@@ -116,6 +117,21 @@ export function createStream<T, TReturn = undefined>(callback: Callback<T, TRetu
       return createStream((publish) => function*() {
         buffer.forEach(publish);
         return yield subscribable.forEach(publish);
+      });
+    },
+
+    stringBuffer(scope: Task): Stream<string, TReturn> {
+      let buffer = "";
+
+      scope.spawn(subscribable.forEach((m) => { buffer += `${m}` }));
+
+      return createStream((publish) => function*() {
+        let internalBuffer = buffer;
+        publish(internalBuffer);
+        return yield subscribable.forEach((m: T) => {
+          internalBuffer += `${m}`;
+          publish(internalBuffer);
+        });
       });
     },
 


### PR DESCRIPTION
Depends on #254 

This method retains a string which concatenates all previously emitted values to each other. This should normally be used on streams of strings or node buffers, however we cannot constrain this method to only work on these types (unless we make it a free function instead). This type of stream is useful for use with node io streams, to aggregate their results in memory. We will be able to use this with the io streams in `@effection/node` to make working with them far easier.