### PR TITLE
Add WritableStream interface

### DIFF
--- a/.changeset/pretty-bears-teach.md
+++ b/.changeset/pretty-bears-teach.md
@@ -1,0 +1,7 @@
+---
+"@effection/subscription": minor
+"@effection/channel": minor
+"effection": minor
+---
+
+Add WritableStream interface and implement it for channels

--- a/packages/subscription/src/index.ts
+++ b/packages/subscription/src/index.ts
@@ -4,4 +4,5 @@ export { OperationIterable } from './operation-iterable';
 export { OperationIterator } from './operation-iterator';
 export { Subscription } from './subscription';
 export { createStream, Stream, StringBufferStream } from './stream';
+export { Writable, WritableStream } from './writable-stream';
 export { subscribe } from './subscribe';

--- a/packages/subscription/src/writable-stream.ts
+++ b/packages/subscription/src/writable-stream.ts
@@ -1,0 +1,7 @@
+import { Stream } from './stream';
+
+export interface Writable<T> {
+  send(message: T): void;
+}
+
+export type WritableStream<TReceive, TSend, TReturn = undefined> = Stream<TReceive, TReturn> & Writable<TSend>;


### PR DESCRIPTION
## Motivation

There are many primitives in effection that represent something which can be sent messages or written to, examples could include a channel, but also for example a socket. We want to provide an abstraction so that a consumer of such an interface does not need to make a choice about the concrete thing they are working with, and instead can use this interface. This allows for example swapping a socket with a channel in tests.

## Approach

Adds an interface called `WritableStream`. Also adds an interface called `Writable` for just the write end part.

### Alternate Designs

The name `WritableStream` is bikesheddable.

The `Writable` interface could be omitted.

The `send` method could be made an operation. This makes it harder to use this from outside effection world, but it is more general, in that it could support asynchronous writes, or for example writing to a bounded channel with backpressure. The thinking here is that we would have a separate interface for these kinds of things in the future.

### Possible Drawbacks or Risks

`send` not being an operation makes this interface unsuitable for some applications.