### PR TITLE
Disable command parsing when exec({ shell: true })

### DIFF
--- a/.changeset/lucky-snails-worry.md
+++ b/.changeset/lucky-snails-worry.md
@@ -1,0 +1,4 @@
+---
+"@effection/node": patch
+---
+Disable command parsing when exec({ shell: true }). This allows complex commands that involve pipes and redirects to work

--- a/packages/node/src/exec.ts
+++ b/packages/node/src/exec.ts
@@ -30,7 +30,7 @@ const createProcess: CreateOSProcess = (cmd, opts) => {
  * forever, consider using `daemon()`
  */
 export function exec(command: string, options: ExecOptions = {}): Exec {
-  let [cmd, ...args] = split(command);
+  let [cmd, ...args] = options.shell ? [command]: split(command);
   let opts = { ...options, arguments: args.concat(options.arguments || []) }
 
   return {

--- a/packages/node/test/exec.test.ts
+++ b/packages/node/test/exec.test.ts
@@ -156,4 +156,32 @@ describe('exec', () => {
       });
     });
   });
+
+  // running shell scripts in windows is not well supported, our windows
+  // process stuff sets shell to `false` and so you probably shouldn't do this
+  // in windows at all.
+  if (process.platform !== 'win32') {
+    describe('when the `shell` option is true', () => {
+      it('lets the shell do all of the shellword parsing', function*() {
+        let proc = exec('echo "first" | echo "second"', {
+          shell: true
+        });
+        let { stdout }: ProcessResult = yield proc.expect();
+
+        expect(stdout).toEqual("second\n");
+      })
+    });
+  }
+
+  describe('when the `shell` option is `false`', () => {
+    it('automatically parses the command argumens using shellwords', function*() {
+      let proc = exec('echo "first" | echo "second"', {
+        shell: false
+      });
+      let { stdout }: ProcessResult = yield proc.expect();
+
+      expect(stdout).toEqual("first | echo second\n");
+    })
+  });
+
 });


### PR DESCRIPTION
Motivation
-----------

> resolves #266

The current strategy of using `shellwords` to parse command and arguments works for single commands. However, for complex commands that do piping and IO redirection, it does not work. But it is precisely for this case that the `shell: true` option exists.

Approach
----------

In the event that `shell: true` is set, we do no parsing at all and just pass the command wholesale down to let the shell do its own parsing.