### PR TITLE
Add support for labels

### DIFF
--- a/.changeset/hip-files-work.md
+++ b/.changeset/hip-files-work.md
@@ -1,0 +1,6 @@
+---
+"@effection/core": minor
+"effection": minor
+---
+
+Add support for labels

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,6 +8,7 @@ export { Operation, Resource } from './operation';
 export { Effection } from './effection';
 export { deprecated } from './deprecated';
 export { Deferred } from './deferred';
+export { Labels, withLabels } from './labels';
 
 export { sleep } from './operations/sleep';
 export { ensure } from './operations/ensure';
@@ -16,6 +17,7 @@ export { withTimeout } from './operations/with-timeout';
 export { spawn } from './operations/spawn';
 export { race } from './operations/race';
 export { all } from './operations/all';
+export { setLabels } from './operations/set-labels';
 
 export function run<TOut>(operation?: Operation<TOut>, options?: TaskOptions): Task<TOut> {
   return Effection.root.spawn(operation, options);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,7 +17,7 @@ export { withTimeout } from './operations/with-timeout';
 export { spawn } from './operations/spawn';
 export { race } from './operations/race';
 export { all } from './operations/all';
-export { setLabels } from './operations/set-labels';
+export { label } from './operations/label';
 
 export function run<TOut>(operation?: Operation<TOut>, options?: TaskOptions): Task<TOut> {
   return Effection.root.spawn(operation, options);

--- a/packages/core/src/labels.ts
+++ b/packages/core/src/labels.ts
@@ -1,0 +1,10 @@
+import { Operation } from './operation';
+
+export type Labels = Record<string, string | number | boolean>;
+
+export function withLabels<T>(operation: Operation<T>, labels: Labels): Operation<T> {
+  if(operation) {
+    operation.labels = { ...(operation.labels || {}), ...labels };
+  }
+  return operation;
+}

--- a/packages/core/src/operation.ts
+++ b/packages/core/src/operation.ts
@@ -1,18 +1,30 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Task } from './task';
+import { Labels } from './labels';
 
-export type OperationIterator<TOut> = Generator<Operation<any>, TOut | undefined, any>;
+export interface Labelled {
+  name?: string;
+  labels?: Labels;
+}
 
-export interface OperationResolution<TOut> {
+export interface OperationIterator<TOut> extends Generator<Operation<any>, TOut | undefined, any>, Labelled {
+};
+
+export interface OperationPromise<TOut> extends PromiseLike<TOut>, Labelled {
+};
+
+export interface OperationResolution<TOut> extends Labelled {
   perform(resolve: (value: TOut) => void, reject: (err: Error) => void): void | (() => void);
 };
 
-export type Continuation<TOut> = PromiseLike<TOut> | OperationIterator<TOut> | OperationResolution<TOut> | undefined;
-
-export type ContinuationFunction<TOut> = (task: Task<TOut>) => Continuation<TOut>;
-
-export type Operation<TOut> = Continuation<TOut> | ContinuationFunction<TOut> | Resource<TOut>;
-
-export interface Resource<TOut> {
+export interface Resource<TOut> extends Labelled {
   init(scope: Task, local: Task): OperationIterator<TOut>;
 }
+
+export type OperationValue<TOut> = OperationPromise<TOut> | OperationIterator<TOut> | OperationResolution<TOut> | undefined;
+
+export interface OperationFunction<TOut> extends Labelled {
+  (task: Task<TOut>): OperationValue<TOut>;
+}
+
+export type Operation<TOut> = OperationValue<TOut> | OperationFunction<TOut> | Resource<TOut>;

--- a/packages/core/src/operations/all.ts
+++ b/packages/core/src/operations/all.ts
@@ -1,13 +1,14 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type { Operation } from '../operation';
 import type { Task } from '../task';
+import { withLabels } from '../labels';
 
 type All<T extends Operation<any>[]> = {
   [P in keyof T]: T[P] extends Operation<infer TArg> ? TArg : never;
 }
 
 export function all<T extends Operation<any>[]>(operations: T): Operation<All<T>> {
-  return function*(scope) {
+  return withLabels(function*(scope) {
     let tasks: Task<unknown>[] = [];
     let results: unknown[] = [];
     for (let operation of operations) {
@@ -19,5 +20,5 @@ export function all<T extends Operation<any>[]>(operations: T): Operation<All<T>
       results.push(yield task);
     }
     return results as All<T>;
-  };
+  }, { name: 'all', count: operations.length });
 }

--- a/packages/core/src/operations/ensure.ts
+++ b/packages/core/src/operations/ensure.ts
@@ -2,6 +2,7 @@ import { Operation, Resource } from '../operation';
 
 export function ensure<T>(fn: () => Operation<T> | void): Resource<undefined> {
   return {
+    name: 'ensure',
     *init(scope) {
       scope.spawn(function*() {
         try {
@@ -12,7 +13,7 @@ export function ensure<T>(fn: () => Operation<T> | void): Resource<undefined> {
             yield result;
           }
         }
-      });
+      }, { labels: { name: 'ensureHandler' } });
       return undefined;
     }
   };

--- a/packages/core/src/operations/label.ts
+++ b/packages/core/src/operations/label.ts
@@ -2,8 +2,9 @@ import { getControls } from '../task';
 import { Resource } from '../operation';
 import { Labels } from '../labels';
 
-export function setLabels(labels: Labels): Resource<void> {
+export function label(labels: Labels): Resource<void> {
   return {
+    name: 'label',
     *init(scope) {
       getControls(scope).setLabels(labels);
     }

--- a/packages/core/src/operations/race.ts
+++ b/packages/core/src/operations/race.ts
@@ -1,7 +1,8 @@
 import type { Operation } from '../operation';
+import { withLabels } from '../labels';
 
 export function race<T>(operations: Operation<T>[]): Operation<T> {
-  return (scope) => ({
+  return withLabels((scope) => ({
     perform: (resolve, reject) => {
       for (let operation of operations) {
         if(scope.state === 'running') {
@@ -15,5 +16,5 @@ export function race<T>(operations: Operation<T>[]): Operation<T> {
         }
       }
     }
-  });
+  }), { name: 'race', count: operations.length });
 }

--- a/packages/core/src/operations/set-labels.ts
+++ b/packages/core/src/operations/set-labels.ts
@@ -1,0 +1,11 @@
+import { getControls } from '../task';
+import { Resource } from '../operation';
+import { Labels } from '../labels';
+
+export function setLabels(labels: Labels): Resource<void> {
+  return {
+    *init(scope) {
+      getControls(scope).setLabels(labels);
+    }
+  }
+}

--- a/packages/core/src/operations/sleep.ts
+++ b/packages/core/src/operations/sleep.ts
@@ -1,9 +1,10 @@
 import { Operation } from '../operation';
 
 export function sleep(duration?: number): Operation<void> {
-  if(duration != null) {
-    return {
-      perform(resolve) {
+  return {
+    labels: { name: 'sleep', duration: (duration != null) ? duration : 'forever' },
+    perform(resolve) {
+      if(duration != null) {
         let timeoutId = setTimeout(resolve, duration);
         return () => clearTimeout(timeoutId);
       }

--- a/packages/core/src/operations/spawn.ts
+++ b/packages/core/src/operations/spawn.ts
@@ -16,5 +16,5 @@ export function spawn<T>(operation?: Operation<T>): Spawn<T> {
     }
   }
 
-  return { init, within };
+  return { init, within, name: 'spawn' };
 }

--- a/packages/core/src/operations/timeout.ts
+++ b/packages/core/src/operations/timeout.ts
@@ -1,11 +1,14 @@
 import { Operation } from '../operation';
 import { sleep } from './sleep';
+import { withLabels } from '../labels';
 
 class TimeoutError extends Error {
   name = "TimeoutError"
 }
 
-export function *timeout(duration: number): Operation<never> {
-  yield sleep(duration)
-  throw new TimeoutError(`timed out after ${duration}ms`);
+export function timeout(duration: number): Operation<never> {
+  return withLabels(function*() {
+    yield sleep(duration)
+    throw new TimeoutError(`timed out after ${duration}ms`);
+  }, { name: 'timeout', duration });
 }

--- a/packages/core/src/operations/with-timeout.ts
+++ b/packages/core/src/operations/with-timeout.ts
@@ -1,9 +1,10 @@
 import { Operation } from '../operation';
 import { timeout } from './timeout';
+import { withLabels } from '../labels';
 
 export function withTimeout<T>(duration: number, operation: Operation<T>): Operation<T> {
-  return function*(task) {
+  return withLabels(function*(task) {
     task.spawn(timeout(duration));
     return yield operation;
-  };
+  }, { name: 'withTimeout', duration });
 }

--- a/packages/core/src/task.ts
+++ b/packages/core/src/task.ts
@@ -17,6 +17,7 @@ export interface TaskOptions {
   readonly blockParent?: boolean;
   readonly ignoreChildErrors?: boolean;
   readonly ignoreError?: boolean;
+  readonly labels?: Labels;
 }
 
 type WithControls<TOut> = { [CONTROLS]?: Controls<TOut> }
@@ -186,7 +187,7 @@ export function createTask<TOut = unknown>(operation: Operation<TOut>, options: 
 
   let controller: Controller<TOut>;
 
-  let labels = operation?.labels || {};
+  let labels: Labels = { ...operation?.labels, ...options.labels }
 
   if(!labels.name && operation?.name) {
     labels.name = operation?.name;

--- a/packages/core/test/labels.test.ts
+++ b/packages/core/test/labels.test.ts
@@ -1,0 +1,73 @@
+import './setup';
+import { describe, it } from 'mocha';
+import * as expect from 'expect';
+
+import { withLabels, run, getControls, sleep, setLabels, Labels } from '../src/index';
+
+describe('labels', () => {
+  describe('withLabels', () => {
+    it('applies labels to an operation', async () => {
+      let someOperation = withLabels(function*() { /* no op */ }, { bar: "baz" });
+
+      await expect(someOperation?.labels).toEqual({ bar: "baz" });
+    });
+
+    it('merges with existing labels', async () => {
+      let someOperation = withLabels(
+        withLabels(
+          function*() { /* no op */ },
+          { foo: "foo", bar: "bar" }
+        ),
+        { foo: "quox", blah: "blah" }
+      );
+
+      await expect(someOperation?.labels).toEqual({ foo: "quox", bar: "bar", blah: "blah" });
+    });
+  });
+
+  it('applies labels on task', async () => {
+    let task = run(withLabels(
+      function*() { yield },
+      { foo: "bar" }
+    ));
+
+    await expect(task.labels).toEqual({ foo: "bar" });
+  });
+
+  it('applies name label from function name', async () => {
+    let task = run(function* blahBlah() { /* no op */ });
+
+    await expect(task.labels).toEqual({ name: "blahBlah" });
+  });
+
+  it('applies name label from other name', async () => {
+    let task = run({ perform: () => { /* no op */ }, name: "doSomething" });
+
+    await expect(task.labels).toEqual({ name: "doSomething" });
+  });
+
+  it('can change labels dynamically', async () => {
+    let task = run(function*() {
+      yield sleep(5);
+      yield setLabels({ foo: "bar" });
+      yield sleep(10);
+      yield setLabels({ quox: "quox" });
+    });
+
+    let events: Labels[] = []
+
+    getControls(task).on('labels', (labels) => events.push(labels));
+
+    expect(task.labels).toEqual({});
+
+    await run(sleep(10));
+
+    expect(task.labels).toEqual({ foo: "bar" });
+    expect(events).toEqual([{ foo: "bar" }]);
+
+    await run(sleep(10));
+
+    expect(task.labels).toEqual({ foo: "bar", quox: "quox" });
+    expect(events).toEqual([{ foo: "bar" }, { foo: "bar", quox: "quox" }]);
+  });
+});

--- a/packages/core/test/labels.test.ts
+++ b/packages/core/test/labels.test.ts
@@ -23,13 +23,19 @@ describe('labels', () => {
 
       await expect(someOperation?.labels).toEqual({ foo: "quox", bar: "bar", blah: "blah" });
     });
+
+    it('applies labels on task', async () => {
+      let task = run(withLabels(
+        function*() { yield },
+        { foo: "bar" }
+      ));
+
+      await expect(task.labels).toEqual({ foo: "bar" });
+    });
   });
 
-  it('applies labels on task', async () => {
-    let task = run(withLabels(
-      function*() { yield },
-      { foo: "bar" }
-    ));
+  it('can apply labels when spawning', async () => {
+    let task = run(function*() { yield }, { labels: { foo: "bar" } });
 
     await expect(task.labels).toEqual({ foo: "bar" });
   });

--- a/packages/core/test/labels.test.ts
+++ b/packages/core/test/labels.test.ts
@@ -2,7 +2,7 @@ import './setup';
 import { describe, it } from 'mocha';
 import * as expect from 'expect';
 
-import { withLabels, run, getControls, sleep, setLabels, Labels } from '../src/index';
+import { withLabels, run, getControls, sleep, label, Labels } from '../src/index';
 
 describe('labels', () => {
   describe('withLabels', () => {
@@ -55,9 +55,9 @@ describe('labels', () => {
   it('can change labels dynamically', async () => {
     let task = run(function*() {
       yield sleep(5);
-      yield setLabels({ foo: "bar" });
+      yield label({ foo: "bar" });
       yield sleep(10);
-      yield setLabels({ quox: "quox" });
+      yield label({ quox: "quox" });
     });
 
     let events: Labels[] = []

--- a/packages/core/test/operations/all.test.ts
+++ b/packages/core/test/operations/all.test.ts
@@ -60,4 +60,8 @@ describe('all()', () => {
 
     await expect(result).rejects.toHaveProperty('message', 'boom: bar');
   });
+
+  it('applies labels', () => {
+    expect(run(all([syncResolve("foo")])).labels).toEqual({ name: 'all', count: 1 });
+  });
 });

--- a/packages/core/test/operations/race.test.ts
+++ b/packages/core/test/operations/race.test.ts
@@ -44,4 +44,8 @@ describe('race()', () => {
 
     await expect(result).rejects.toHaveProperty('message', 'boom: foo');
   });
+
+  it('applies labels', () => {
+    expect(run(race([syncResolve("foo")])).labels).toEqual({ name: 'race', count: 1 });
+  });
 });

--- a/packages/core/test/operations/sleep.test.ts
+++ b/packages/core/test/operations/sleep.test.ts
@@ -33,4 +33,10 @@ describe('sleep', () => {
     await new Promise((resolve) => setTimeout(resolve, 5));
     expect(root.state).toEqual('running');
   });
+
+  it('applies labels', () => {
+    expect(run(sleep()).labels).toEqual({ name: 'sleep', duration: 'forever' });
+    expect(run(sleep(0)).labels).toEqual({ name: 'sleep', duration: 0 });
+    expect(run(sleep(100)).labels).toEqual({ name: 'sleep', duration: 100 });
+  });
 });

--- a/packages/core/test/operations/timeout.test.ts
+++ b/packages/core/test/operations/timeout.test.ts
@@ -14,4 +14,8 @@ describe('timeout', () => {
     expect(root.state).toEqual('errored');
     await expect(root).rejects.toHaveProperty('message', 'timed out after 10ms');
   });
+
+  it('applies labels', () => {
+    expect(run(timeout(200)).labels).toEqual({ name: 'timeout', duration: 200 });
+  });
 });

--- a/packages/core/test/operations/with-timeout.test.ts
+++ b/packages/core/test/operations/with-timeout.test.ts
@@ -22,4 +22,8 @@ describe('withTimeout', () => {
 
     await expect(root).rejects.toHaveProperty('message', 'timed out after 5ms');
   });
+
+  it('applies labels', () => {
+    expect(run(withTimeout(200, function*() { /* no op */ })).labels).toEqual({ name: 'withTimeout', duration: 200 });
+  });
 });


### PR DESCRIPTION
See #329 

This adds support for tagging operations and running tasks with labels. If an operation has been tagged with labels, these labels are automatically transferred to the task when it is created. Additionally labels can be changed at runtime on a task, via the `setLabels` operation.

Labels can either be set statically like this:

``` typescript
let myOperation = withLabels(function*() { ... }, { some: "label" });
```

Or dynamically like this:

``` typescript
let myOperation = function*() {
  yield setLabels({ some: "label" });
}
```

Or when spawning like this:

``` typescript
yield spawn(function*() {}, { labels: { some: "label" } });
```

The latter makes it possible to tag a task with a label which was discovered while the task was running. This can also be useful to track the progress of an operation.