### PR TITLE
Improve reentrancy on atom

### DIFF
--- a/.changeset/calm-points-arrive.md
+++ b/.changeset/calm-points-arrive.md
@@ -1,0 +1,6 @@
+---
+"@effection/atom": patch
+"effection": patch
+---
+
+Make atom more reentrant


### PR DESCRIPTION
This makes state changes appear in the correct order if a state change is itself triggered by another state change. While this improves the status quo, there are still some pretty significant traps to fall into here. Most significantly the state received by a subscription might not actually match the current state of the atom. This is sort of a pest/cholera situation, where we have to choose in favour of correctness in some way, and neither option is particularly appealing.

There is a case to be made that this entire situation would be best avoided entirely. Maybe we should throw an error if the user tried to set the state from within a state change?