### PR TITLE
Fix monocle import

### DIFF
--- a/.changeset/polite-trains-turn.md
+++ b/.changeset/polite-trains-turn.md
@@ -1,0 +1,5 @@
+---
+"@effection/atom": patch
+---
+
+Use the generic monocle-ts import and not the commonjs import

--- a/packages/atom/src/atom.ts
+++ b/packages/atom/src/atom.ts
@@ -1,5 +1,5 @@
-import * as O from "fp-ts/Option";
-import * as Op from "monocle-ts/lib/Optional"
+import * as O from 'fp-ts/Option';
+import * as Op from 'monocle-ts/Optional'
 import { pipe } from 'fp-ts/function'
 import { Operation } from '@effection/core';
 import { createStream } from '@effection/subscription';


### PR DESCRIPTION
## Motivation

Both monocle-ts and fp-ts have different imports for the different module targets.

anything with `/lib/` will give you commonjs and not the tree-shakable version of the imports.

## Approach

```ts
import * as Op from 'monocle-ts/lib/Optional'
```

becomes

```ts
import * as Op from 'monocle-ts/Optional'
```
