### PR TITLE
Lock atom dependency versions

### DIFF
--- a/.changeset/real-doors-train.md
+++ b/.changeset/real-doors-train.md
@@ -1,0 +1,5 @@
+---
+"@effection/atom": patch
+---
+
+Lock dependency versions

--- a/packages/atom/package.json
+++ b/packages/atom/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@effection/core": "2.0.0-preview.10",
     "@effection/subscription": "2.0.0-preview.12",
-    "@effection/channel": "^2.0.0-preview.13",
+    "@effection/channel": "2.0.0-preview.13",
     "assert-ts": "^0.2.2",
     "fp-ts": "^2.8.2",
     "monocle-ts": "^2.3.3"


### PR DESCRIPTION
Due to our preview packages still floating around, depending on caret versions is prone to breaking. We need to lock all dependency versions for this reason.