### PR TITLE
Add once() equivalent

### DIFF
--- a/.changeset/stream-once.md
+++ b/.changeset/stream-once.md
@@ -1,0 +1,6 @@
+---
+"effection": patch
+"@effection/subscription": patch
+---
+Allow `first()` and `expect()` methods to accept an optional predicate
+against which to match results.

--- a/packages/subscription/test/stream.test.ts
+++ b/packages/subscription/test/stream.test.ts
@@ -116,6 +116,10 @@ describe('Stream', () => {
       expect(yield stuff.first()).toEqual({ name: 'bob', type: 'person' });
     });
 
+    it('accepts a predicate that defines what first is', function*() {
+      expect(yield stuff.first(thing => thing.type === 'planet')).toMatchObject({ name: 'world' });
+    });
+
     it('returns undefined if the subscription is empty', function*() {
       expect(yield emptyStream.first()).toEqual(undefined);
     });
@@ -124,6 +128,10 @@ describe('Stream', () => {
   describe('expect', () => {
     it('returns the first item in the subscription', function*() {
       expect(yield stuff.expect()).toEqual({ name: 'bob', type: 'person' });
+    });
+
+    it('accepts a predicate that defines what first is', function*() {
+      expect(yield stuff.first(thing => thing.type === 'planet')).toMatchObject({ name: 'world' });
     });
 
     it('throws an error if the subscription is empty', function*() {


### PR DESCRIPTION
Motivation
-----------

The ability to synchronize on an observed condition is extremely handy, and we use it quite often in `Atom`. It would be nice if we could define this upstream in the stream interface instead of the atom. That way, there really wouldn't be anything special about the `once()` method in the atom.

Approach
----------

Originally, I set about adding a `once()` method for stream that was just a composition of `filter(predicate).first()`. But there are cases that you want to have the actual matched value, and not just synchronize on it:

```ts
let match = yield stream.once(({ status }) => status === 'ready');
```

In those cases where you want the return value, this method should behave like `expect()`, raising an exception if the stream is closed before a value is received.

On other occasions however, you don't necessarily need the value, you just want to synchronize, and in those cases it's ok for the stream to close. In order to support both of these cases, we would need both a `once()` and `onceExpect()` so I opted instead to allow the `first()` and `expect()` methods to accept a predicate against which to match. This lets us not any any methods to the API and yet cover all of our use-cases. In essence, first really means "first matching predicate" and expect means "expect a value matching predicate".

### Alternate Designs

It is very easy and straightforward to implement `once()` in terms of `filter()` and `first()` and this was the temptation. It does keep the `first()` and `expect()` methods simpler which is nice.

### Possible Drawbacks or Risks

I don't like optional parameters as a rule as they make methods difficult to curry later on.