### PR TITLE
Link subtask

### DIFF
--- a/.changeset/calm-bulldogs-cross.md
+++ b/.changeset/calm-bulldogs-cross.md
@@ -1,0 +1,6 @@
+---
+"@effection/core": minor
+"effection": minor
+---
+
+Add ignoreError option to prevent a task from propagating its errors to the parent

--- a/.changeset/good-parents-itch.md
+++ b/.changeset/good-parents-itch.md
@@ -1,0 +1,6 @@
+---
+"@effection/core": minor
+"effection": minor
+---
+
+Prevent race condition in promise controller if promise resolves in the same tick as halt signal

--- a/.changeset/little-pets-smell.md
+++ b/.changeset/little-pets-smell.md
@@ -1,0 +1,6 @@
+---
+"@effection/core": minor
+"effection": minor
+---
+
+Fix race condition when halting a task while in between yield points

--- a/.changeset/six-otters-bow.md
+++ b/.changeset/six-otters-bow.md
@@ -1,0 +1,6 @@
+---
+"@effection/core": minor
+"effection": minor
+---
+
+When yielded to an asynchronously halting task, wait for the task to be fully halted before proceeding

--- a/.changeset/tiny-taxis-jam.md
+++ b/.changeset/tiny-taxis-jam.md
@@ -1,0 +1,6 @@
+---
+"@effection/core": minor
+"effection": minor
+---
+
+The sub task created by iterators is now linked to the parent task

--- a/packages/core/src/controller/promise-controller.ts
+++ b/packages/core/src/controller/promise-controller.ts
@@ -11,9 +11,7 @@ export function createPromiseController<TOut>(task: Task<TOut>, promise: Promise
   function start() {
     Promise.race([promise, haltSignal.promise]).then(
       (value) => {
-        if(value === HALT) {
-          controls.halted();
-        } else {
+        if(value !== HALT) {
           controls.resolve(value);
         }
       },
@@ -25,6 +23,7 @@ export function createPromiseController<TOut>(task: Task<TOut>, promise: Promise
 
   function halt() {
     haltSignal.resolve(HALT);
+    controls.halted();
   }
 
   return { start, halt };

--- a/packages/core/src/task.ts
+++ b/packages/core/src/task.ts
@@ -14,6 +14,7 @@ const CONTROLS = Symbol.for('effection/v2/controls');
 export interface TaskOptions {
   blockParent?: boolean;
   ignoreChildErrors?: boolean;
+  ignoreError?: boolean;
 }
 
 type WithControls<TOut> = { [CONTROLS]?: Controls<TOut> }
@@ -156,7 +157,7 @@ export function createTask<TOut = unknown>(operation: Operation<TOut>, options: 
 
     trap(child) {
       if(children.has(child)) {
-        if(child.state === 'errored' && !options.ignoreChildErrors) {
+        if(child.state === 'errored' && !getControls(child).options.ignoreError && !options.ignoreChildErrors) {
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           controls.reject(getControls(child).error!);
         }

--- a/packages/core/test/iterator.test.ts
+++ b/packages/core/test/iterator.test.ts
@@ -140,6 +140,32 @@ describe('generator function', () => {
     expect(task.state).toEqual('halted');
   });
 
+  it('can suspend in yielded finally block', async () => {
+    let things: string[] = [];
+
+    let task = run(function*() {
+      try {
+        yield function*() {
+          try {
+            yield
+          } finally {
+            yield sleep(5);
+            things.push("first");
+          }
+        }
+      } finally {
+        things.push("second");
+      }
+    });
+
+    task.halt();
+
+    await expect(task).rejects.toHaveProperty('message', 'halted')
+    expect(task.state).toEqual('halted');
+
+    expect(things).toEqual(['first', 'second']);
+  });
+
   it('can await halt', async () => {
     let didRun = false;
 

--- a/packages/core/test/iterator.test.ts
+++ b/packages/core/test/iterator.test.ts
@@ -206,4 +206,19 @@ describe('generator function', () => {
     await expect(task).rejects.toHaveProperty('message', 'halted');
     expect(task.state).toEqual('halted');
   });
+
+  it('can halt itself between yield points', async () => {
+    let task = run(function*(inner) {
+      yield sleep(1);
+
+      inner.spawn(function*() {
+        inner.halt();
+      });
+
+      yield
+    });
+
+    await expect(task).rejects.toHaveProperty('message', 'halted');
+    expect(task.state).toEqual('halted');
+  });
 });

--- a/packages/core/test/promise.test.ts
+++ b/packages/core/test/promise.test.ts
@@ -28,6 +28,26 @@ describe('promise', () => {
     expect(task.state).toEqual('halted');
   });
 
+  it('can halt a pending promise which will resolve in the next event loop tick', async () => {
+    let promise = Promise.resolve("foo");
+    let task = run(promise);
+
+    task.halt();
+
+    await expect(task).rejects.toHaveProperty('message', 'halted')
+    expect(task.state).toEqual('halted');
+  });
+
+  it('can halt a pending promise which will reject in the next event loop tick', async () => {
+    let promise = Promise.reject(new Error('moo'));
+    let task = run(promise);
+
+    task.halt();
+
+    await expect(task).rejects.toHaveProperty('message', 'halted')
+    expect(task.state).toEqual('halted');
+  });
+
   describe('function', () => {
     it('runs a promise to completion', async () => {
       let task = run(() => Promise.resolve(123))


### PR DESCRIPTION
Depends on #307 

## Motivation

The iterator controller has a subtask, which is the task that it is currently yielded to. This task is a little bit special. Up until now we have not linked this task to the parent task, because a failure in the sub task should be handled by throwing into the generator, rather than throwing into the parent. However, this has the downside that the subtask (and any tasks below it) are not actually part of the task tree. And while we do take great care to clean up the sub task when necessary, it is still not bound to the scope of the parent.

## Approach

With this change, the sub task becomes linked to the parent, and we introduce a new option on a task, which makes it not throw its errors to the parent. This has utility in some other places as well.

### Alternate Designs

It would be nice to be able to just call `task.spawn()` to create the sub task. This was the initial vision, but it is unclear how we can add the trapper before starting the execution of the task.

There was some discussion around the necessity of the option, and whether we can instead make this work through overriding the trapping behaviour, but a clear design did not emerge, and we went with the simpler solution for now.

### Possible Drawbacks or Risks

It introduces a task option which is a bit difficult to understand.