### PR TITLE
✨Add a race() combinator

### DIFF
--- a/.changeset/race-combinator.md
+++ b/.changeset/race-combinator.md
@@ -1,0 +1,4 @@
+---
+"@effection/core": minor
+---
+add race() combinator

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,6 +9,7 @@ export { sleep } from './sleep';
 export { Effection } from './effection';
 export { deprecated } from './deprecated';
 export { Deferred } from './deferred';
+export { race } from './race';
 
 export function run<TOut>(operation?: Operation<TOut>, options?: TaskOptions): Task<TOut> {
   return Effection.root.spawn(operation, options);

--- a/packages/core/src/race.ts
+++ b/packages/core/src/race.ts
@@ -1,0 +1,15 @@
+import type { Operation } from './operation';
+
+export function race<T>(operations: Operation<T>[]): Operation<T> {
+  return scope => (resolve, reject) => {
+    for (let operation of operations) {
+      scope.spawn(function*() {
+        try {
+          resolve(yield operation);
+        } catch (error) {
+          reject(error);
+        }
+      })
+    }
+  }
+}

--- a/packages/core/test/race.test.ts
+++ b/packages/core/test/race.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, beforeEach } from 'mocha';
+import * as expect from 'expect';
+
+import { Deferred, Task, race, run } from '../src/index';
+
+describe('race()', () => {
+  let contestants: Deferred<number>[];
+  let task: Task<number>;
+  let draw = () => contestants[Math.floor(Math.random() * contestants.length)];
+
+
+  beforeEach(() => {
+    contestants = Array.from(Array(100)).map(() => Deferred<number>());
+
+    task = run(race(contestants.map(op => op.promise)));
+  });
+
+  describe('when a winner emerges', () => {
+    beforeEach(() => {
+      let winner = draw();
+      winner.resolve(42);
+    });
+
+    it('assumes that result as the race result', async () => {
+      await expect(task).resolves.toBe(42);
+    });
+  });
+
+  describe('when any of the contestants fails', () => {
+    beforeEach(() => {
+      let failer = draw();
+      failer.reject(new Error('kaboom!'));
+    });
+
+    it('rejects the task with the same error', async () => {
+      await expect(task).rejects.toMatchObject({ message: 'kaboom!' });
+    });
+  });
+
+});

--- a/packages/subscription/test/helpers.ts
+++ b/packages/subscription/test/helpers.ts
@@ -1,25 +1,6 @@
-import { Operation, sleep, getControls } from '@effection/core';
-
-// TODO: move this to core?
-export function race<T>(...ops: Operation<T>[]): Operation<T> {
-  return function(scope) {
-    return (resolve, reject) => {
-      for(let op of ops) {
-        let task = scope.spawn(op);
-        task.ensure(() => {
-          if(task.state === 'completed') {
-            resolve(getControls(task).result as T);
-          }
-          if(task.state === 'errored') {
-            reject(getControls(task).error as Error);
-          }
-        })
-      }
-    }
-  }
-}
+import { Operation, race, sleep } from '@effection/core';
 
 export function abortAfter<T>(op: Operation<T>, ms: number): Operation<T | undefined> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return race<any>(sleep(ms), op);
+  return race<any>([sleep(ms), op]);
 }


### PR DESCRIPTION
Motivation
----------

Called for in https://github.com/thefrontside/effection/issues/292

Approach
----------

This adds a `race()` combinator that runs an array of operations in parallel where the first one to complete becomes the result of the race operation.

If any of the operations fail, then the race operation fails.

The API is designed to mirror the functionality of [Promise.race][1] as closely as possible

### Alternate Designs

The `race()` function as implemented is simple in its implementation, but it _will_ spawn all operations _always_. However, if the operation is a resolution function, then there is the possibility that it operation _could_ complete or fail synchronously, and so we might not need even spawn the remaining operations because we have our answer. However, by wrapping each operation in a generator function with `try/catch`, we have eliminated the possibility of detecting this case and short-circuiting. In practice, it's hard to imagine this being an issue unless you are racing thousands and thousands of operations against each other, but I did want to bring it up.

[1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/race