### PR TITLE
Sleeping for zero ms should not suspend indefinitely

### DIFF
--- a/.changeset/eighty-weeks-fix.md
+++ b/.changeset/eighty-weeks-fix.md
@@ -1,0 +1,6 @@
+---
+"@effection/core": patch
+"effection": patch
+---
+
+Sleeping for zero milliseconds should not suspend indefinitely

--- a/packages/core/src/operations/sleep.ts
+++ b/packages/core/src/operations/sleep.ts
@@ -1,7 +1,7 @@
 import { Operation } from '../operation';
 
 export function sleep(duration?: number): Operation<void> {
-  if(duration) {
+  if(duration != null) {
     return {
       perform(resolve) {
         let timeoutId = setTimeout(resolve, duration);

--- a/packages/core/test/operations/sleep.test.ts
+++ b/packages/core/test/operations/sleep.test.ts
@@ -16,6 +16,15 @@ describe('sleep', () => {
     expect(root.state).toEqual('completed');
   });
 
+  it('suspends for zero seconds', async () => {
+    let root = run(function*() {
+      yield sleep(0);
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    expect(root.state).toEqual('completed');
+  });
+
   it('suspends indefinitely', async () => {
     let root = run(function*() {
       yield sleep();


### PR DESCRIPTION
The correct behaviour is to sleep just until the next event loop tick. This is a bug introduced by #292.