### PR TITLE
Add resources 👊

### DIFF
--- a/.changeset/wicked-melons-bake.md
+++ b/.changeset/wicked-melons-bake.md
@@ -1,0 +1,6 @@
+---
+"@effection/core": minor
+"effection": minor
+---
+
+Add Resource to create an option for spawning tasks in the background in an operation

--- a/packages/core/src/controller/controller.ts
+++ b/packages/core/src/controller/controller.ts
@@ -1,14 +1,15 @@
 import type { Task } from '../task';
 import type { Operation } from '../operation';
-import { isResolution, isPromise, isGenerator } from '../predicates';
+import { isResource, isResolution, isPromise, isGenerator } from '../predicates';
 import { createFunctionController } from './function-controller';
 import { createSuspendController } from './suspend-controller';
 import { createPromiseController } from './promise-controller';
 import { createIteratorController } from './iterator-controller';
 import { createResolutionController } from './resolution-controller';
+import { createResourceController } from './resource-controller';
 
 export interface Controller<TOut> {
-  start(task: Task<TOut>): void;
+  start(): void;
   halt(): void;
 }
 
@@ -17,6 +18,8 @@ export function createController<T>(task: Task<T>, operation: Operation<T>): Con
     return createFunctionController(task, () => createController(task, operation(task)));
   } else if(!operation) {
     return createSuspendController(task);
+  } else if (isResource(operation)) {
+    return createResourceController(task, operation);
   } else if (isResolution(operation)) {
     return createResolutionController(task, operation);
   } else if(isPromise(operation)) {

--- a/packages/core/src/controller/function-controller.ts
+++ b/packages/core/src/controller/function-controller.ts
@@ -5,14 +5,14 @@ export function createFunctionController<TOut>(task: Task<TOut>, createControlle
   let delegate: Controller<TOut>;
   let controls = getControls(task);
 
-  function start(task: Task<TOut>) {
+  function start() {
     try {
       delegate = createController();
     } catch (error) {
       controls.reject(error);
       return;
     }
-    delegate.start(task);
+    delegate.start();
   }
 
   function halt() {

--- a/packages/core/src/controller/iterator-controller.ts
+++ b/packages/core/src/controller/iterator-controller.ts
@@ -11,7 +11,11 @@ interface Claimable {
   [claimed]?: boolean;
 }
 
-export function createIteratorController<TOut>(task: Task<TOut>, iterator: OperationIterator<TOut> & Claimable): Controller<TOut> {
+type Options = {
+  resourceTask?: Task;
+}
+
+export function createIteratorController<TOut>(task: Task<TOut>, iterator: OperationIterator<TOut> & Claimable, options: Options = {}): Controller<TOut> {
   let didHalt = false;
   let didEnter = false;
   let subTask: Task | undefined;
@@ -64,7 +68,7 @@ export function createIteratorController<TOut>(task: Task<TOut>, iterator: Opera
         controls.resolve(next.value);
       }
     } else {
-      subTask = createTask(next.value, { ignoreError: true });
+      subTask = createTask(next.value, { parent: options.resourceTask || task, ignoreError: true });
       getControls(task).link(subTask);
       getControls(subTask).addTrapper(trap);
       getControls(subTask).start();

--- a/packages/core/src/controller/resource-controller.ts
+++ b/packages/core/src/controller/resource-controller.ts
@@ -1,0 +1,31 @@
+import { Controller } from './controller';
+import { createIteratorController } from './iterator-controller';
+import { Resource } from '../operation';
+import { Task, getControls } from '../task';
+
+export function createResourceController<TOut>(task: Task<TOut>, resource: Resource<TOut>): Controller<TOut> {
+  let controls = getControls(task);
+  let delegate: Controller<TOut>;
+  let { parent } = controls.options;
+
+  function start() {
+    if(!parent) {
+      throw new Error('cannot spawn resource in task which has no parent')
+    }
+    let init;
+    try {
+      init = resource.init(parent);
+    } catch(error) {
+      controls.reject(error);
+      return;
+    }
+    delegate = createIteratorController(task, init, { resourceTask: parent });
+    delegate.start();
+  }
+
+  function halt() {
+    delegate.halt();
+  }
+
+  return { start, halt };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,7 +4,7 @@ import { Effection } from './effection';
 
 export { State, StateTransition } from './state-machine';
 export { createTask, Task, TaskOptions, Controls, getControls } from './task';
-export { Operation } from './operation';
+export { Operation, Resource } from './operation';
 export { sleep } from './sleep';
 export { Effection } from './effection';
 export { deprecated } from './deprecated';

--- a/packages/core/src/operation.ts
+++ b/packages/core/src/operation.ts
@@ -11,4 +11,8 @@ export type Continuation<TOut> = PromiseLike<TOut> | OperationIterator<TOut> | O
 
 export type ContinuationFunction<TOut> = (task: Task<TOut>) => Continuation<TOut>;
 
-export type Operation<TOut> = Continuation<TOut> | ContinuationFunction<TOut>;
+export type Operation<TOut> = Continuation<TOut> | ContinuationFunction<TOut> | Resource<TOut>;
+
+export interface Resource<TOut> {
+  init(scope: Task): OperationIterator<TOut>;
+}

--- a/packages/core/src/predicates.ts
+++ b/packages/core/src/predicates.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { OperationResolution } from "./operation";
+import { OperationResolution, Resource } from "./operation";
 
 export function isPromise(value: any): value is PromiseLike<unknown> {
   return value && typeof(value.then) === 'function';
@@ -12,4 +12,8 @@ export function isGenerator(value: any): value is Iterator<unknown> {
 
 export function isResolution<T>(value: any): value is OperationResolution<T> {
   return value && typeof(value.perform) === 'function';
+}
+
+export function isResource<TOut>(value: any): value is Resource<TOut> {
+  return typeof(value) === 'object' && typeof(value.init) === 'function';
 }

--- a/packages/core/src/task.ts
+++ b/packages/core/src/task.ts
@@ -12,6 +12,7 @@ let COUNTER = 0;
 const CONTROLS = Symbol.for('effection/v2/controls');
 
 export interface TaskOptions {
+  parent?: Task;
   blockParent?: boolean;
   ignoreChildErrors?: boolean;
   ignoreError?: boolean;
@@ -111,7 +112,7 @@ export function createTask<TOut = unknown>(operation: Operation<TOut>, options: 
 
     start() {
       stateMachine.start();
-      controller.start(task);
+      controller.start();
     },
 
     resolve: (result: TOut) => {
@@ -189,10 +190,11 @@ export function createTask<TOut = unknown>(operation: Operation<TOut>, options: 
       return deferred.promise.catch(swallowHalt);
     },
 
-    spawn(operation?, options?) {
+    spawn(operation?, options = {}) {
       if(stateMachine.current !== 'running') {
         throw new Error('cannot spawn a child on a task which is not running');
       }
+      options.parent = task;
       let child = createTask(operation, options);
       controls.link(child as Task);
       getControls(child).start();

--- a/packages/core/test/resource.test.ts
+++ b/packages/core/test/resource.test.ts
@@ -1,0 +1,111 @@
+import './setup';
+import { describe, it } from 'mocha';
+import * as expect from 'expect';
+
+import { Task, Resource, run, sleep } from '../src/index';
+
+export const myResource: Resource<{ status: string }> = {
+  *init(scope: Task) {
+    let container = { status: 'pending' }
+    scope.spawn(function*() {
+      yield sleep(5);
+      container.status = 'active';
+    });
+    yield sleep(2)
+    return container;
+  }
+}
+
+export const metaResource: Resource<{ status: string }> = {
+  *init(scope: Task) {
+    return yield scope.spawn(myResource);
+  }
+}
+
+export const magicMetaResource: Resource<{ status: string }> = {
+  *init() {
+    return yield myResource;
+  }
+}
+
+describe('resource', () => {
+  describe('with spawned resource', () => {
+    it('runs resource in task scope', async () => {
+      await run(function*(task) {
+        let result = yield task.spawn(myResource);
+        expect(result.status).toEqual('pending');
+        yield sleep(10);
+        expect(result.status).toEqual('active');
+      });
+    });
+
+    it('terminates resource when task completes', async () => {
+      let result: { status: string } = await run(function*(task) {
+        return yield task.spawn(myResource);
+      });
+      expect(result.status).toEqual('pending');
+      await run(sleep(10));
+      expect(result.status).toEqual('pending'); // is finished, should not switch to active
+    });
+  });
+
+  describe('with yielded resource', () => {
+    it('runs resource in task scope', async () => {
+      await run(function*() {
+        let result = yield myResource;
+        expect(result.status).toEqual('pending');
+        yield sleep(10);
+        expect(result.status).toEqual('active');
+      });
+    });
+
+    it('terminates resource when task completes', async () => {
+      let result: { status: string } = await run(function*() {
+        return yield myResource;
+      });
+      expect(result.status).toEqual('pending');
+      await run(sleep(10));
+      expect(result.status).toEqual('pending'); // is finished, should not switch to active
+    });
+  });
+
+  describe('with resource which spawns other resources', () => {
+    it('runs resource in task scope', async () => {
+      await run(function*() {
+        let result = yield metaResource;
+        expect(result.status).toEqual('pending');
+        yield sleep(10);
+        expect(result.status).toEqual('active');
+      });
+    });
+
+    it('terminates resource when task completes', async () => {
+      let result: { status: string } = await run(function*() {
+        return yield metaResource;
+      });
+      expect(result.status).toEqual('pending');
+      await run(sleep(10));
+      expect(result.status).toEqual('pending'); // is finished, should not switch to active
+    });
+  });
+
+  describe('with resource which yields to other resources', () => {
+    it('runs resource in task scope', async () => {
+      await run(function*() {
+        let result = yield magicMetaResource;
+        expect(result.status).toEqual('pending');
+        yield sleep(10);
+        expect(result.status).toEqual('active');
+      });
+    });
+
+    it('terminates resource when task completes', async () => {
+      let result: { status: string } = await run(function*() {
+        return yield magicMetaResource;
+      });
+      expect(result.status).toEqual('pending');
+      await run(sleep(10));
+      expect(result.status).toEqual('pending'); // is finished, should not switch to active
+    });
+  });
+});


### PR DESCRIPTION
## Motivation

Oftentimes we want to have an operation both continue to keep running, but also be able to interact with it in some fashion. For example, a process might want to be kept running, while we are able to interact with its IO-streams, or send signals to it. There is currently no good solution for this. In v2 we opted for a simple solution whereby we did not add any framework support for this pattern. However, we discovered that we keep using the same pattern over and over, and by adding some framework support for it, we can greatly simplify it and remove a lot of boilerplate.  

## Approach

There is a new interface called `Resource`, implementing a resource looks like this:

``` typescript
let myResource: Resource<string> {
  *init(scope) {
    scope.spawn(function*() { ... }) // keeps running when generator function finishes
    yield sleep(10);
    return "result";
  }
}
```

Resource can be consumed like this:

``` typescript
main(function*(task) {
  yield myResource;
  yield task.spawn(myResource); // alternatively
});
```

### Alternate Designs

We have explored many, many alternate designs to this approach.

In this PR I chose to not create a wrapping task as the scope for the resource. This way tasks spawned by the resource are direct children of its parent. I felt that this wrapping task while *neat* is also simply not necessary, and might get in the way of future ideas, such as a `spawn` resource.

Additionally, this PR has a trick up its sleeve compared to versions we've discussed earlier: yielding to a resource in a resource actually works! This allows one to write resources without a deeper understanding of the scope of things, at the cost of being a bit magical.

### Possible Drawbacks or Risks

It adds complexity, both from an implementation perspective and from a cognitive perspective.

- [ ] Is the magical yield thing to magical?