### PR TITLE
Run destructors in reverse order and in series

### DIFF
--- a/.changeset/serious-shrimps-rescue.md
+++ b/.changeset/serious-shrimps-rescue.md
@@ -1,0 +1,6 @@
+---
+"@effection/core": minor
+"effection": minor
+---
+
+Run destructors in reverse order and in series

--- a/packages/core/test/spawn.test.ts
+++ b/packages/core/test/spawn.test.ts
@@ -167,6 +167,34 @@ describe('spawn', () => {
     expect(didFinish).toEqual(true);
   });
 
+  it('runs destructors in reverse order and in series', async () => {
+    let result: string[] = [];
+    let root = run(function*(context: Task) {
+      context.spawn(function*() {
+        try {
+          yield
+        } finally {
+          result.push('first start');
+          yield sleep(5);
+          result.push('first done');
+        }
+      });
+      context.spawn(function*() {
+        try {
+          yield
+        } finally {
+          result.push('second start');
+          yield sleep(10);
+          result.push('second done');
+        }
+      });
+    });
+
+    await root;
+
+    expect(result).toEqual(['second start', 'second done', 'first start', 'first done']);
+  });
+
   describe('with blockParent: true', () => {
     it('blocks on child when finishing normally', async () => {
       let child: Task<string> | undefined;


### PR DESCRIPTION
## Motivation

When spawning multiple children in a task, it is intuitive that the child that was spawned will be terminated first (last in first out), this makes sense for example if the second child has some dependency on the first (e.g. uses its network services), and we expect the second child to be cleaned up before the resource it depends on is cleaned up.

For the same reason, destructors must be run in *series* rather than in parallel. Termination of the second child must complete *fully* before even initiating termination of the first. This may sound very inefficient at first glance, but it is not as bas as it seems, since a vast majority of children in fact terminate synchronously, and async termination is an edge case.

## Approach

The implementation strategy has been to reuse the *trapper* mechanism and add an additional trapper to the child which continues the termination until there are no haltable children left. 

### Alternate Designs

A Promise based design is possible, but this has the downside of not running synchronously if destructors are sync, which is desirable. Also, since we are not using tasks as promises in the implementation anywhere else, but are relying on our state machine and trapper mechanisms, it feels a little out of place.

### Possible Drawbacks or Risks

There is a slightly tricky order-dependency here in that the child must have been removed from the set before the added trapper triggers. This is safe for now since:

1) trappers are executed in order
2) the trapper which removes the child from the set is added on `link` which must always be
called before halt

So there is no possibility of these executing out of order. Nevertheless, this implicit dependency is a little worrisome.