### PR TITLE
New, more ergonomic `exec` API

### DIFF
--- a/.changeset/rude-cooks-shave.md
+++ b/.changeset/rude-cooks-shave.md
@@ -1,0 +1,6 @@
+---
+"@effection/node": minor
+"effection": minor
+---
+
+New API for exec and daemon which does not take scope directly

--- a/packages/node/src/daemon.ts
+++ b/packages/node/src/daemon.ts
@@ -1,6 +1,6 @@
 import { Task } from '@effection/core';
 
-import { exec, Process, ExecOptions, StdIO, ExitStatus, stringifyExitStatus  } from './exec';
+import { exec, Process, ExecOptions, StdIO, ExitStatus, DaemonExitError } from './exec';
 
 /**
  * Start a long-running process, like a web server that run perpetually.
@@ -14,11 +14,7 @@ export function daemon(scope: Task, command: string, options: ExecOptions = {}):
   scope.spawn(function*() {
     let status: ExitStatus = yield process.join();
 
-    let error = new Error(`daemon process quit unexpectedly\n${stringifyExitStatus(status)}`);
-
-    error.name = 'DaemonExitError';
-
-    throw error;
+    throw new DaemonExitError(status, command, options);
   });
 
   return process;

--- a/packages/node/src/exec.ts
+++ b/packages/node/src/exec.ts
@@ -7,6 +7,7 @@ import { createPosixProcess } from './exec/posix';
 import { createWin32Process, isWin32 } from './exec/win32';
 
 export * from './exec/api';
+export * from './exec/error';
 
 /**
  * Execute `command` with `options`. You should use this operation for processes

--- a/packages/node/src/exec.ts
+++ b/packages/node/src/exec.ts
@@ -15,11 +15,11 @@ export interface Exec {
   expect(): Operation<ProcessResult>;
 }
 
-const createProcess: CreateOSProcess = (scope, cmd, opts) => {
+const createProcess: CreateOSProcess = (cmd, opts) => {
   if (isWin32()) {
-    return createWin32Process(scope, cmd, opts);
+    return createWin32Process(cmd, opts);
   } else {
-    return createPosixProcess(scope, cmd, opts);
+    return createPosixProcess(cmd, opts);
   }
 };
 
@@ -35,11 +35,11 @@ export function exec(command: string, options: ExecOptions = {}): Exec {
 
   return {
     run(scope: Task) {
-      return createProcess(scope, cmd, opts);
+      return createProcess(cmd, opts).run(scope);
     },
     join() {
       return function*(scope: Task) {
-        let process = createProcess(scope, cmd, { ...opts, buffered: true });
+        let process = createProcess(cmd, { ...opts, buffered: true }).run(scope);
 
         let status = yield process.join();
         let stdout = yield process.stdout.expect();
@@ -50,7 +50,7 @@ export function exec(command: string, options: ExecOptions = {}): Exec {
     },
     expect() {
       return function*(scope: Task) {
-        let process = createProcess(scope, cmd, { ...opts, buffered: true });
+        let process = createProcess(cmd, { ...opts, buffered: true }).run(scope);
 
         let status = yield process.expect();
         let stdout = yield process.stdout.expect();

--- a/packages/node/src/exec.ts
+++ b/packages/node/src/exec.ts
@@ -1,13 +1,27 @@
 /// <reference types="../types/shellwords" />
 import { split } from 'shellwords';
 
-import { Task } from '@effection/core';
-import { ExecOptions, Process, } from './exec/api';
+import { Task, Operation } from '@effection/core';
+import { ExecOptions, Process, ProcessResult, CreateOSProcess } from './exec/api';
 import { createPosixProcess } from './exec/posix';
 import { createWin32Process, isWin32 } from './exec/win32';
 
 export * from './exec/api';
 export * from './exec/error';
+
+export interface Exec {
+  run(scope: Task): Process;
+  join(): Operation<ProcessResult>;
+  expect(): Operation<ProcessResult>;
+}
+
+const createProcess: CreateOSProcess = (scope, cmd, opts) => {
+  if (isWin32()) {
+    return createWin32Process(scope, cmd, opts);
+  } else {
+    return createPosixProcess(scope, cmd, opts);
+  }
+};
 
 /**
  * Execute `command` with `options`. You should use this operation for processes
@@ -15,13 +29,35 @@ export * from './exec/error';
  * exit status. If you want to start a process like a server that spins up and runs
  * forever, consider using `daemon()`
  */
-export function exec(scope: Task, command: string, options: ExecOptions = {}): Process {
+export function exec(command: string, options: ExecOptions = {}): Exec {
   let [cmd, ...args] = split(command);
   let opts = { ...options, arguments: args.concat(options.arguments || []) }
 
-  if (isWin32()) {
-    return createWin32Process(scope, cmd, opts);
-  } else {
-    return createPosixProcess(scope, cmd, opts);
+  return {
+    run(scope: Task) {
+      return createProcess(scope, cmd, opts);
+    },
+    join() {
+      return function*(scope: Task) {
+        let process = createProcess(scope, cmd, { ...opts, buffered: true });
+
+        let status = yield process.join();
+        let stdout = yield process.stdout.expect();
+        let stderr = yield process.stderr.expect();
+
+        return { ...status, stdout, stderr };
+      };
+    },
+    expect() {
+      return function*(scope: Task) {
+        let process = createProcess(scope, cmd, { ...opts, buffered: true });
+
+        let status = yield process.expect();
+        let stdout = yield process.stdout.expect();
+        let stderr = yield process.stderr.expect();
+
+        return { ...status, stdout, stderr };
+      };
+    }
   }
 }

--- a/packages/node/src/exec/api.ts
+++ b/packages/node/src/exec/api.ts
@@ -81,6 +81,10 @@ export interface ProcessResult extends ExitStatus {
   stderr: string;
 }
 
+export interface OSProcess {
+  run(scope: Task): Process;
+}
+
 export interface CreateOSProcess {
-  (scope: Task, command: string, options: ExecOptions): Process;
+  (command: string, options: ExecOptions): OSProcess;
 }

--- a/packages/node/src/exec/api.ts
+++ b/packages/node/src/exec/api.ts
@@ -74,38 +74,9 @@ export interface ExitStatus {
    * is recorded here.
    */
   signal?: string;
-
-  /**
-   * The original command used to create the process
-   */
-  command: string;
-
-  /**
-   * The original options used to create the process.
-   */
-  options: ExecOptions;
 }
 
 
 export interface CreateOSProcess {
   (scope: Task, command: string, options: ExecOptions): Process;
-}
-
-
-export function stringifyExitStatus(status: ExitStatus) {
-  let { options } = status;
-
-  let code = status.code ? `code: ${status.code}`: null;
-
-  let signal = status.signal ? `signal: ${status.signal}` : null;
-
-  let env = `env: ${JSON.stringify(options.env || {})}`;
-
-  let shell = options.shell ? `shell: ${options.shell}` : null;
-
-  let cwd = options.cwd ? `cwd: ${options.cwd}` : null;
-
-  let command = `$ ${status.command} ${options.arguments?.join(" ")}`.trim()
-
-  return [code, signal, env, shell, cwd, command].filter(item => !!item).join("\n");
 }

--- a/packages/node/src/exec/api.ts
+++ b/packages/node/src/exec/api.ts
@@ -1,5 +1,10 @@
 import { Task, Operation } from '@effection/core';
-import { Channel } from '@effection/channel';
+import { Stream } from '@effection/subscription';
+
+// TODO: import from subscription package once #236 is merged
+export interface Writable<T> {
+  send(message: T): void;
+}
 
 /**
  * The process type is what is returned by the `exec` operation. It has all of
@@ -44,12 +49,17 @@ export interface ExecOptions {
    * Sets the working directory of the process
    */
   cwd?: string;
+
+  /**
+   * Skip buffering of output streams
+   */
+  unbuffered?: boolean
 }
 
 export interface StdIO {
-  stdout: Channel<string>;
-  stderr: Channel<string>;
-  stdin: Channel<string>;
+  stdout: Stream<string>;
+  stderr: Stream<string>;
+  stdin: Writable<string>;
 }
 
 export interface ExitStatus {
@@ -64,12 +74,6 @@ export interface ExitStatus {
    * is recorded here.
    */
   signal?: string;
-
-  /**
-   * A buffer of the recent output from both `stdout` and `stderr` that can
-   * be helpful for debugging
-   */
-  tail: string[];
 
   /**
    * The original command used to create the process
@@ -103,7 +107,5 @@ export function stringifyExitStatus(status: ExitStatus) {
 
   let command = `$ ${status.command} ${options.arguments?.join(" ")}`.trim()
 
-  let tail = status.tail.join("");
-
-  return [code, signal, env, shell, cwd, command, tail].filter(item => !!item).join("\n");
+  return [code, signal, env, shell, cwd, command].filter(item => !!item).join("\n");
 }

--- a/packages/node/src/exec/api.ts
+++ b/packages/node/src/exec/api.ts
@@ -76,6 +76,10 @@ export interface ExitStatus {
   signal?: string;
 }
 
+export interface ProcessResult extends ExitStatus {
+  stdout: string;
+  stderr: string;
+}
 
 export interface CreateOSProcess {
   (scope: Task, command: string, options: ExecOptions): Process;

--- a/packages/node/src/exec/api.ts
+++ b/packages/node/src/exec/api.ts
@@ -53,7 +53,7 @@ export interface ExecOptions {
   /**
    * Skip buffering of output streams
    */
-  unbuffered?: boolean
+  buffered?: boolean;
 }
 
 export interface StdIO {

--- a/packages/node/src/exec/error.ts
+++ b/packages/node/src/exec/error.ts
@@ -1,0 +1,33 @@
+import { ExitStatus, ExecOptions } from './api';
+
+export class ExecError extends Error {
+  constructor(public status: ExitStatus, public command: string, public options: ExecOptions) {
+    super();
+  }
+
+  name = "ExecError";
+
+  get message(): string {
+    let code = this.status.code ? `code: ${this.status.code}`: null;
+
+    let signal = this.status.signal ? `signal: ${this.status.signal}` : null;
+
+    let env = `env: ${JSON.stringify(this.options.env || {})}`;
+
+    let shell = this.options.shell ? `shell: ${this.options.shell}` : null;
+
+    let cwd = this.options.cwd ? `cwd: ${this.options.cwd}` : null;
+
+    let command = `$ ${this.command} ${this.options.arguments?.join(" ")}`.trim()
+
+    return [code, signal, env, shell, cwd, command].filter(item => !!item).join("\n");
+  }
+}
+
+export class DaemonExitError extends ExecError {
+  name = "DaemonExitError";
+
+  get message(): string {
+    return `daemon process quit unexpectedly\n${super.message}`;
+  }
+}

--- a/packages/node/src/exec/posix.ts
+++ b/packages/node/src/exec/posix.ts
@@ -7,85 +7,89 @@ import { ExecError } from './error';
 
 type Result = { type: 'error'; value: unknown } | { type: 'status'; value: [number?, string?] };
 
-export const createPosixProcess: CreateOSProcess = (scope, command, options) => {
-  let getResult = Deferred<Result>();
+export const createPosixProcess: CreateOSProcess = (command, options) => {
+  return {
+    run(scope) {
+      let getResult = Deferred<Result>();
 
-  let join = (): Operation<ExitStatus> => function*() {
-    let result: Result = yield getResult.promise;
-    if (result.type === 'status') {
-      let [code, signal] = result.value;
-      return { command, options, code, signal };
-    } else {
-      throw result.value;
-    }
-  }
-
-  let expect = (): Operation<ExitStatus> => function*() {
-    let status: ExitStatus = yield join();
-    if (status.code != 0) {
-      throw new ExecError(status, command, options)
-    } else {
-      return status;
-    }
-  }
-  // Killing all child processes started by this command is surprisingly
-  // tricky. If a process spawns another processes and we kill the parent,
-  // then the child process is NOT automatically killed. Instead we're using
-  // the `detached` option to force the child into its own process group,
-  // which all of its children in turn will inherit. By sending the signal to
-  // `-pid` rather than `pid`, we are sending it to the entire process group
-  // instead. This will send the signal to all processes started by the child
-  // process.
-  //
-  // More information here: https://unix.stackexchange.com/questions/14815/process-descendants
-  let childProcess = spawnProcess(command, options.arguments || [], {
-    detached: true,
-    shell: options.shell,
-    env: options.env,
-    cwd: options.cwd
-  });
-
-  let { pid } = childProcess;
-
-  let stdoutChannel = createChannel<string>();
-  let stderrChannel = createChannel<string>();
-
-  let stdin: Writable<string> = {
-    send(data: string) {
-      childProcess.stdin.write(data);
-    }
-  };
-
-  scope.spawn(function*(task) {
-    task.spawn(function*() {
-      let value: Error = yield once(childProcess, 'error');
-      getResult.resolve({ type: 'error', value });
-    });
-
-    task.spawn(on<Buffer>(childProcess.stdout, 'data').map((c) => c.toString()).forEach(stdoutChannel.send));
-    task.spawn(on<Buffer>(childProcess.stderr, 'data').map((c) => c.toString()).forEach(stderrChannel.send));
-
-    try {
-      let value = yield onceEmit(childProcess, 'exit');
-      getResult.resolve({ type: 'status', value });
-    } finally {
-      stdoutChannel.close();
-      stderrChannel.close();
-      try {
-        process.kill(-childProcess.pid, "SIGTERM")
-      } catch(e) {
-        // do nothing, process is probably already dead
+      let join = (): Operation<ExitStatus> => function*() {
+        let result: Result = yield getResult.promise;
+        if (result.type === 'status') {
+          let [code, signal] = result.value;
+          return { command, options, code, signal };
+        } else {
+          throw result.value;
+        }
       }
+
+      let expect = (): Operation<ExitStatus> => function*() {
+        let status: ExitStatus = yield join();
+        if (status.code != 0) {
+          throw new ExecError(status, command, options)
+        } else {
+          return status;
+        }
+      }
+      // Killing all child processes started by this command is surprisingly
+      // tricky. If a process spawns another processes and we kill the parent,
+      // then the child process is NOT automatically killed. Instead we're using
+      // the `detached` option to force the child into its own process group,
+      // which all of its children in turn will inherit. By sending the signal to
+      // `-pid` rather than `pid`, we are sending it to the entire process group
+      // instead. This will send the signal to all processes started by the child
+      // process.
+      //
+      // More information here: https://unix.stackexchange.com/questions/14815/process-descendants
+      let childProcess = spawnProcess(command, options.arguments || [], {
+        detached: true,
+        shell: options.shell,
+        env: options.env,
+        cwd: options.cwd
+      });
+
+      let { pid } = childProcess;
+
+      let stdoutChannel = createChannel<string>();
+      let stderrChannel = createChannel<string>();
+
+      let stdin: Writable<string> = {
+        send(data: string) {
+          childProcess.stdin.write(data);
+        }
+      };
+
+      scope.spawn(function*(task) {
+        task.spawn(function*() {
+          let value: Error = yield once(childProcess, 'error');
+          getResult.resolve({ type: 'error', value });
+        });
+
+        task.spawn(on<Buffer>(childProcess.stdout, 'data').map((c) => c.toString()).forEach(stdoutChannel.send));
+        task.spawn(on<Buffer>(childProcess.stderr, 'data').map((c) => c.toString()).forEach(stderrChannel.send));
+
+        try {
+          let value = yield onceEmit(childProcess, 'exit');
+          getResult.resolve({ type: 'status', value });
+        } finally {
+          stdoutChannel.close();
+          stderrChannel.close();
+          try {
+            process.kill(-childProcess.pid, "SIGTERM")
+          } catch(e) {
+            // do nothing, process is probably already dead
+          }
+        }
+      });
+
+      let { stream: stdout } = stdoutChannel;
+      let { stream: stderr } = stderrChannel;
+
+      if(options.buffered) {
+        stdout = stdout.stringBuffer(scope);
+        stderr = stderr.stringBuffer(scope);
+      }
+
+      return { pid, stdin, stdout, stderr, join, expect }
     }
-  });
-
-  let { stream: stdout } = stdoutChannel;
-  let { stream: stderr } = stderrChannel;
-
-  if(options.buffered) {
-    stdout = stdout.stringBuffer(scope);
-    stderr = stderr.stringBuffer(scope);
   }
-
-  return { pid, stdin, stdout, stderr, join, expect }
 }

--- a/packages/node/src/exec/posix.ts
+++ b/packages/node/src/exec/posix.ts
@@ -2,7 +2,8 @@ import { Operation, Deferred } from '@effection/core';
 import { createChannel } from '@effection/channel';
 import { on, once, onceEmit } from '@effection/events';
 import { spawn as spawnProcess } from 'child_process';
-import { Writable, ExitStatus, CreateOSProcess, stringifyExitStatus } from './api';
+import { Writable, ExitStatus, CreateOSProcess } from './api';
+import { ExecError } from './error';
 
 type Result = { type: 'error'; value: unknown } | { type: 'status'; value: [number?, string?] };
 
@@ -22,9 +23,7 @@ export const createPosixProcess: CreateOSProcess = (scope, command, options) => 
   let expect = (): Operation<ExitStatus> => function*() {
     let status: ExitStatus = yield join();
     if (status.code != 0) {
-      let error = new Error(stringifyExitStatus(status))
-      error.name = `ExecError`;
-      throw error;
+      throw new ExecError(status, command, options)
     } else {
       return status;
     }

--- a/packages/node/src/exec/posix.ts
+++ b/packages/node/src/exec/posix.ts
@@ -1,5 +1,4 @@
 import { Operation, Deferred } from '@effection/core';
-import { Stream } from '@effection/subscription';
 import { createChannel } from '@effection/channel';
 import { on, once, onceEmit } from '@effection/events';
 import { spawn as spawnProcess } from 'child_process';
@@ -84,7 +83,7 @@ export const createPosixProcess: CreateOSProcess = (scope, command, options) => 
   let { stream: stdout } = stdoutChannel;
   let { stream: stderr } = stderrChannel;
 
-  if(!options.unbuffered) {
+  if(options.buffered) {
     stdout = stdout.stringBuffer(scope);
     stderr = stderr.stringBuffer(scope);
   }

--- a/packages/node/src/exec/win32.ts
+++ b/packages/node/src/exec/win32.ts
@@ -96,7 +96,7 @@ export const createWin32Process: CreateOSProcess = (scope, command, options) => 
   let { stream: stdout } = stdoutChannel;
   let { stream: stderr } = stderrChannel;
 
-  if(!options.unbuffered) {
+  if(options.buffered) {
     stdout = stdout.stringBuffer(scope);
     stderr = stderr.stringBuffer(scope);
   }

--- a/packages/node/src/exec/win32.ts
+++ b/packages/node/src/exec/win32.ts
@@ -4,7 +4,8 @@ import { createChannel } from '@effection/channel';
 import { on, once, onceEmit } from "@effection/events";
 import { spawn as spawnProcess } from "cross-spawn";
 import { ctrlc } from "ctrlc-windows";
-import { ExitStatus, CreateOSProcess, stringifyExitStatus } from "./api";
+import { ExitStatus, CreateOSProcess } from "./api";
+import { ExecError } from "./error";
 
 type Result =
   | { type: "error"; value: unknown }
@@ -26,9 +27,7 @@ export const createWin32Process: CreateOSProcess = (scope, command, options) => 
   let expect = (): Operation<ExitStatus> => function*() {
     let status: ExitStatus = yield join();
     if (status.code != 0) {
-      let error = new Error(stringifyExitStatus(status));
-      error.name = `ExecError`;
-      throw error;
+      throw new ExecError(status, command, options);
     } else {
       return status;
     }

--- a/packages/node/src/exec/win32.ts
+++ b/packages/node/src/exec/win32.ts
@@ -11,96 +11,100 @@ type Result =
   | { type: "error"; value: unknown }
   | { type: "status"; value: [number?, string?] };
 
-export const createWin32Process: CreateOSProcess = (scope, command, options) => {
-  let getResult = Deferred<Result>();
+export const createWin32Process: CreateOSProcess = (command, options) => {
+  return {
+    run(scope) {
+      let getResult = Deferred<Result>();
 
-  let join = (): Operation<ExitStatus> => function*() {
-    let result: Result = yield getResult.promise;
-    if (result.type === "status") {
-      let [code, signal] = result.value;
-      return { command, options, code, signal };
-    } else {
-      throw result.value;
-    }
-  }
-
-  let expect = (): Operation<ExitStatus> => function*() {
-    let status: ExitStatus = yield join();
-    if (status.code != 0) {
-      throw new ExecError(status, command, options);
-    } else {
-      return status;
-    }
-  }
-
-  let childProcess = spawnProcess(command, options.arguments || [], {
-    // We lose exit information and events if this is detached in windows
-    // and it opens a window in windows+powershell.
-    detached: false,
-    // When windows shell is true, it runs with cmd.exe by default, but
-    // node has trouble with PATHEXT and exe. It can't run exe directly for example.
-    // `cross-spawn` handles running it with the shell in windows if needed.
-    // Neither mac nor linux need shell and we run it detached.
-    shell: false,
-    // With stdio as pipe, windows gets stuck where neither the child nor the
-    // parent wants to close the stream, so we call it ourselves in the exit event.
-    stdio: "pipe",
-    // Hide the child window so that killing it will not block the parent
-    // with a Terminate Batch Process (Y/n)
-    windowsHide: true,
-
-    env: options.env,
-    cwd: options.cwd,
-  });
-
-  let { pid } = childProcess;
-
-  let stdoutChannel = createChannel<string>();
-  let stderrChannel = createChannel<string>();
-  let stdin = {
-    send(data: string) {
-      childProcess.stdin.write(data);
-    }
-  };
-
-  scope.spawn(function*(task) {
-    task.spawn(function*() {
-      let value: Error = yield once(childProcess, 'error');
-      getResult.resolve({ type: 'error', value });
-    });
-
-    task.spawn(on<Buffer>(childProcess.stdout, 'data').map((c) => c.toString()).forEach(stdoutChannel.send));
-    task.spawn(on<Buffer>(childProcess.stderr, 'data').map((c) => c.toString()).forEach(stderrChannel.send));
-
-    try {
-      let value = yield onceEmit(childProcess, "exit");
-      getResult.resolve({ type: "status", value });
-    } finally {
-      stdoutChannel.close();
-      stderrChannel.close();
-      if (pid) {
-        ctrlc(pid);
-        let stdin = childProcess.stdin;
-        if (stdin.writable) {
-          try {
-            //Terminate batch process (Y/N)
-            stdin.write("Y\n");
-          } catch (_err) { /* not much we can do here */}
+      let join = (): Operation<ExitStatus> => function*() {
+        let result: Result = yield getResult.promise;
+        if (result.type === "status") {
+          let [code, signal] = result.value;
+          return { command, options, code, signal };
+        } else {
+          throw result.value;
         }
-        stdin.end();
       }
+
+      let expect = (): Operation<ExitStatus> => function*() {
+        let status: ExitStatus = yield join();
+        if (status.code != 0) {
+          throw new ExecError(status, command, options);
+        } else {
+          return status;
+        }
+      }
+
+      let childProcess = spawnProcess(command, options.arguments || [], {
+        // We lose exit information and events if this is detached in windows
+        // and it opens a window in windows+powershell.
+        detached: false,
+        // When windows shell is true, it runs with cmd.exe by default, but
+        // node has trouble with PATHEXT and exe. It can't run exe directly for example.
+        // `cross-spawn` handles running it with the shell in windows if needed.
+        // Neither mac nor linux need shell and we run it detached.
+        shell: false,
+        // With stdio as pipe, windows gets stuck where neither the child nor the
+        // parent wants to close the stream, so we call it ourselves in the exit event.
+        stdio: "pipe",
+        // Hide the child window so that killing it will not block the parent
+        // with a Terminate Batch Process (Y/n)
+        windowsHide: true,
+
+        env: options.env,
+        cwd: options.cwd,
+      });
+
+      let { pid } = childProcess;
+
+      let stdoutChannel = createChannel<string>();
+      let stderrChannel = createChannel<string>();
+      let stdin = {
+        send(data: string) {
+          childProcess.stdin.write(data);
+        }
+      };
+
+      scope.spawn(function*(task) {
+        task.spawn(function*() {
+          let value: Error = yield once(childProcess, 'error');
+          getResult.resolve({ type: 'error', value });
+        });
+
+        task.spawn(on<Buffer>(childProcess.stdout, 'data').map((c) => c.toString()).forEach(stdoutChannel.send));
+        task.spawn(on<Buffer>(childProcess.stderr, 'data').map((c) => c.toString()).forEach(stderrChannel.send));
+
+        try {
+          let value = yield onceEmit(childProcess, "exit");
+          getResult.resolve({ type: "status", value });
+        } finally {
+          stdoutChannel.close();
+          stderrChannel.close();
+          if (pid) {
+            ctrlc(pid);
+            let stdin = childProcess.stdin;
+            if (stdin.writable) {
+              try {
+                //Terminate batch process (Y/N)
+                stdin.write("Y\n");
+              } catch (_err) { /* not much we can do here */}
+            }
+            stdin.end();
+          }
+        }
+      });
+
+      let { stream: stdout } = stdoutChannel;
+      let { stream: stderr } = stderrChannel;
+
+      if(options.buffered) {
+        stdout = stdout.stringBuffer(scope);
+        stderr = stderr.stringBuffer(scope);
+      }
+
+      return { pid, stdin, stdout, stderr, join, expect };
     }
-  });
-
-  let { stream: stdout } = stdoutChannel;
-  let { stream: stderr } = stderrChannel;
-
-  if(options.buffered) {
-    stdout = stdout.stringBuffer(scope);
-    stderr = stderr.stringBuffer(scope);
   }
-
-  return { pid, stdin, stdout, stderr, join, expect };
 };
 
 export const isWin32 = () => platform() === "win32";

--- a/packages/node/test/daemon.test.ts
+++ b/packages/node/test/daemon.test.ts
@@ -5,23 +5,23 @@ import fetch from 'node-fetch';
 import '@effection/mocha';
 import { run, Task } from '@effection/core';
 
-import { daemon, StdIO } from '../src';
+import { daemon, Process } from '../src';
 
-describe('daemon()', () => {
+describe('daemon', () => {
   let task: Task;
-  let io: StdIO;
+  let proc: Process;
 
   beforeEach(function*() {
     task = run(function*(inner) {
-      io = daemon(inner, 'node', {
+      proc = daemon('node', {
         arguments: ['./fixtures/echo-server.js'],
         env: { PORT: '29000', PATH: process.env.PATH as string },
         cwd: __dirname,
-      });
+      }).run(inner);
       yield
     });
 
-    yield io.stdout.filter((v) => v.includes('listening')).expect();
+    yield proc.stdout.filter((v) => v.includes('listening')).expect();
   });
 
   afterEach(function*() {

--- a/packages/node/test/daemon.test.ts
+++ b/packages/node/test/daemon.test.ts
@@ -5,31 +5,23 @@ import fetch from 'node-fetch';
 import '@effection/mocha';
 import { run, Task } from '@effection/core';
 
-import { converge } from './helpers';
-
 import { daemon, StdIO } from '../src';
 
 describe('daemon()', () => {
-  let output: string;
   let task: Task;
-  let error: Error;
+  let io: StdIO;
 
-  beforeEach(function*(t) {
-    output = '';
-
+  beforeEach(function*() {
     task = run(function*(inner) {
-      let io = daemon(inner, 'node', {
+      io = daemon(inner, 'node', {
         arguments: ['./fixtures/echo-server.js'],
         env: { PORT: '29000', PATH: process.env.PATH as string },
         cwd: __dirname,
       });
-
-      inner.spawn(io.stdout.forEach((chunk) => { output += chunk; }));
-
       yield
     });
 
-    yield converge(() => expect(output).toContain("listening"));
+    yield io.stdout.filter((v) => v.includes('listening')).expect();
   });
 
   afterEach(function*() {

--- a/packages/node/test/exec.test.ts
+++ b/packages/node/test/exec.test.ts
@@ -45,6 +45,7 @@ describe('exec()', () => {
       proc = exec(task, "node './fixtures/echo-server.js'", {
         env: { PORT: '29000', PATH: process.env.PATH as string },
         cwd: __dirname,
+        buffered: true,
       });
 
       task.spawn(function*() {

--- a/packages/node/test/exec.test.ts
+++ b/packages/node/test/exec.test.ts
@@ -1,122 +1,158 @@
-import { Deferred } from '@effection/core';
-import { describe, it, beforeEach } from '@effection/mocha';
+import { describe, it, beforeEach, captureError } from '@effection/mocha';
 import * as expect from 'expect';
+
+import { Deferred } from '@effection/core';
+import { exec, Process, ProcessResult } from '../src';
 import fetch from 'node-fetch';
 
-import { exec, Process } from '../src';
+describe('exec', () => {
+  describe('.join', () => {
+    it('runs successfully to completion', function*() {
+      let result: ProcessResult = yield exec("node './test/fixtures/hello-world.js'").join();
 
-describe('exec()', () => {
-  describe('a process that fails to start', () => {
-    describe('calling join()', () => {
-      it('reports the failed status', function*(task) {
-        let error: unknown;
-        let proc = exec(task, "argle", { arguments: ['bargle'] });
-        try {
-          yield proc.join();
-        } catch(e) {
-          error = e;
-        }
-        expect(error).toBeInstanceOf(Error);
-      });
+      expect(result.code).toEqual(0);
+      expect(result.stdout).toEqual('hello\nworld\n');
+      expect(result.stderr).toEqual('boom\n');
     });
 
-    describe('calling expect()', () => {
-      it('fails', function*(task) {
-        let error: unknown;
-        let proc = exec(task, "argle", { arguments: ['bargle'] });
-        try {
-          yield proc.expect()
-        } catch (e) { error = e; }
+    it('runs failed process to completion', function*() {
+      let result: ProcessResult = yield exec("node './test/fixtures/hello-world-failed.js'").join();
 
-        expect(error).toBeDefined();
-      });
+      expect(result.code).toEqual(37);
+      expect(result.stdout).toEqual('hello world\n');
+      expect(result.stderr).toEqual('boom\n');
     });
   });
 
-  describe('a process that starts successfully', () => {
-    let proc: Process;
-    let didCloseStdout: Deferred<boolean>;
-    let didCloseStderr: Deferred<boolean>;
+  describe('.expect', () => {
+    it('runs successfully to completion', function*() {
+      let result: ProcessResult = yield exec("node './test/fixtures/hello-world.js'").expect();
 
-    beforeEach(function*(task) {
-      didCloseStdout = Deferred<boolean>();
-      didCloseStderr = Deferred<boolean>();
-
-      proc = exec(task, "node './fixtures/echo-server.js'", {
-        env: { PORT: '29000', PATH: process.env.PATH as string },
-        cwd: __dirname,
-        buffered: true,
-      });
-
-      task.spawn(function*() {
-        yield proc.stdout.join();
-        didCloseStdout.resolve(true);
-      });
-
-      task.spawn(function*() {
-        yield proc.stderr.join();
-        didCloseStderr.resolve(true);
-      });
-
-      yield proc.stdout.filter((v) => v.includes('listening')).expect();
+      expect(result.code).toEqual(0);
+      expect(result.stdout).toEqual('hello\nworld\n');
+      expect(result.stderr).toEqual('boom\n');
     });
 
-    it('has a pid', function*() {
-      expect(typeof proc.pid).toBe('number');
-      expect(proc.pid).not.toBeNaN();
+    it('throws an error if process fails', function*() {
+      let error: Error = yield captureError(exec("node './test/fixtures/hello-world-failed.js'").expect());
+
+      expect(error.name).toEqual('ExecError');
     });
+  });
 
-    describe('when it succeeds', () => {
-      beforeEach(function*() {
-        yield fetch('http://localhost:29000', { method: "POST", body: "exit" });
-      });
-
-      it('joins successfully', function*() {
-        let status = yield proc.join();
-        expect(status.code).toEqual(0);
-      });
-
-      it('expects successfully', function*() {
-        let status = yield proc.expect();
-        expect(status.code).toEqual(0);
-      });
-
-      it('closes stdout and stderr', function*() {
-        yield proc.expect();
-        let output = yield proc.stdout.expect();
-        let errput = yield proc.stderr.expect();
-        expect(output).toContain('exit(0)');
-        expect(errput).toContain('got request');
-        expect(yield didCloseStdout.promise).toEqual(true);
-        expect(yield didCloseStderr.promise).toEqual(true);
-      });
-    });
-
-    describe('when it fails', () => {
-      let error: Error
-      beforeEach(function*() {
-        yield fetch('http://localhost:29000', { method: "POST", body: "fail" });
-      });
-
-      it('joins successfully', function*() {
-        let status = yield proc.join();
-        expect(status.code).not.toEqual(0);
-      });
-
-      it('expects unsuccessfully', function*() {
-        yield function* () {
+  describe('.run', () => {
+    describe('a process that fails to start', () => {
+      describe('calling join()', () => {
+        it('reports the failed status', function*(task) {
+          let error: unknown;
+          let proc = exec("argle", { arguments: ['bargle'] }).run(task);
           try {
-            yield proc.expect();
-          } catch (e) {
+            yield proc.join();
+          } catch(e) {
             error = e;
           }
-        };
-        expect(error).toBeDefined()
+          expect(error).toBeInstanceOf(Error);
+        });
       });
 
-      it('closes stdout and stderr', function*() {
-        expect(yield didCloseStdout.promise).toEqual(true);
-        expect(yield didCloseStderr.promise).toEqual(true);
+      describe('calling expect()', () => {
+        it('fails', function*(task) {
+          let error: unknown;
+          let proc = exec("argle", { arguments: ['bargle'] }).run(task);
+          try {
+            yield proc.expect()
+          } catch (e) { error = e; }
+
+          expect(error).toBeDefined();
+        });
+      });
+    });
+
+    describe('a process that starts successfully', () => {
+      let proc: Process;
+      let didCloseStdout: Deferred<boolean>;
+      let didCloseStderr: Deferred<boolean>;
+
+      beforeEach(function*(task) {
+        didCloseStdout = Deferred<boolean>();
+        didCloseStderr = Deferred<boolean>();
+
+        proc = exec("node './fixtures/echo-server.js'", {
+          env: { PORT: '29000', PATH: process.env.PATH as string },
+          cwd: __dirname,
+          buffered: true,
+        }).run(task);
+
+        task.spawn(function*() {
+          yield proc.stdout.join();
+          didCloseStdout.resolve(true);
+        });
+
+        task.spawn(function*() {
+          yield proc.stderr.join();
+          didCloseStderr.resolve(true);
+        });
+
+        yield proc.stdout.filter((v) => v.includes('listening')).expect();
+      });
+
+      it('has a pid', function*() {
+        expect(typeof proc.pid).toBe('number');
+        expect(proc.pid).not.toBeNaN();
+      });
+
+      describe('when it succeeds', () => {
+        beforeEach(function*() {
+          yield fetch('http://localhost:29000', { method: "POST", body: "exit" });
+        });
+
+        it('joins successfully', function*() {
+          let status = yield proc.join();
+          expect(status.code).toEqual(0);
+        });
+
+        it('expects successfully', function*() {
+          let status = yield proc.expect();
+          expect(status.code).toEqual(0);
+        });
+
+        it('closes stdout and stderr', function*() {
+          yield proc.expect();
+          let output = yield proc.stdout.expect();
+          let errput = yield proc.stderr.expect();
+          expect(output).toContain('exit(0)');
+          expect(errput).toContain('got request');
+          expect(yield didCloseStdout.promise).toEqual(true);
+          expect(yield didCloseStderr.promise).toEqual(true);
+        });
+      });
+
+      describe('when it fails', () => {
+        let error: Error
+        beforeEach(function*() {
+          yield fetch('http://localhost:29000', { method: "POST", body: "fail" });
+        });
+
+        it('joins successfully', function*() {
+          let status = yield proc.join();
+          expect(status.code).not.toEqual(0);
+        });
+
+        it('expects unsuccessfully', function*() {
+          yield function* () {
+            try {
+              yield proc.expect();
+            } catch (e) {
+              error = e;
+            }
+          };
+          expect(error).toBeDefined()
+        });
+
+        it('closes stdout and stderr', function*() {
+          expect(yield didCloseStdout.promise).toEqual(true);
+          expect(yield didCloseStderr.promise).toEqual(true);
+        });
       });
     });
   });

--- a/packages/node/test/fixtures/hello-world-failed.js
+++ b/packages/node/test/fixtures/hello-world-failed.js
@@ -1,0 +1,3 @@
+process.stdout.write("hello world\n");
+process.stderr.write("boom\n");
+process.exit(37);

--- a/packages/node/test/fixtures/hello-world.js
+++ b/packages/node/test/fixtures/hello-world.js
@@ -1,0 +1,3 @@
+process.stdout.write("hello\n");
+process.stdout.write("world\n");
+process.stderr.write("boom\n");

--- a/packages/node/test/helpers.ts
+++ b/packages/node/test/helpers.ts
@@ -6,81 +6,27 @@ import { Channel } from '@effection/channel';
 import { ctrlc } from 'ctrlc-windows';
 import { exec, Process } from '../src/exec';
 
-export class TestProcess {
-  isWin32 = global.process.platform === 'win32';
-  stdout: TestStream;
-  stderr: TestStream;
+const isWin32 = global.process.platform === 'win32';
 
-  static exec(task: Task, cmd: string) {
-    return new TestProcess(exec(task, cmd, { cwd: __dirname }));
-  }
-
-  constructor(public process: Process) {
-    this.stdout = TestStream.of(process.stdout);
-    this.stderr = TestStream.of(process.stderr);
-  }
-
-  async join() {
-    return await run(this.process.join());
-  }
-
-  // cross platform graceful shutdown request. What would
-  // be sent to the process by the Operating system when
-  // a users requests a terminate.
-  async terminate() {
-    if (this.isWin32) {
-      ctrlc(this.process.pid);
-      //Terminate batch process? (Y/N)
-      this.process.stdin.send("Y\n");
-    } else {
-      process.kill(this.process.pid, 'SIGTERM');
-    }
-  }
-
-  // cross platform user initiated graceful shutdown request. What would
-  // be sent to the process by the Operating system when
-  // a users requests an interrupt via CTRL-C or equivalent.
-  async interrupt() {
-    if (this.isWin32) {
-      ctrlc(this.process.pid);
-      //Terminate batch process? (Y/N)
-      this.process.stdin.send("Y\n");
-    } else {
-      process.kill(this.process.pid, 'SIGINT');
-    }
+export function terminate(process: Process) {
+  if (isWin32) {
+    ctrlc(process.pid);
+    //Terminate batch process? (Y/N)
+    process.stdin.send("Y\n");
+  } else {
+    global.process.kill(process.pid, 'SIGTERM');
   }
 }
 
-export class TestStream {
-  public output = "";
-
-  static of(channel: Channel<string>) {
-    let testStream = new TestStream();
-    run(channel.forEach((chunk) => function*() {
-      testStream.output += chunk.toString();
-    }));
-    return testStream;
-  }
-
-  constructor() {};
-
-  async detect(text: string, timeout = 5000) {
-    return converge(() => expect(this.output).toContain(text), timeout);
-  }
-}
-
-export async function converge<T>(fn: () => T, timeout = 2000): Promise<T> {
-  let startTime = performance.now();
-  while(true) {
-    try {
-      return fn();
-    } catch(e) {
-      let diff = performance.now() - startTime;
-      if(diff > timeout) {
-        throw e;
-      } else {
-        await new Promise((resolve) => setTimeout(resolve, 1));
-      }
-    }
+// cross platform user initiated graceful shutdown request. What would
+// be sent to the process by the Operating system when
+// a users requests an interrupt via CTRL-C or equivalent.
+export function interrupt(process: Process) {
+  if (isWin32) {
+    ctrlc(process.pid);
+    //Terminate batch process? (Y/N)
+    process.stdin.send("Y\n");
+  } else {
+    global.process.kill(process.pid, 'SIGINT');
   }
 }

--- a/packages/node/test/main.test.ts
+++ b/packages/node/test/main.test.ts
@@ -10,7 +10,7 @@ describe('main', () => {
 
   describe('with successful process', () => {
     beforeEach(function*(world) {
-      child = exec(world, `ts-node ./test/fixtures/text-writer.ts`);
+      child = exec(world, `ts-node ./test/fixtures/text-writer.ts`, { buffered: true });
 
       yield child.stdout.filter((s) => s.includes("started")).expect();
     });
@@ -40,7 +40,7 @@ describe('main', () => {
 
   describe('with failing process', () => {
     it('sets exit code and prints error', function*(world) {
-      let child = exec(world, `ts-node ./test/fixtures/main-failed.ts`);
+      let child = exec(world, `ts-node ./test/fixtures/main-failed.ts`, { buffered: true });
       let status = yield child.join();
       let stderr = yield child.stderr.expect();
 
@@ -49,7 +49,7 @@ describe('main', () => {
     });
 
     it('sets custom exit code and hides error', function*(world) {
-      let child = exec(world, `ts-node ./test/fixtures/main-failed-custom.ts`);
+      let child = exec(world, `ts-node ./test/fixtures/main-failed-custom.ts`, { buffered: true });
       let status = yield child.join();
       let stderr = yield child.stderr.expect();
 

--- a/packages/node/test/main.test.ts
+++ b/packages/node/test/main.test.ts
@@ -10,7 +10,7 @@ describe('main', () => {
 
   describe('with successful process', () => {
     beforeEach(function*(world) {
-      child = exec(world, `ts-node ./test/fixtures/text-writer.ts`, { buffered: true });
+      child = exec(`ts-node ./test/fixtures/text-writer.ts`, { buffered: true }).run(world);
 
       yield child.stdout.filter((s) => s.includes("started")).expect();
     });
@@ -40,7 +40,7 @@ describe('main', () => {
 
   describe('with failing process', () => {
     it('sets exit code and prints error', function*(world) {
-      let child = exec(world, `ts-node ./test/fixtures/main-failed.ts`, { buffered: true });
+      let child = exec(`ts-node ./test/fixtures/main-failed.ts`, { buffered: true }).run(world);
       let status = yield child.join();
       let stderr = yield child.stderr.expect();
 
@@ -49,7 +49,7 @@ describe('main', () => {
     });
 
     it('sets custom exit code and hides error', function*(world) {
-      let child = exec(world, `ts-node ./test/fixtures/main-failed-custom.ts`, { buffered: true });
+      let child = exec(`ts-node ./test/fixtures/main-failed-custom.ts`, { buffered: true }).run(world);
       let status = yield child.join();
       let stderr = yield child.stderr.expect();
 

--- a/packages/node/test/main.test.ts
+++ b/packages/node/test/main.test.ts
@@ -2,57 +2,59 @@ import * as path from 'path';
 import * as expect from 'expect';
 import { describe, it, beforeEach } from '@effection/mocha';
 
-import { Effection } from '@effection/core';
-import { TestProcess } from './helpers';
+import { exec, Process } from '../src/index';
+import { terminate, interrupt } from './helpers';
 
 describe('main', () => {
-  let child: TestProcess;
+  let child: Process;
 
   describe('with successful process', () => {
-    beforeEach(function*() {
-      child = TestProcess.exec(Effection.root, `ts-node ./fixtures/text-writer.ts`);
+    beforeEach(function*(world) {
+      child = exec(world, `ts-node ./test/fixtures/text-writer.ts`);
 
-      yield child.stdout.detect("started");
+      yield child.stdout.filter((s) => s.includes("started")).expect();
     });
 
     describe('interrupting the process', () => {
       beforeEach(function*() {
-        child.interrupt();
+        interrupt(child);
         yield child.join();
       });
 
       it('shuts down gracefully', function*() {
-        yield child.stdout.detect("stopped");
+        yield child.stdout.filter((s) => s.includes("stopped")).expect();
       });
     });
 
     describe('terminating the process', () => {
       beforeEach(function*() {
-        child.terminate();
+        terminate(child);
         yield child.join();
       });
 
       it('shuts down gracefully', function*() {
-        yield child.stdout.detect("stopped");
+        yield child.stdout.filter((s) => s.includes("stopped")).expect();
       });
     });
   });
 
   describe('with failing process', () => {
-    it('sets exit code and prints error', function*() {
-      let child = TestProcess.exec(Effection.root, `ts-node ./fixtures/main-failed.ts`);
+    it('sets exit code and prints error', function*(world) {
+      let child = exec(world, `ts-node ./test/fixtures/main-failed.ts`);
       let status = yield child.join();
+      let stderr = yield child.stderr.expect();
 
-      expect(child.stderr.output).toContain('Error: moo');
+      expect(stderr).toContain('Error: moo');
       expect(status.code).toEqual(1);
     });
 
-    it('sets custom exit code and hides error', function*() {
-      let child = TestProcess.exec(Effection.root, `ts-node ./fixtures/main-failed-custom.ts`);
+    it('sets custom exit code and hides error', function*(world) {
+      let child = exec(world, `ts-node ./test/fixtures/main-failed-custom.ts`);
       let status = yield child.join();
+      let stderr = yield child.stderr.expect();
 
-      expect(child.stderr.output).toContain('It all went horribly wrong');
-      expect(child.stderr.output).not.toContain('EffectionMainError');
+      expect(stderr).toContain('It all went horribly wrong');
+      expect(stderr).not.toContain('EffectionMainError');
       expect(status.code).toEqual(23);
     });
   });


### PR DESCRIPTION
This changes the `exec` API to not take a `scope` anymore. Instead there are functions to either spawn the process in a scope via `run`, spawn it as a daemon which is expected to be kept running via `daemon`, or run to completion via operations `join` and `expect`. The latter two do not require a scope at all. This makes use of the same kind of pattern we have used for streams, where we create an abstract thing which can either be spawned in the current context, or run to completion as an operation. The API looks like this:

``` typescript
run(function*(scope) {
  let process = exec('node some-server.js').run(scope); // run in scope
  
  console.log('started process:', process.pid);
  scope.spawn(process.stdout.forEach((m) => ...));
  yield process.join();
});

run(function*(scope) {
  let process = daemon('node some-server.js').run(scope); // run in scope, throw on early exit

  console.log('started daemon:', process.pid);
});

run(function*(scope) {
  let result = yield exec('node some-server.js').join(); // run to completion
  
  console.log('process completed', result.code, result.stdout);
});

run(function*(scope) {
  let result = yield exec('node some-server.js').expect(); // run to completion, throw on non-zero exit code
});
```

Both `join` and `expect` return `stdout` and `stderr` as strings, rather than streams. This makes it easy to run a process to completion and grab the output, which is a pretty common thing to need to do.