### PR TITLE
Increase default value for max subscribers

### DIFF
--- a/.changeset/late-eagles-brush.md
+++ b/.changeset/late-eagles-brush.md
@@ -1,0 +1,6 @@
+---
+"@effection/channel": minor
+"effection": minor
+---
+
+Increase default value of max subscribers on channel

--- a/packages/channel/src/channel.ts
+++ b/packages/channel/src/channel.ts
@@ -17,6 +17,8 @@ export function createChannel<T, TClose = undefined>(options: ChannelOptions = {
 
   if(options.maxSubscribers) {
     bus.setMaxListeners(options.maxSubscribers);
+  } else {
+    bus.setMaxListeners(100000);
   }
 
   let subscribable = createStream<T, TClose>((publish) => function*(task) {


### PR DESCRIPTION
Node's default value of `10` is unreasonably low, and while having a max value is probably a good idea, having it set so low is silly.