### PR TITLE
Buffered stream for node processes

### DIFF
--- a/.changeset/two-bees-sort.md
+++ b/.changeset/two-bees-sort.md
@@ -1,0 +1,6 @@
+---
+"@effection/subscription": minor
+"effection": minor
+---
+
+Add `stringBuffer` method to stream which buffers stream to a string

--- a/packages/subscription/src/index.ts
+++ b/packages/subscription/src/index.ts
@@ -3,5 +3,5 @@ export { SymbolOperationIterable } from './symbol-operation-iterable';
 export { OperationIterable } from './operation-iterable';
 export { OperationIterator } from './operation-iterator';
 export { Subscription } from './subscription';
-export { createStream, Stream } from './stream';
+export { createStream, Stream, StringBufferStream } from './stream';
 export { subscribe } from './subscribe';

--- a/packages/subscription/test/stream.test.ts
+++ b/packages/subscription/test/stream.test.ts
@@ -153,4 +153,33 @@ describe('chaining subscribable', () => {
       expect(yield iterator.next()).toEqual({ done: false, value: 'blah' });
     });
   });
+
+  describe('stringBuffer', () => {
+    it('concatenates previous messages with each other', function*(world) {
+      let emitter = new EventEmitter();
+      let stream = createStream<string>((publish) => function*() {
+        try {
+          emitter.on('message', publish);
+          yield;
+        } finally {
+          emitter.off('message', publish);
+        }
+        return undefined;
+      });
+
+      emitter.emit('message', 'ignored');
+
+      let bufferedStream = stream.stringBuffer(world);
+
+      emitter.emit('message', 'hello');
+      emitter.emit('message', 'world');
+
+      let iterator = bufferedStream.subscribe(world);
+
+      emitter.emit('message', 'blah');
+
+      expect(yield iterator.next()).toEqual({ done: false, value: 'helloworld' });
+      expect(yield iterator.next()).toEqual({ done: false, value: 'helloworldblah' });
+    });
+  });
 });


### PR DESCRIPTION
This makes use of #255 to add the option of buffering the output streams of processes. This makes it easy to keep an in-memory buffer of the output of the process.

Currently this value can only be accessed as a stream, this works since subscribing to the string buffer stream always immediately publishes the current value, but it would be more elegant if we could access the output directly.

This works by making `stdout` and `stderr` both a `Stream<string>`. If it is buffered it will stream the full value of the output since the process was started. If it is unbuffered it will streams the chunks of data received.