### PR TITLE
Remove delay before starting iterator

### DIFF
--- a/.changeset/empty-sheep-buy.md
+++ b/.changeset/empty-sheep-buy.md
@@ -1,0 +1,6 @@
+---
+"@effection/core": minor
+"effection": minor
+---
+
+Remove delay on starting iterator/generator

--- a/packages/core/src/controller/iterator-controller.ts
+++ b/packages/core/src/controller/iterator-controller.ts
@@ -22,8 +22,7 @@ export class IteratorController<TOut> implements Controller<TOut>, Trapper {
 
   constructor(private controls: Controls<TOut>, private iterator: OperationIterator<TOut> & Claimable) {}
 
-  // make this an async function to delay the first iteration until the next event loop tick
-  async start() {
+  start() {
     if (this.iterator[claimed]) {
       let error = new Error(`An operation iterator can only be run once in a single task, but it looks like has been either yielded to, or run multiple times`)
       error.name = 'DoubleEvalError';


### PR DESCRIPTION
In v2 we started off with a lot of asynchronicity, but the more we did this, the more we realized that synchronous operation is a core part of the workings of effection. It prevents race conditions in criticial portions of the code and allows us to interoperate with callbacks and evented code seamlessly.

This is the last remaining piece of asynchronous execution, where when we step into an iterator controller, we delay the start of execution until the next tick. There is no technical reason to do this, aside from the astheatic of delaying the tick.

Removing this delay puts us on a path towards getting rid of resolution functions entirely, since we now can do both synchronous setup as well as synchronous teardown with generators. This does require a bit of caution when implementing, but this should be mostly restricted to primitives, such as `once`.

Interestingly, the current behaviour has actually caused a potential race condition in `once`, since it is now implemented on top of
`onceEmit` with a generator function. This PR fixes this issue without having to change the code in `@effection/events`.