### PR TITLE
Publish with beta tag for v2 releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,21 +1,21 @@
-# name: Release
+name: Release
 
-# on:
-#   push:
-#     branches:
-#       - 'v[0-9]+'
+on:
+  push:
+    branches:
+      - 'v[0-9]+'
 
-# jobs:
-#   publish-releases:
-#     name: Publish Releases
-#     runs-on: ubuntu-latest
-#     steps:
-#     - uses: actions/checkout@v1
-#     - name: Publish Releases
-#       uses: thefrontside/actions/synchronize-with-npm@v1.7
-#       with:
-#         before_all: yarn prepack
-#         npm_publish: yarn publish
-#       env:
-#         GITHUB_TOKEN: ${{ secrets.FRONTSIDEJACK_GITHUB_TOKEN }}
-#         NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+jobs:
+  publish-releases:
+    name: Publish Releases
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Publish Releases
+      uses: thefrontside/actions/synchronize-with-npm@v1.7
+      with:
+        before_all: yarn prepack
+        npm_publish: yarn publish --tag v2-beta
+      env:
+        GITHUB_TOKEN: ${{ secrets.FRONTSIDEJACK_GITHUB_TOKEN }}
+        NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,21 +1,21 @@
-name: Release
+# name: Release
 
-on:
-  push:
-    branches:
-      - 'v[0-9]+'
+# on:
+#   push:
+#     branches:
+#       - 'v[0-9]+'
 
-jobs:
-  publish-releases:
-    name: Publish Releases
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v1
-    - name: Publish Releases
-      uses: thefrontside/actions/synchronize-with-npm@v1.7
-      with:
-        before_all: yarn prepack
-        npm_publish: yarn publish
-      env:
-        GITHUB_TOKEN: ${{ secrets.FRONTSIDEJACK_GITHUB_TOKEN }}
-        NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+# jobs:
+#   publish-releases:
+#     name: Publish Releases
+#     runs-on: ubuntu-latest
+#     steps:
+#     - uses: actions/checkout@v1
+#     - name: Publish Releases
+#       uses: thefrontside/actions/synchronize-with-npm@v1.7
+#       with:
+#         before_all: yarn prepack
+#         npm_publish: yarn publish
+#       env:
+#         GITHUB_TOKEN: ${{ secrets.FRONTSIDEJACK_GITHUB_TOKEN }}
+#         NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}


### PR DESCRIPTION
## Motivation

v2 changes are being published with the latest tag so anyone that adds effection to their package will get v2 unless they specify otherwise.

## Approach

- ~Disabled release workflow for v2 by commenting out the whole workflow~
- Specify `yarn publish --tag v2-beta` command for the release workflow.

## TODOs

- [x] ~We need to do a release of v1 to take back the latest tag.~ Push the latest tags on all of the current versions of v1 effection packages.
  - [x] @effection/channel @ 1.0.0
  - [x] effection @ 1.0.0
  - [x] @effection/events @ 1.0.0
  - [x] @effection/fetch @ 1.0.0
  - [x] @effection/node @ 1.0.1
  - [x] @effection/subscription @ 1.0.0