### PR TITLE
Make task options public

### DIFF
--- a/.changeset/perfect-badgers-carry.md
+++ b/.changeset/perfect-badgers-carry.md
@@ -1,0 +1,6 @@
+---
+"@effection/core": minor
+"effection": minor
+---
+
+Make task options public

--- a/packages/core/src/controller/resource-controller.ts
+++ b/packages/core/src/controller/resource-controller.ts
@@ -6,7 +6,7 @@ import { Task, getControls } from '../task';
 export function createResourceController<TOut>(task: Task<TOut>, resource: Resource<TOut>): Controller<TOut> {
   let controls = getControls(task);
   let delegate: Controller<TOut>;
-  let { resourceScope } = controls.options;
+  let { resourceScope } = task.options;
 
   function start() {
     if(!resourceScope) {


### PR DESCRIPTION
Previously we slimmed down the task interface significantly, which was good, but there is a case to be made that these options should be publicly *readable* at least. There are already several places in the codebase where we need to do this, but crucially, I ran into this when writing combinators, where the new `resourceScope` option is useful to be able to read out of the options. Using `getControls` in a combinator, which should be implementable by anyone feels a bit wrong, and so therefore I propose making these options part of the `Task` interface.