### PR TITLE
Store effection root in global variable

### DIFF
--- a/.changeset/slimy-seals-attend.md
+++ b/.changeset/slimy-seals-attend.md
@@ -1,0 +1,6 @@
+---
+"@effection/core": minor
+"effection": minor
+---
+
+Store root in a global variable

--- a/packages/core/src/effection.ts
+++ b/packages/core/src/effection.ts
@@ -1,4 +1,9 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { Task } from './task';
+import { version } from '../package.json';
+
+const MAJOR_VERSION = version.split('.')[0];
+const GLOBAL_PROPERTY = `__effectionV${MAJOR_VERSION}`;
 
 function createRootTask() {
   let task = new Task(undefined, { ignoreChildErrors: true });
@@ -6,8 +11,27 @@ function createRootTask() {
   return task;
 }
 
+type GlobalConfig = {
+  root: Task;
+}
+
+function getGlobalConfig() {
+  if(!(globalThis as any)[GLOBAL_PROPERTY]) {
+    (globalThis as any)[GLOBAL_PROPERTY] = {
+      root: createRootTask()
+    };
+  }
+  return (globalThis as any)[GLOBAL_PROPERTY] as GlobalConfig;
+}
+
 export const Effection = {
-  root: createRootTask(),
+  get root(): Task {
+    return getGlobalConfig().root;
+  },
+
+  set root(value: Task){
+    getGlobalConfig().root = value;
+  },
 
   async reset() {
     await Effection.root.halt();

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -7,7 +7,8 @@
       "./node_modules/@types",
       "./typings"
     ],
-    "baseUrl": "."
+    "baseUrl": ".",
+    "resolveJsonModule": true
   },
   "include": [
     "test/**/*.ts",


### PR DESCRIPTION
If there are multiple versions of the effection package, for example if effection is also a transitive dependency, then we might end up with multiple roots. By using a global variable we can share the same root between all instances of effection. The name of the global variable includes the major version of effection, so that we can make breaking changes to its layout in major versions.