### PR TITLE
Add join method to Streams

### DIFF
--- a/.changeset/sharp-lobsters-work.md
+++ b/.changeset/sharp-lobsters-work.md
@@ -1,0 +1,6 @@
+---
+"@effection/subscription": minor
+"effection": minor
+---
+
+Add `join` method on stream to return stream result

--- a/packages/subscription/src/stream.ts
+++ b/packages/subscription/src/stream.ts
@@ -13,6 +13,7 @@ export interface Stream<T, TReturn = undefined> extends OperationIterable<T, TRe
   first(): Operation<T | undefined>;
   expect(): Operation<T>;
   forEach(visit: (value: T) => (Operation<void> | void)): Operation<TReturn>;
+  join(): Operation<TReturn>;
   collect(): Operation<Iterator<T, TReturn>>;
   toArray(): Operation<T[]>;
   subscribe(scope: Task): OperationIterator<T, TReturn>;
@@ -84,6 +85,10 @@ export function createStream<T, TReturn = undefined>(callback: Callback<T, TRetu
           }
         }
       }
+    },
+
+    join(): Operation<TReturn> {
+      return subscribable.forEach(() => { /* no op */ });
     },
 
     collect(): Operation<Iterator<T, TReturn>> {

--- a/packages/subscription/test/stream.test.ts
+++ b/packages/subscription/test/stream.test.ts
@@ -20,7 +20,14 @@ const emptyStream: Stream<Thing, number> = createStream(() => function*() {
   return 12;
 });
 
-describe('chaining subscribable', () => {
+describe('Stream', () => {
+  describe('join', () => {
+    it('returns the result of the stream', function*() {
+      let result = yield stuff.join();
+      expect(result).toEqual(3);
+    });
+  });
+
   describe('forEach', () => {
     it('iterates through all members of the subscribable', function*() {
       let values: Thing[] = [];


### PR DESCRIPTION
There are some cases where we want to wait for a stream to close, or for the its return value. This is currently possible by supplying an empty function to `forEach`, but this is neither semantically explanatory not ergonomic.