### PR TITLE
Lock dependency versions while in prerelease mode

### DIFF
--- a/.changeset/gorgeous-months-shop.md
+++ b/.changeset/gorgeous-months-shop.md
@@ -1,0 +1,13 @@
+---
+"@effection/atom": patch
+"@effection/channel": patch
+"@effection/events": patch
+"@effection/fetch": patch
+"@effection/mocha": patch
+"@effection/node": patch
+"@effection/subscription": patch
+"@effection/core": patch
+"effection": patch
+---
+
+Use strict dependency requirements for internal dependencies while in prerelease mode

--- a/packages/atom/package.json
+++ b/packages/atom/package.json
@@ -37,8 +37,8 @@
     "yarn": "1.19.1"
   },
   "dependencies": {
-    "@effection/core": "^2.0.0-preview.5",
-    "@effection/subscription": "^2.0.0-preview.5",
+    "@effection/core": "2.0.0-preview.5",
+    "@effection/subscription": "2.0.0-preview.5",
     "assert-ts": "^0.2.2",
     "fp-ts": "^2.8.2",
     "monocle-ts": "^2.3.3"

--- a/packages/channel/package.json
+++ b/packages/channel/package.json
@@ -34,8 +34,8 @@
     "yarn": "1.19.1"
   },
   "dependencies": {
-    "@effection/core": "^2.0.0-preview.5",
-    "@effection/events": "^2.0.0-preview.4",
-    "@effection/subscription": "^2.0.0-preview.5"
+    "@effection/core": "2.0.0-preview.5",
+    "@effection/events": "2.0.0-preview.4",
+    "@effection/subscription": "2.0.0-preview.5"
   }
 }

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -21,8 +21,8 @@
     "mocha": "mocha -r ts-node/register"
   },
   "dependencies": {
-    "@effection/subscription": "^2.0.0-preview.5",
-    "effection": "^2.0.0-preview.6"
+    "@effection/subscription": "2.0.0-preview.5",
+    "@effection/core": "2.0.0-preview.5"
   },
   "devDependencies": {
     "@effection/mocha": "2.0.0-preview.4",

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -30,7 +30,7 @@
     "typescript": "^3.9.5"
   },
   "dependencies": {
-    "@effection/core": "^2.0.0-preview.5",
+    "@effection/core": "2.0.0-preview.5",
     "abort-controller": "^3.0.0",
     "cross-fetch": "^3.0.4",
     "node-fetch": "^2.6.1"

--- a/packages/mocha/package.json
+++ b/packages/mocha/package.json
@@ -20,7 +20,7 @@
     "mocha": "mocha -r ts-node/register"
   },
   "peerDependencies": {
-    "@effection/core": "^2.0.0-preview.5",
+    "@effection/core": "2.0.0-preview.5",
     "mocha": "^8.0.0"
   },
   "devDependencies": {

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -33,10 +33,10 @@
     "typescript": "^3.7.0"
   },
   "dependencies": {
-    "@effection/channel": "^2.0.0-preview.5",
-    "@effection/core": "^2.0.0-preview.5",
-    "@effection/events": "^2.0.0-preview.4",
-    "@effection/subscription": "^2.0.0-preview.5",
+    "@effection/channel": "2.0.0-preview.5",
+    "@effection/core": "2.0.0-preview.5",
+    "@effection/events": "2.0.0-preview.4",
+    "@effection/subscription": "2.0.0-preview.5",
     "cross-spawn": "^7.0.3",
     "ctrlc-windows": "^1.0.3",
     "shellwords": "^0.1.1"

--- a/packages/subscription/package.json
+++ b/packages/subscription/package.json
@@ -20,7 +20,7 @@
     "mocha": "mocha -r ts-node/register"
   },
   "dependencies": {
-    "@effection/core": "^2.0.0-preview.5"
+    "@effection/core": "2.0.0-preview.5"
   },
   "devDependencies": {
     "@effection/mocha": "2.0.0-preview.4",


### PR DESCRIPTION
Since minor and patch versions are equivalent in prerelease mode, and the caret `^` operator does not work well in prerelease mode, we should lock the versions of internal dependencies.

Changesets will keep the type of dependency, so when the version is bumped it will keep it as a strict dependency.

Since bumping a package will also release all of its downstream packages, it should be easier to upgrade packages together.