### PR TITLE
Emit initial state as part of atom stream, deprecate once.

### DIFF
--- a/.changeset/atom-stream-initial-state.md
+++ b/.changeset/atom-stream-initial-state.md
@@ -1,0 +1,6 @@
+---
+"@effection/atom": patch
+---
+subscribing to an atom now always includes its current state as the
+first item in the stream. Depreacet the `once()` method as it is now
+redundant with `filter().expect()`

--- a/packages/atom/test/atom.test.ts
+++ b/packages/atom/test/atom.test.ts
@@ -1,7 +1,7 @@
 import { describe, beforeEach, it } from '@effection/mocha';
 import * as expect from 'expect';
 import { createAtom } from '../src/atom';
-import { Stream, OperationIterator } from '@effection/subscription';
+import { OperationIterator } from '@effection/subscription';
 import { Slice } from '../src/types';
 
 type TestRunAgentState = {
@@ -141,6 +141,7 @@ describe('@bigtest/atom createAtom', () => {
 
     it('iterates over emitted states', function*() {
       expect(yield iterator.next()).toEqual({ done: false, value: { foo: 'bar' } });
+      expect(yield iterator.next()).toEqual({ done: false, value: { foo: 'bar' } });
       expect(yield iterator.next()).toEqual({ done: false, value: { foo: 'baz' } });
       expect(yield iterator.next()).toEqual({ done: false, value: { foo: 'quox' } });
     });
@@ -203,7 +204,8 @@ describe('@bigtest/atom createAtom', () => {
       subject.update(() => bar);
     });
 
-    it('should only publish unique state changes', function*() {
+    it('publishes the initial state and subsequent  unique state changes', function*() {
+      expect(yield iterator.next()).toEqual({ done: false, value: { foo: 'bar' } });
       expect(yield iterator.next()).toEqual({ done: false, value: { foo: 'baz' } });
       expect(yield iterator.next()).toEqual({ done: false, value: { foo: 'qux' } });
       expect(yield iterator.next()).toEqual({ done: false, value: { foo: 'bar' } });

--- a/packages/atom/test/slice.test.ts
+++ b/packages/atom/test/slice.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, beforeEach } from '@effection/mocha';
 import * as expect from 'expect';
 import { createAtom } from '../src/atom';
-import { Stream, OperationIterator } from '@effection/subscription';
+import { OperationIterator } from '@effection/subscription';
 import { Slice } from '../src/types';
 
 type Data = { data: string };
@@ -147,7 +147,8 @@ describe('@bigtest/atom Slice', () => {
       slice.update(() => 'quox');
     });
 
-    it('iterates over emitted states', function*() {
+    it('iterates over initial and emitted states', function*() {
+      expect(yield subscription.next()).toEqual({ done: false, value: 'foo' });
       expect(yield subscription.next()).toEqual({ done: false, value: 'bar' });
       expect(yield subscription.next()).toEqual({ done: false, value: 'baz' });
       expect(yield subscription.next()).toEqual({ done: false, value: 'quox' });
@@ -165,8 +166,8 @@ describe('@bigtest/atom Slice', () => {
 
       iterator = slice.subscribe(world);
 
-      // foo is the initial value
-      // should not appear as element 1 in the result
+      // foo is the initial value, it should only appear once
+      // as the first result
       slice.update(() => 'foo');
       slice.update(() => 'bar');
       slice.update(() => 'bar');
@@ -176,7 +177,8 @@ describe('@bigtest/atom Slice', () => {
       slice.update(() => 'foo');
     });
 
-    it('should only publish unique state changes', function*() {
+    it('should only publish the initial state and unique state changes', function*() {
+      expect(yield iterator.next()).toEqual({ done: false, value: 'foo' });
       expect(yield iterator.next()).toEqual({ done: false, value: 'bar' });
       expect(yield iterator.next()).toEqual({ done: false, value: 'baz' });
       expect(yield iterator.next()).toEqual({ done: false, value: 'foo' });


### PR DESCRIPTION
## Motivation

As part of simplifying the atom, it was decided to make the atom implement the streaming API directly. However, one of the extremely useful cases for atom is to synchronize on state. It is really nice because it impervious to the same race conditions that event listeners are. This is because you can match against the current state and all future states and so it does not matter when you start your subscription, because you are guaranteed that _if_ the "event" that you're looking for arises, you will see it. Even better, there is zero additional memory cost that would come with solution like buffering because you're only matching against an already allocated data structure.

It's desirable to not have to use a one-off API when the same can be achieved my composing `filter()` and `expect()`. However, in order to achieve this, but also retain the semantics of the `once()` method, we have to be able to filter on the _current_ atom state as well.

## Approach
This creates a new stream off of the channel of states and publishes the current state first, before publishng.

The `once()` method, now no longer needed has been deprecated. It will issue a single warning per atom, which is multiple in the test suite, but only once per application. We can remove it once we've replaced it in simulacrum and bigtest
