### PR TITLE
Add Task `use` to formalize resources

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,6 +4,7 @@ import { Effection } from './effection';
 
 export { Task, TaskOptions } from './task';
 export { Operation } from './operation';
+export { Resource, ResourceTask } from './resource';
 export { sleep } from './sleep';
 export { Effection } from './effection';
 export { deprecated } from './deprecated';

--- a/packages/core/src/resource.ts
+++ b/packages/core/src/resource.ts
@@ -1,0 +1,11 @@
+import { Task, Operation } from './index';
+
+export interface Resource<TOut> {
+  use(scope: Task): Operation<TOut>;
+}
+
+export interface ResourceTask<TOut> extends Promise<TOut> {
+  task: Task;
+  initTask: Task<TOut>;
+  halt(): Promise<void>;
+}

--- a/packages/core/test/resource.test.ts
+++ b/packages/core/test/resource.test.ts
@@ -1,0 +1,50 @@
+import './setup';
+import { describe, it } from 'mocha';
+import * as expect from 'expect';
+
+import { run, sleep, Task, Resource } from '../src/index';
+
+const myResource: Resource<{ status: string }> = {
+  use(scope: Task) {
+    return function*() {
+      let container = { status: 'pending' }
+      scope.spawn(function*() {
+        yield sleep(5);
+        container.status = 'active';
+      });
+      yield sleep(2)
+      return container;
+    }
+  }
+}
+
+describe('use', () => {
+  it('runs resource in task scope', async () => {
+    await run(function*(task) {
+      let result = yield task.use(myResource);
+      expect(result.status).toEqual('pending');
+      yield sleep(10);
+      expect(result.status).toEqual('active');
+    });
+  });
+
+  it('terminates resource when task completes', async () => {
+    let result: { status: string } = await run(function*(task) {
+      return yield task.use(myResource);
+    });
+    expect(result.status).toEqual('pending');
+    await run(sleep(10));
+    expect(result.status).toEqual('pending'); // is finished, should not switch to active
+  });
+
+  it('can terminate resource', async () => {
+    await run(function*(task) {
+      let resource = task.use(myResource);
+      let result = yield resource;
+      expect(result.status).toEqual('pending');
+      yield resource.halt();
+      yield sleep(10);
+      expect(result.status).toEqual('pending'); // resource has been halted
+    });
+  });
+});

--- a/packages/node/src/daemon.ts
+++ b/packages/node/src/daemon.ts
@@ -1,4 +1,4 @@
-import { Task } from '@effection/core';
+import { Task, Resource } from '@effection/core';
 
 import { exec, Process, ExecOptions, ExitStatus, DaemonExitError } from './exec';
 
@@ -8,14 +8,13 @@ import { exec, Process, ExecOptions, ExitStatus, DaemonExitError } from './exec'
  * before the operation containing them passes out of scope it raises an error.
  */
 
-export interface Daemon {
-  run(scope: Task): Process;
-}
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface Daemon extends Resource<Process> {}
 
 export function daemon(command: string, options: ExecOptions = {}): Daemon {
   return {
-    run(scope) {
-      let process = exec(command, options).run(scope);
+    use: (scope: Task) => function*() {
+      let process = yield scope.use(exec(command, options));
 
       scope.spawn(function*() {
         let status: ExitStatus = yield process.join();

--- a/packages/node/src/exec.ts
+++ b/packages/node/src/exec.ts
@@ -1,7 +1,7 @@
 /// <reference types="../types/shellwords" />
 import { split } from 'shellwords';
 
-import { Task, Operation } from '@effection/core';
+import { Task, Operation, Resource } from '@effection/core';
 import { ExecOptions, Process, ProcessResult, CreateOSProcess } from './exec/api';
 import { createPosixProcess } from './exec/posix';
 import { createWin32Process, isWin32 } from './exec/win32';
@@ -9,8 +9,7 @@ import { createWin32Process, isWin32 } from './exec/win32';
 export * from './exec/api';
 export * from './exec/error';
 
-export interface Exec {
-  run(scope: Task): Process;
+export interface Exec extends Resource<Process> {
   join(): Operation<ProcessResult>;
   expect(): Operation<ProcessResult>;
 }
@@ -34,12 +33,12 @@ export function exec(command: string, options: ExecOptions = {}): Exec {
   let opts = { ...options, arguments: args.concat(options.arguments || []) }
 
   return {
-    run(scope: Task) {
-      return createProcess(cmd, opts).run(scope);
+    use(scope: Task) {
+      return createProcess(cmd, opts).use(scope);
     },
     join() {
       return function*(scope: Task) {
-        let process = createProcess(cmd, { ...opts, buffered: true }).run(scope);
+        let process = yield scope.use(createProcess(cmd, { ...opts, buffered: true }));
 
         let status = yield process.join();
         let stdout = yield process.stdout.expect();
@@ -50,7 +49,7 @@ export function exec(command: string, options: ExecOptions = {}): Exec {
     },
     expect() {
       return function*(scope: Task) {
-        let process = createProcess(cmd, { ...opts, buffered: true }).run(scope);
+        let process = yield scope.use(createProcess(cmd, { ...opts, buffered: true }));
 
         let status = yield process.expect();
         let stdout = yield process.stdout.expect();

--- a/packages/node/src/exec/api.ts
+++ b/packages/node/src/exec/api.ts
@@ -1,4 +1,4 @@
-import { Task, Operation } from '@effection/core';
+import { Task, Operation, Resource } from '@effection/core';
 import { Stream } from '@effection/subscription';
 
 // TODO: import from subscription package once #236 is merged
@@ -81,10 +81,6 @@ export interface ProcessResult extends ExitStatus {
   stderr: string;
 }
 
-export interface OSProcess {
-  run(scope: Task): Process;
-}
-
 export interface CreateOSProcess {
-  (command: string, options: ExecOptions): OSProcess;
+  (command: string, options: ExecOptions): Resource<Process>;
 }

--- a/packages/node/src/exec/posix.ts
+++ b/packages/node/src/exec/posix.ts
@@ -1,4 +1,4 @@
-import { Operation, Deferred } from '@effection/core';
+import { Task, Operation, Deferred } from '@effection/core';
 import { createChannel } from '@effection/channel';
 import { on, once, onceEmit } from '@effection/events';
 import { spawn as spawnProcess } from 'child_process';
@@ -9,7 +9,7 @@ type Result = { type: 'error'; value: unknown } | { type: 'status'; value: [numb
 
 export const createPosixProcess: CreateOSProcess = (command, options) => {
   return {
-    run(scope) {
+    use: (scope: Task) => function*() {
       let getResult = Deferred<Result>();
 
       let join = (): Operation<ExitStatus> => function*() {

--- a/packages/node/src/exec/win32.ts
+++ b/packages/node/src/exec/win32.ts
@@ -1,5 +1,5 @@
 import { platform } from "os";
-import { Operation, Deferred } from "@effection/core";
+import { Task, Operation, Deferred } from "@effection/core";
 import { createChannel } from '@effection/channel';
 import { on, once, onceEmit } from "@effection/events";
 import { spawn as spawnProcess } from "cross-spawn";
@@ -13,7 +13,7 @@ type Result =
 
 export const createWin32Process: CreateOSProcess = (command, options) => {
   return {
-    run(scope) {
+    use: (scope: Task) => function*() {
       let getResult = Deferred<Result>();
 
       let join = (): Operation<ExitStatus> => function*() {

--- a/packages/node/test/daemon.test.ts
+++ b/packages/node/test/daemon.test.ts
@@ -3,7 +3,7 @@ import * as expect from 'expect';
 import fetch from 'node-fetch';
 
 import '@effection/mocha';
-import { run, Task } from '@effection/core';
+import { run, Task, Deferred } from '@effection/core';
 
 import { daemon, Process } from '../src';
 
@@ -12,14 +12,16 @@ describe('daemon', () => {
   let proc: Process;
 
   beforeEach(function*() {
+    let deferred = Deferred<Process>();
     task = run(function*(inner) {
-      proc = daemon('node', {
+      deferred.resolve(yield inner.use(daemon('node', {
         arguments: ['./fixtures/echo-server.js'],
         env: { PORT: '29000', PATH: process.env.PATH as string },
         cwd: __dirname,
-      }).run(inner);
+      })));
       yield
     });
+    proc = yield deferred.promise;
 
     yield proc.stdout.filter((v) => v.includes('listening')).expect();
   });

--- a/packages/node/test/exec.test.ts
+++ b/packages/node/test/exec.test.ts
@@ -40,12 +40,12 @@ describe('exec', () => {
     });
   });
 
-  describe('.run', () => {
+  describe('.use', () => {
     describe('a process that fails to start', () => {
       describe('calling join()', () => {
         it('reports the failed status', function*(task) {
           let error: unknown;
-          let proc = exec("argle", { arguments: ['bargle'] }).run(task);
+          let proc = yield task.use(exec("argle", { arguments: ['bargle'] }));
           try {
             yield proc.join();
           } catch(e) {
@@ -58,7 +58,7 @@ describe('exec', () => {
       describe('calling expect()', () => {
         it('fails', function*(task) {
           let error: unknown;
-          let proc = exec("argle", { arguments: ['bargle'] }).run(task);
+          let proc = yield task.use(exec("argle", { arguments: ['bargle'] }));
           try {
             yield proc.expect()
           } catch (e) { error = e; }
@@ -77,11 +77,11 @@ describe('exec', () => {
         didCloseStdout = Deferred<boolean>();
         didCloseStderr = Deferred<boolean>();
 
-        proc = exec("node './fixtures/echo-server.js'", {
+        proc = yield task.use(exec("node './fixtures/echo-server.js'", {
           env: { PORT: '29000', PATH: process.env.PATH as string },
           cwd: __dirname,
           buffered: true,
-        }).run(task);
+        }));
 
         task.spawn(function*() {
           yield proc.stdout.join();

--- a/packages/node/test/main.test.ts
+++ b/packages/node/test/main.test.ts
@@ -10,7 +10,7 @@ describe('main', () => {
 
   describe('with successful process', () => {
     beforeEach(function*(world) {
-      child = exec(`ts-node ./test/fixtures/text-writer.ts`, { buffered: true }).run(world);
+      child = yield world.use(exec(`ts-node ./test/fixtures/text-writer.ts`, { buffered: true }));
 
       yield child.stdout.filter((s) => s.includes("started")).expect();
     });
@@ -40,7 +40,7 @@ describe('main', () => {
 
   describe('with failing process', () => {
     it('sets exit code and prints error', function*(world) {
-      let child = exec(`ts-node ./test/fixtures/main-failed.ts`, { buffered: true }).run(world);
+      let child: Process = yield world.use(exec(`ts-node ./test/fixtures/main-failed.ts`, { buffered: true }));
       let status = yield child.join();
       let stderr = yield child.stderr.expect();
 
@@ -49,7 +49,7 @@ describe('main', () => {
     });
 
     it('sets custom exit code and hides error', function*(world) {
-      let child = exec(`ts-node ./test/fixtures/main-failed-custom.ts`, { buffered: true }).run(world);
+      let child: Process = yield world.use(exec(`ts-node ./test/fixtures/main-failed-custom.ts`, { buffered: true }));
       let status = yield child.join();
       let stderr = yield child.stderr.expect();
 


### PR DESCRIPTION
Another, more conservative approach to adding resource-like things. An alternative to #293. This time by adding `task.use` which allocates a resource and returns a pseudo-task like thing. The advantage to this is that we can cleanly halt the entire resource and everything it allocates. The interface for defining a resource is the same.