### PR TITLE
Make throwOnErrorEvent a normal operation

### DIFF
--- a/.changeset/calm-starfishes-wink.md
+++ b/.changeset/calm-starfishes-wink.md
@@ -1,0 +1,6 @@
+---
+"@effection/events": minor
+"effection": minor
+---
+
+Turn throwOnErrorEvent into an operation

--- a/packages/events/src/throw-on-error-event.ts
+++ b/packages/events/src/throw-on-error-event.ts
@@ -1,10 +1,8 @@
-import { Task } from '@effection/core';
+import { Operation } from '@effection/core';
 import { once } from './once';
 import { EventSource } from './event-source';
 
-export function throwOnErrorEvent(task: Task, source: EventSource): Task {
-  return task.spawn(function*() {
-    let error: Error = yield once(source, 'error');
-    throw error;
-  });
+export function *throwOnErrorEvent(source: EventSource): Operation<void> {
+  let error: Error = yield once(source, 'error');
+  throw error;
 }

--- a/packages/events/test/throw-on-error-event.test.ts
+++ b/packages/events/test/throw-on-error-event.test.ts
@@ -14,7 +14,7 @@ describe("throwOnErrorEvent", () => {
   beforeEach(function*(t) {
     emitter = new EventEmitter();
     task = t.spawn(captureError(function*(inner) {
-      throwOnErrorEvent(inner, emitter);
+      inner.spawn(throwOnErrorEvent(emitter));
       yield;
     }));
   });

--- a/packages/fetch/test/echo-server.ts
+++ b/packages/fetch/test/echo-server.ts
@@ -54,7 +54,7 @@ export class EchoServer {
         throw e;
       }
 
-      throwOnErrorEvent(scope, http);
+      scope.spawn(throwOnErrorEvent(http));
       scope.spawn(function*() {
         try {
           yield;


### PR DESCRIPTION
When using this function, it feels odd to have to pass in a task. Making it an ordinary operation seems simpler and better.