### PR TITLE
Fix Atom dependencies and channel typings

### DIFF
--- a/.changeset/fix-atom-deps.md
+++ b/.changeset/fix-atom-deps.md
@@ -1,0 +1,5 @@
+---
+"@effection/atom": patch
+"@effection/channel": patch
+---
+Add missing dependency on @effection/channel which could cause incorrect module resolution

--- a/packages/atom/package.json
+++ b/packages/atom/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0-preview.7",
   "description": "State atom implementation for effection",
   "main": "dist/index.js",
-  "typings": "dist/index.d.js",
+  "typings": "dist/index.d.ts",
   "repository": "https://github.com/thefrontside/bigtest.git",
   "author": "Frontside Engineering <engineering@frontside.io>",
   "license": "MIT",

--- a/packages/atom/package.json
+++ b/packages/atom/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "@effection/core": "2.0.0-preview.7",
     "@effection/subscription": "2.0.0-preview.8",
+    "@effection/channel": "^2.0.0-preview.8",
     "assert-ts": "^0.2.2",
     "fp-ts": "^2.8.2",
     "monocle-ts": "^2.3.3"

--- a/packages/channel/package.json
+++ b/packages/channel/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0-preview.8",
   "description": "MPMC Channel implementation for effection",
   "main": "dist/index.js",
-  "typings": "dist/index.d.js",
+  "typings": "dist/index.d.ts",
   "repository": "https://github.com/thefrontside/bigtest.git",
   "author": "Frontside Engineering <engineering@frontside.io>",
   "license": "MIT",


### PR DESCRIPTION
Motivation
-----------

It's possible for effection atom to completely bork a typescript compilation if there are multiple versions of `effection` inside the same monorepo. In this case, simulacrum was using v2, but it was using covector to publish which uses v1. And, as a result, when `@effection/atom` imported `@effection/channel` it got whatever the runtime deemed closest since the dependency on channel was not explicit.


ALso, while trying to trace module resolution in order to debug this, I noticed that TypeScript was actually guessing the correct location of the typings index for both channel and atom even though it was incorrectly specified in package.json

```
======== Resolving module '@effection/channel' from '/packages/server/node_modules/effection/dist/index.d.ts'. ========
Loading module '@effection/channel' from 'node_modules' folder, target file type 'TypeScript'.
Directory '/packages/server/node_modules/effection/dist/node_modules' does not exist, skipping all lookups in it.
Scoped package detected, looking in 'effection__channel'
Directory '/packages/server/node_modules/effection/node_modules' does not exist, skipping all lookups in it.
Scoped package detected, looking in 'effection__channel'
Found 'package.json' at '/packages/server/node_modules/@effection/channel/package.json'.
File '/packages/server/node_modules/@effection/channel.ts' does not exist.
File '/packages/server/node_modules/@effection/channel.tsx' does not exist.
File '/packages/server/node_modules/@effection/channel.d.ts' does not exist.
'package.json' has 'typings' field 'dist/index.d.js' that references '/packages/server/node_modules/@effection/channel/dist/index.d.js'.
File '/packages/server/node_modules/@effection/channel/dist/index.d.js' does not exist.
Loading module as file / folder, candidate module location '/packages/server/node_modules/@effection/channel/dist/index.d.js', target file type 'TypeScript'.
File '/packages/server/node_modules/@effection/channel/dist/index.d.js.ts' does not exist.
File '/packages/server/node_modules/@effection/channel/dist/index.d.js.tsx' does not exist.
File '/packages/server/node_modules/@effection/channel/dist/index.d.js.d.ts' does not exist.
File name '/packages/server/node_modules/@effection/channel/dist/index.d.js' has a '.js' extension - stripping it.
File '/packages/server/node_modules/@effection/channel/dist/index.d.ts' exist - use it as a name resolution result.
Resolving real path for '/packages/server/node_modules/@effection/channel/dist/index.d.ts', result '/packages/server/no
de_modules/@effection/channel/dist/index.d.ts'.
======== Module name '@effection/channel' was successfully resolved to '/packages/server/node_modules/@effection/channel/dist/index.d.ts' with Package ID '@effec
tion/channel/dist/index.d.ts@2.0.0-preview.8'. ========
```

As you can see The typings file is actually `dist/index.d.ts`, not `.js` and that TypeScript correctly guesses the name of the real file. (probably because this is a common error)

While that is quite cool that TypeScript can make it work, we should nevertheless not rely on compiler cleverness.
