### PR TITLE
✨ Allow for pending `it()` blocks

### DIFF
--- a/.changeset/pending-mocha-it-blocks.md
+++ b/.changeset/pending-mocha-it-blocks.md
@@ -1,0 +1,5 @@
+---
+"@effection/mocha": patch
+---
+Allow "pending" it blocks that don't yet have a body. E.g.
+`it('willb do this')`;

--- a/.changeset/pending-mocha-it-blocks.md
+++ b/.changeset/pending-mocha-it-blocks.md
@@ -2,4 +2,4 @@
 "@effection/mocha": patch
 ---
 Allow "pending" it blocks that don't yet have a body. E.g.
-`it('willb do this')`;
+`it('will do this')`;

--- a/packages/mocha/src/index.ts
+++ b/packages/mocha/src/index.ts
@@ -7,7 +7,7 @@ let world: Task | undefined;
 type TestFunction = (this: mocha.Context, world: Task, scope: Task) => Generator<Operation<any>, any, any>;
 
 interface ItFunction {
-  (title: string, fn: TestFunction): void;
+  (title: string, fn?: TestFunction): void;
   only(title: string, fn: TestFunction): void;
   skip(title: string, fn: TestFunction): void;
 }
@@ -36,7 +36,7 @@ export const beforeEach = (fn: TestFunction) => mocha.beforeEach(runInWorld(fn))
 export const afterEach = (fn: TestFunction) => mocha.afterEach(runInWorld(fn));
 
 export const it: ItFunction = Object.assign(
-  (title: string, fn: TestFunction) => mocha.it(title, runInWorld(fn)),
+  (title: string, fn?: TestFunction) => mocha.it(title, fn ? runInWorld(fn): fn),
   {
     only: (title: string, fn: TestFunction) => mocha.it.only(title, runInWorld(fn)),
     skip: (title: string, fn: TestFunction) => mocha.it.skip(title, runInWorld(fn)),

--- a/packages/mocha/test/mocha.test.ts
+++ b/packages/mocha/test/mocha.test.ts
@@ -22,6 +22,8 @@ describe('@effection/mocha', () => {
   //   yield sleep(10);
   // });
 
+  it('can have pending tasks (note: this is not actually pending)');
+
   describe('accessing mocha API', () => {
     it('works', function*() {
       this.timeout(100);


### PR DESCRIPTION
Motivation
-----------

Mocha allows for `it()` blocks that do not yet have a body. This is so that you can write out the flow of a testcase before you actually get around to making it work. To support this, the second argument to `mocha.it()` is actually optional.

```js
describe('a thing', () => {
  it('will do this');
  it('will do that');
})
```

Approach
----------
This allows the same construction in `@effection/mocha` by relaxing the requirement for the second argument to `it()`
