### PR TITLE
Turn Task into an interface

### DIFF
--- a/packages/core/src/controller/iterator-controller.ts
+++ b/packages/core/src/controller/iterator-controller.ts
@@ -1,6 +1,6 @@
 import { Controller } from './controller';
 import { OperationIterator } from '../operation';
-import { Task, Controls } from '../task';
+import { createTask, Task, Controls, getControls } from '../task';
 import { HaltError } from '../halt-error';
 import { Operation } from '../operation';
 import { Trapper } from '../trapper';
@@ -56,9 +56,9 @@ export class IteratorController<TOut> implements Controller<TOut>, Trapper {
         this.controls.resolve(next.value);
       }
     } else {
-      this.subTask = new Task(next.value);
-      this.subTask.addTrapper(this);
-      this.subTask.start();
+      this.subTask = createTask(next.value);
+      getControls(this.subTask).addTrapper(this);
+      getControls(this.subTask).start();
     }
   }
 
@@ -80,7 +80,7 @@ export class IteratorController<TOut> implements Controller<TOut>, Trapper {
     if(!this.didHalt) {
       this.didHalt = true;
       if(this.subTask) {
-        this.subTask.removeTrapper(this);
+        getControls(this.subTask).removeTrapper(this);
         this.subTask.halt();
       }
       this.resume(() => this.iterator.return(undefined));

--- a/packages/core/src/controller/iterator-controller.ts
+++ b/packages/core/src/controller/iterator-controller.ts
@@ -65,11 +65,11 @@ export class IteratorController<TOut> implements Controller<TOut>, Trapper {
   trap(child: Task) {
     if(child.state === 'completed') {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      this.resume(() => this.iterator.next(child.result!));
+      this.resume(() => this.iterator.next(getControls(child).result!));
     }
     if(child.state === 'errored') {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      this.resume(() => this.iterator.throw(child.error!));
+      this.resume(() => this.iterator.throw(getControls(child).error!));
     }
     if(child.state === 'halted') {
       this.resume(() => this.iterator.throw(new HaltError()));

--- a/packages/core/src/effection.ts
+++ b/packages/core/src/effection.ts
@@ -1,13 +1,13 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { Task } from './task';
+import { Task, createTask, getControls } from './task';
 import { version } from '../package.json';
 
 const MAJOR_VERSION = version.split('.')[0];
 const GLOBAL_PROPERTY = `__effectionV${MAJOR_VERSION}`;
 
 function createRootTask() {
-  let task = new Task(undefined, { ignoreChildErrors: true });
-  task.start();
+  let task = createTask(undefined, { ignoreChildErrors: true });
+  getControls(task).start();
   return task;
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,7 +2,8 @@ import { Operation } from './operation';
 import { Task, TaskOptions } from './task';
 import { Effection } from './effection';
 
-export { Task, TaskOptions } from './task';
+export { State, StateTransition } from './state-machine';
+export { createTask, Task, TaskOptions, Controls, getControls } from './task';
 export { Operation } from './operation';
 export { sleep } from './sleep';
 export { Effection } from './effection';

--- a/packages/core/src/state-machine.ts
+++ b/packages/core/src/state-machine.ts
@@ -4,6 +4,11 @@ export type State = 'pending' | 'running' | 'halting' | 'halted' | 'erroring' | 
 
 function f(value: string) { return JSON.stringify(value) };
 
+export type StateTransition = {
+  from: State;
+  to: State;
+};
+
 export class StateMachine {
   current: State = 'pending';
 

--- a/packages/core/src/task.ts
+++ b/packages/core/src/task.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { SuspendController } from './controller/suspend-controller';
 import { PromiseController } from './controller/promise-controller';
 import { FunctionContoller } from './controller/function-controller';
@@ -8,16 +9,11 @@ import { isPromise } from './predicates';
 import { Trapper } from './trapper';
 import { swallowHalt } from './halt-error';
 import { EventEmitter } from 'events';
-import { StateMachine, State } from './state-machine';
+import { StateMachine, State, StateTransition } from './state-machine';
 import { HaltError } from './halt-error';
 
 let COUNTER = 0;
-
-export interface Controls<TOut> {
-  halted(): void;
-  resolve(value: TOut): void;
-  reject(error: Error): void;
-}
+const CONTROLS = Symbol.for('effection/v2/controls');
 
 export interface TaskOptions {
   blockParent?: boolean;
@@ -26,180 +22,221 @@ export interface TaskOptions {
 
 type EnsureHandler = () => void;
 
-export class Task<TOut = unknown> extends EventEmitter implements Promise<TOut>, Trapper {
-  public id = ++COUNTER;
+type WithControls<TOut> = { [CONTROLS]?: Controls<TOut> }
 
-  public readonly children: Set<Task> = new Set();
-  private trappers: Set<Trapper> = new Set();
-  private ensureHandlers: Set<EnsureHandler> = new Set();
+export interface Task<TOut = unknown> extends Promise<TOut> {
+  readonly id: number;
+  readonly state: State;
+  readonly result?: TOut;
+  readonly error?: Error;
+  catchHalt(): Promise<TOut | undefined>;
+  spawn<R>(operation?: Operation<R>, options?: TaskOptions): Task<R>;
+  ensure(fn: EnsureHandler): void;
+  halt(): Promise<void>;
+}
 
-  private controller: Controller<TOut>;
-  private deferred = Deferred<TOut>();
+export interface Controls<TOut = unknown> extends Trapper {
+  readonly options: TaskOptions;
+  readonly children: Set<Task>;
+  start(): void;
+  halted(): void;
+  resolve(value: TOut): void;
+  reject(error: Error): void;
+  link(child: Task): void;
+  unlink(child: Task): void;
+  addTrapper(trapper: Trapper): void;
+  removeTrapper(trapper: Trapper): void;
+  on(name: 'state', listener: (transition: StateTransition) => void): void;
+  on(name: 'link', listener: (child: Task) => void): void;
+  on(name: 'unlink', listener: (child: Task) => void): void;
+  on(name: string, listener: (...args: any[]) => void): void;
+  off(name: 'state', listener: (transition: StateTransition) => void): void;
+  off(name: 'link', listener: (child: Task) => void): void;
+  off(name: 'unlink', listener: (child: Task) => void): void;
+  off(name: string, listener: (...args: any[]) => void): void;
+}
 
-  private stateMachine = new StateMachine(this);
+export function createTask<TOut = unknown>(operation: Operation<TOut>, options: TaskOptions = {}): Task<TOut> {
+  let id = ++COUNTER;
 
-  public result?: TOut;
-  public error?: Error;
+  let children = new Set<Task>();
+  let trappers = new Set<Trapper>();
+  let ensureHandlers = new Set<EnsureHandler>();
+  let emitter = new EventEmitter();
+  let _result: TOut | undefined;
+  let _error: Error | undefined;
 
-  private controls: Controls<TOut> = {
-    resolve: (result: TOut) => {
-      this.stateMachine.resolve();
-      this.result = result;
-      this.haltChildren(false);
-      this.resume();
-    },
+  let stateMachine = new StateMachine(emitter);
 
-    reject: (error: Error) => {
-      this.stateMachine.reject();
-      this.result = undefined; // clear result if it has previously been set
-      this.error = error;
-      this.haltChildren(true);
-      this.resume();
-    },
+  let deferred = Deferred<TOut>();
+  deferred.promise.catch(() => {
+    // prevent uncaught promise warnings
+  });
 
-    halted: () => {
-      this.stateMachine.halt();
-      this.haltChildren(true);
-      this.resume();
-    },
+  function resume() {
+    if(stateMachine.isFinishing && children.size === 0) {
+      stateMachine.finish();
+
+      ensureHandlers.forEach((handler) => handler());
+      trappers.forEach((trapper) => trapper.trap(task as Task));
+
+      ensureHandlers.clear();
+      trappers.clear();
+
+      if(stateMachine.current === 'completed') {
+        // TODO: model state as a union so we do not need this non-null assertion
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        deferred.resolve(_result!);
+      } else if(stateMachine.current === 'halted') {
+        deferred.reject(new HaltError());
+      } else if(stateMachine.current === 'errored') {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        deferred.reject(_error!);
+      }
+    }
   }
 
-  private haltChildren(force: boolean) {
-    for(let child of Array.from(this.children).reverse()) {
-      if(force || !child.options.blockParent) {
+  function haltChildren(force: boolean) {
+    for(let child of Array.from(children).reverse()) {
+      let controls = getControls(child);
+      if(force || !controls.options.blockParent) {
         // Continue halting once the first found child has been fully halted.
         // The child will always have been removed from the Set when this runs.
-        child.addTrapper({ trap: () => this.haltChildren(force) });
+        controls.addTrapper({ trap: () => haltChildren(force) });
         child.halt()
         return;
       }
     }
   }
 
-  get state(): State {
-    return this.stateMachine.current;
-  }
+  let controls: Controls<TOut> = {
+    options,
 
-  constructor(private operation: Operation<TOut>, public options: TaskOptions = {}) {
-    super();
-    if(!operation) {
-      this.controller = new SuspendController(this.controls);
-    } else if(isPromise(operation)) {
-      this.controller = new PromiseController(this.controls, operation);
-    } else if(typeof(operation) === 'function') {
-      this.controller = new FunctionContoller(this.controls, operation);
-    } else {
-      throw new Error(`unkown type of operation: ${operation}`);
-    }
-    this.deferred.promise.catch(() => {
-      // prevent uncaught promise warnings
-    });
-  }
+    children,
 
-  start() {
-    this.stateMachine.start();
-    this.controller.start(this);
-  }
+    start() {
+      stateMachine.start();
+      controller.start(task);
+    },
 
-  private resume() {
-    if(this.stateMachine.isFinishing && this.children.size === 0) {
-      this.stateMachine.finish();
+    resolve: (result: TOut) => {
+      stateMachine.resolve();
+      _result = result;
+      haltChildren(false);
+      resume();
+    },
 
-      this.ensureHandlers.forEach((handler) => handler());
-      this.trappers.forEach((trapper) => trapper.trap(this as Task));
+    reject: (error: Error) => {
+      stateMachine.reject();
+      _result = undefined; // clear result if it has previously been set
+      _error = error;
+      haltChildren(true);
+      resume();
+    },
 
-      this.ensureHandlers.clear();
-      this.trappers.clear();
+    halted: () => {
+      stateMachine.halt();
+      haltChildren(true);
+      resume();
+    },
 
-      if(this.state === 'completed') {
-        // TODO: model state as a union so we do not need this non-null assertion
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        this.deferred.resolve(this.result!);
-      } else if(this.state === 'halted') {
-        this.deferred.reject(new HaltError());
-      } else if(this.state === 'errored') {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        this.deferred.reject(this.error!);
+    link(child) {
+      if(!children.has(child)) {
+        getControls(child).addTrapper(controls);
+        children.add(child);
+        emitter.emit('link', child);
       }
-    }
-  }
+    },
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  then<TResult1 = TOut, TResult2 = never>(onfulfilled?: ((value: TOut) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): Promise<TResult1 | TResult2> {
-    return this.deferred.promise.then(onfulfilled, onrejected);
-  }
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): Promise<TOut | TResult> {
-    return this.deferred.promise.catch(onrejected);
-  }
-
-  catchHalt(): Promise<TOut | undefined> {
-    return this.deferred.promise.catch(swallowHalt);
-  }
-
-  finally(onfinally?: (() => void) | null | undefined): Promise<TOut> {
-    return this.deferred.promise.finally(onfinally);
-  }
-
-  spawn<R>(operation?: Operation<R>, options?: TaskOptions): Task<R> {
-    if(this.state !== 'running') {
-      throw new Error('cannot spawn a child on a task which is not running');
-    }
-    let child = new Task(operation, options);
-    this.link(child as Task);
-    child.start();
-    return child;
-  }
-
-  link(child: Task) {
-    if(!this.children.has(child)) {
-      child.addTrapper(this);
-      this.children.add(child);
-      this.emit('link', child);
-    }
-  }
-
-  unlink(child: Task) {
-    if(this.children.has(child)) {
-      child.removeTrapper(this);
-      this.children.delete(child);
-      this.emit('unlink', child);
-    }
-  }
-
-  trap(child: Task) {
-    if(this.children.has(child)) {
-      if(child.state === 'errored' && !this.options.ignoreChildErrors) {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        this.controls.reject(child.error!);
+    unlink(child) {
+      if(children.has(child)) {
+        getControls(child).removeTrapper(controls);
+        children.delete(child);
+        emitter.emit('unlink', child);
       }
-      this.unlink(child);
-    }
-    this.resume();
+    },
+
+    trap(child) {
+      if(children.has(child)) {
+        if(child.state === 'errored' && !options.ignoreChildErrors) {
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          controls.reject(child.error!);
+        }
+        controls.unlink(child);
+      }
+      resume();
+    },
+
+    addTrapper(trapper) {
+      trappers.add(trapper);
+    },
+
+    removeTrapper(trapper) {
+      trappers.delete(trapper);
+    },
+
+    on: (name: string, listener: (...args: any[]) => void) => { emitter.on(name, listener) },
+    off: (name: string, listener: (...args: any[]) => void) => { emitter.off(name, listener) },
+  };
+
+  let controller: Controller<TOut>;
+
+  if(!operation) {
+    controller = new SuspendController(controls);
+  } else if(isPromise(operation)) {
+    controller = new PromiseController(controls, operation);
+  } else if(typeof(operation) === 'function') {
+    controller = new FunctionContoller(controls, operation);
+  } else {
+    throw new Error(`unkown type of operation: ${operation}`);
   }
 
-  ensure(fn: EnsureHandler) {
-    this.ensureHandlers.add(fn);
+  let task: Task<TOut> & WithControls<TOut> = {
+    id,
+
+    get state() { return stateMachine.current; },
+    get result() { return _result },
+    get error() { return _error },
+
+    catchHalt() {
+      return deferred.promise.catch(swallowHalt);
+    },
+
+    spawn(operation?, options?) {
+      if(stateMachine.current !== 'running') {
+        throw new Error('cannot spawn a child on a task which is not running');
+      }
+      let child = createTask(operation, options);
+      controls.link(child as Task);
+      getControls(child).start();
+      return child;
+    },
+
+    ensure(fn) {
+      ensureHandlers.add(fn);
+    },
+
+    async halt() {
+      controller.halt();
+      await deferred.promise.catch(() => {
+        // TODO: should this catch all errors, or only halt errors?
+        // see https://github.com/jnicklas/mini-effection/issues/23
+      });
+    },
+    then: (...args) => deferred.promise.then(...args),
+    catch: (...args) => deferred.promise.catch(...args),
+    finally: (...args) => deferred.promise.finally(...args),
+    [Symbol.toStringTag]: `[Task ${id}]`,
+    [CONTROLS]: controls,
   }
 
-  addTrapper(trapper: Trapper) {
-    this.trappers.add(trapper);
-  }
+  return task;
+};
 
-  removeTrapper(trapper: Trapper) {
-    this.trappers.delete(trapper);
+export function getControls<TOut>(task: Task<TOut>): Controls<TOut> {
+  let controls = (task as WithControls<TOut>)[CONTROLS];
+  if(!controls) {
+    throw new Error(`EFFECTION INTERNAL ERROR unable to retrieve controls for task ${task}`);
   }
-
-  async halt() {
-    this.controller.halt();
-    await this.catch(() => {
-      // TODO: should this catch all errors, or only halt errors?
-      // see https://github.com/jnicklas/mini-effection/issues/23
-    });
-  }
-
-  get [Symbol.toStringTag](): string {
-    return `[Task ${this.id}]`
-  }
+  return controls;
 }

--- a/packages/core/test/iterator.test.ts
+++ b/packages/core/test/iterator.test.ts
@@ -14,7 +14,6 @@ describe('generator function', () => {
     });
     await expect(task).resolves.toEqual(67);
     expect(task.state).toEqual('completed');
-    expect(task.result).toEqual(67);
   });
 
   it('can compose operations', async () => {
@@ -25,7 +24,6 @@ describe('generator function', () => {
     });
     await expect(task).resolves.toEqual(67);
     expect(task.state).toEqual('completed');
-    expect(task.result).toEqual(67);
   });
 
   it('rejects generator if subtask promise fails', async () => {
@@ -37,7 +35,6 @@ describe('generator function', () => {
     });
     await expect(task).rejects.toEqual(error);
     expect(task.state).toEqual('errored');
-    expect(task.error).toEqual(error);
   });
 
   it('rejects generator if generator creation fails', async () => {
@@ -46,7 +43,6 @@ describe('generator function', () => {
     });
     await expect(task).rejects.toHaveProperty('message', 'boom');
     expect(task.state).toEqual('errored');
-    expect(task.error).toHaveProperty('message', 'boom');
   });
 
   it('rejects generator if subtask operation fails', async () => {
@@ -57,7 +53,6 @@ describe('generator function', () => {
     });
     await expect(task).rejects.toHaveProperty('message', 'boom');
     expect(task.state).toEqual('errored');
-    expect(task.error).toHaveProperty('message', 'boom');
   });
 
   it('can recover from errors in promise', async () => {
@@ -77,7 +72,6 @@ describe('generator function', () => {
     });
     await expect(task).resolves.toEqual(75);
     expect(task.state).toEqual('completed');
-    expect(task.result).toEqual(75);
   });
 
   it('can recover from errors in operation', async () => {
@@ -96,7 +90,6 @@ describe('generator function', () => {
     });
     await expect(task).resolves.toEqual(75);
     expect(task.state).toEqual('completed');
-    expect(task.result).toEqual(75);
   });
 
   it('can halt generator', async () => {
@@ -110,7 +103,6 @@ describe('generator function', () => {
 
     await expect(task).rejects.toHaveProperty('message', 'halted')
     expect(task.state).toEqual('halted');
-    expect(task.result).toEqual(undefined);
   });
 
   it('halts task when halted generator', async () => {
@@ -127,9 +119,7 @@ describe('generator function', () => {
     await expect(task).rejects.toHaveProperty('message', 'halted')
     await expect(child).rejects.toHaveProperty('message', 'halted')
     expect(task.state).toEqual('halted');
-    expect(task.result).toEqual(undefined);
     expect(child && child.state).toEqual('halted');
-    expect(child && child.result).toEqual(undefined);
   });
 
   it('can suspend in finally block', async () => {
@@ -180,7 +170,6 @@ describe('generator function', () => {
 
     await expect(task).rejects.toHaveProperty('message', 'boom');
     expect(task.state).toEqual('errored');
-    expect(task.error).toHaveProperty('message', 'boom');
   });
 
   it('can halt itself', async () => {

--- a/packages/core/test/promise.test.ts
+++ b/packages/core/test/promise.test.ts
@@ -9,7 +9,6 @@ describe('promise', () => {
     let task = run(Promise.resolve(123))
     await expect(task).resolves.toEqual(123);
     expect(task.state).toEqual('completed');
-    expect(task.result).toEqual(123);
   });
 
   it('rejects a failed promise', async () => {
@@ -17,7 +16,6 @@ describe('promise', () => {
     let task = run(Promise.reject(error))
     await expect(task).rejects.toEqual(error);
     expect(task.state).toEqual('errored');
-    expect(task.error).toEqual(error);
   });
 
   it('can halt a promise', async () => {
@@ -28,7 +26,6 @@ describe('promise', () => {
 
     await expect(task).rejects.toHaveProperty('message', 'halted')
     expect(task.state).toEqual('halted');
-    expect(task.result).toEqual(undefined);
   });
 
   describe('function', () => {
@@ -36,7 +33,6 @@ describe('promise', () => {
       let task = run(() => Promise.resolve(123))
       await expect(task).resolves.toEqual(123);
       expect(task.state).toEqual('completed');
-      expect(task.result).toEqual(123);
     });
 
     it('rejects a failed promise', async () => {
@@ -44,7 +40,6 @@ describe('promise', () => {
       let task = run(() => Promise.reject(error))
       await expect(task).rejects.toEqual(error);
       expect(task.state).toEqual('errored');
-      expect(task.error).toEqual(error);
     });
 
     it('can halt a promise', async () => {
@@ -55,7 +50,6 @@ describe('promise', () => {
 
       await expect(task).rejects.toHaveProperty('message', 'halted')
       expect(task.state).toEqual('halted');
-      expect(task.result).toEqual(undefined);
     });
   });
 });

--- a/packages/core/test/resolution.test.ts
+++ b/packages/core/test/resolution.test.ts
@@ -13,7 +13,6 @@ describe('resolution function', () => {
     });
     await expect(task).resolves.toEqual(123);
     expect(task.state).toEqual('completed');
-    expect(task.result).toEqual(123);
   });
 
   it('rejects when reject is called', async () => {
@@ -24,7 +23,6 @@ describe('resolution function', () => {
     });
     await expect(task).rejects.toHaveProperty('message', 'boom');
     expect(task.state).toEqual('errored');
-    expect(task.error).toHaveProperty('message', 'boom');
   });
 
   it('rejects when error is thrown in function', async () => {
@@ -35,7 +33,6 @@ describe('resolution function', () => {
     });
     await expect(task).rejects.toHaveProperty('message', 'boom');
     expect(task.state).toEqual('errored');
-    expect(task.error).toHaveProperty('message', 'boom');
   });
 
   it('can be halted', async () => {
@@ -49,6 +46,5 @@ describe('resolution function', () => {
 
     await expect(task).rejects.toHaveProperty('message', 'halted')
     expect(task.state).toEqual('halted');
-    expect(task.result).toEqual(undefined);
   });
 });

--- a/packages/core/test/run.test.ts
+++ b/packages/core/test/run.test.ts
@@ -2,11 +2,11 @@ import './setup';
 import { describe, it } from 'mocha';
 import * as expect from 'expect';
 
-import { run, Effection, Task } from '../src/index';
+import { run, Effection, Task, getControls } from '../src/index';
 
 describe('run', () => {
   it('adds the new task to the global task', () => {
     let task = run(Promise.resolve(123))
-    expect(Effection.root.children.has(task as Task)).toEqual(true);
+    expect(getControls(Effection.root).children.has(task as Task)).toEqual(true);
   });
 });

--- a/packages/core/test/suspend.test.ts
+++ b/packages/core/test/suspend.test.ts
@@ -20,6 +20,5 @@ describe('suspend', () => {
 
     await expect(task).rejects.toHaveProperty('message', 'halted')
     expect(task.state).toEqual('halted');
-    expect(task.result).toEqual(undefined);
   });
 });

--- a/packages/core/test/task.test.ts
+++ b/packages/core/test/task.test.ts
@@ -2,7 +2,7 @@ import './setup';
 import { describe, it } from 'mocha';
 import * as expect from 'expect';
 
-import { run, sleep, Task } from '../src/index';
+import { run, sleep, createTask, Task, getControls } from '../src/index';
 
 describe('Task', () => {
   describe('ensure', () => {
@@ -62,11 +62,10 @@ describe('Task', () => {
   describe('event: state', () => {
     it('is triggered when a task changes state', async () => {
       let events: { to: string; from: string }[] = []
-      let task = new Task(function*() { sleep(5) });
+      let task = createTask(function*() { sleep(5) });
 
-      task.on('state', (transition) => events.push(transition));
-
-      task.start();
+      getControls(task).on('state', (transition) => events.push(transition));
+      getControls(task).start();
 
       await task;
 
@@ -83,7 +82,7 @@ describe('Task', () => {
       let events: Task[] = []
       let task = run();
 
-      task.on('link', (child) => events.push(child));
+      getControls(task).on('link', (child) => events.push(child));
 
       let child = task.spawn();
 
@@ -96,7 +95,7 @@ describe('Task', () => {
       let events: Task[] = []
       let task = run();
 
-      task.on('unlink', (child) => events.push(child));
+      getControls(task).on('unlink', (child) => events.push(child));
 
       let child = task.spawn(function*() { yield sleep(5); return 1 });
 
@@ -109,7 +108,7 @@ describe('Task', () => {
       let events: Task[] = []
       let task = run();
 
-      task.on('unlink', (child) => events.push(child));
+      getControls(task).on('unlink', (child) => events.push(child));
 
       let child = task.spawn(function*() { yield sleep(5); return 1 });
 

--- a/packages/events/test/once.test.ts
+++ b/packages/events/test/once.test.ts
@@ -39,17 +39,6 @@ describe("once()", () => {
       expect(task.state).toEqual('running');
     });
   });
-
-  describe('shutting down the task and then emitting the event on which it is waiting', () => {
-    beforeEach(function*() {
-      yield task.halt();
-      source.emit('event', 1);
-    });
-
-    it('never returns', function*() {
-      expect(task.result).toBeUndefined();
-    });
-  });
 });
 
 describe('onceEmit()', () => {

--- a/packages/subscription/test/helpers.ts
+++ b/packages/subscription/test/helpers.ts
@@ -1,4 +1,4 @@
-import { Operation, sleep } from '@effection/core';
+import { Operation, sleep, getControls } from '@effection/core';
 
 // TODO: move this to core?
 export function race<T>(...ops: Operation<T>[]): Operation<T> {
@@ -8,10 +8,10 @@ export function race<T>(...ops: Operation<T>[]): Operation<T> {
         let task = scope.spawn(op);
         task.ensure(() => {
           if(task.state === 'completed') {
-            resolve(task.result as T);
+            resolve(getControls(task).result as T);
           }
           if(task.state === 'errored') {
-            reject(task.error as Error);
+            reject(getControls(task).error as Error);
           }
         })
       }


### PR DESCRIPTION
Using an interface allows us more flexibility. The interface is kept intentionally minimal, with a separate interface for the internal controls.

## Motivation

There are a couple of reasons to prefer interfaces over classes:

1. bound functions are nice
2. interfaces allow tighter control over the public API
3. interfaces allow different underlying implementations

Especially the last point is important. For the case of resources we would like to return something which acts mostly like a task, but which actually consists of two tasks meshed together. This will be much easier to achieve when we can fake the interface, rather than having to create a bogus class.

## Approach

We create a very minimal Task interface, which only exposes those operations which should be public, and expand the controls interface to hide all the things which are internal. Some things might move to the public interface at some point.

### Alternate Designs

We could preserve `Task` as a class (something like `TaskInternal`) and have it implement the `Task` interface, as well as the controls, or maybe have a separate class for the controls. This would allow us to 

### Possible Drawbacks or Risks

Allocating a Task should be cheap. In theory, classes make better use of memory, since they do not require an allocation beyond the instance and its instance variables, whereas a bound object would need to allocate both every single bound function, as well as the object itself. However, assuming a sufficiently smart JIT, maybe this is fine?