### PR TITLE
Add task type for better diagnostics

### DIFF
--- a/.changeset/brave-tools-hear.md
+++ b/.changeset/brave-tools-hear.md
@@ -1,0 +1,6 @@
+---
+"@effection/core": minor
+"effection": minor
+---
+
+Add type to task

--- a/packages/core/src/controller/controller.ts
+++ b/packages/core/src/controller/controller.ts
@@ -9,6 +9,7 @@ import { createResolutionController } from './resolution-controller';
 import { createResourceController } from './resource-controller';
 
 export interface Controller<TOut> {
+  type: string;
   start(): void;
   halt(): void;
 }

--- a/packages/core/src/controller/function-controller.ts
+++ b/packages/core/src/controller/function-controller.ts
@@ -22,5 +22,11 @@ export function createFunctionController<TOut>(task: Task<TOut>, createControlle
     delegate.halt();
   }
 
-  return { start, halt };
+  return {
+    get type() {
+      return delegate.type === 'promise' ? 'async function' : `${delegate.type} function`;
+    },
+    start,
+    halt,
+  }
 }

--- a/packages/core/src/controller/iterator-controller.ts
+++ b/packages/core/src/controller/iterator-controller.ts
@@ -101,5 +101,5 @@ export function createIteratorController<TOut>(task: Task<TOut>, iterator: Opera
     }
   }
 
-  return { start, halt };
+  return { start, halt, type: 'generator' };
 }

--- a/packages/core/src/controller/promise-controller.ts
+++ b/packages/core/src/controller/promise-controller.ts
@@ -26,5 +26,5 @@ export function createPromiseController<TOut>(task: Task<TOut>, promise: Promise
     controls.halted();
   }
 
-  return { start, halt };
+  return { start, halt, type: 'promise' };
 }

--- a/packages/core/src/controller/resolution-controller.ts
+++ b/packages/core/src/controller/resolution-controller.ts
@@ -20,5 +20,5 @@ export function createResolutionController<TOut>(task: Task<TOut>, resolution: O
     controls.halted();
   }
 
-  return { start, halt };
+  return { start, halt, type: 'resolution' };
 }

--- a/packages/core/src/controller/resource-controller.ts
+++ b/packages/core/src/controller/resource-controller.ts
@@ -27,5 +27,5 @@ export function createResourceController<TOut>(task: Task<TOut>, resource: Resou
     delegate.halt();
   }
 
-  return { start, halt };
+  return { start, halt, type: 'resource' };
 }

--- a/packages/core/src/controller/suspend-controller.ts
+++ b/packages/core/src/controller/suspend-controller.ts
@@ -12,5 +12,5 @@ export function createSuspendController<TOut>(task: Task<TOut>): Controller<TOut
     controls.halted();
   }
 
-  return { start, halt };
+  return { start, halt, type: 'suspend' };
 }

--- a/packages/core/src/task.ts
+++ b/packages/core/src/task.ts
@@ -23,6 +23,7 @@ type EnsureHandler = () => void;
 
 export interface Task<TOut = unknown> extends Promise<TOut> {
   readonly id: number;
+  readonly type: string;
   readonly state: State;
   readonly options: TaskOptions;
   catchHalt(): Promise<TOut | undefined>;
@@ -184,6 +185,8 @@ export function createTask<TOut = unknown>(operation: Operation<TOut>, options: 
     options,
 
     get state() { return stateMachine.current; },
+
+    get type() { return controller.type },
 
     catchHalt() {
       return deferred.promise.catch(swallowHalt);

--- a/packages/core/test/task.test.ts
+++ b/packages/core/test/task.test.ts
@@ -5,6 +5,18 @@ import * as expect from 'expect';
 import { run, sleep, createTask, Task, getControls } from '../src/index';
 
 describe('Task', () => {
+  describe('type', () => {
+    it('returns the type of the task', async () => {
+      expect(run(Promise.resolve(123)).type).toEqual('promise');
+      expect(run(() => Promise.resolve(123)).type).toEqual('async function');
+      expect(run(function*() { /* no op */ }).type).toEqual('generator function');
+      expect(run((function*() { /* no op */ })()).type).toEqual('generator');
+      expect(run().type).toEqual('suspend');
+      expect(run({ perform() { /* no op */ } }).type).toEqual('resolution');
+      expect(run({ *init() { /* no op */ } }).type).toEqual('resource');
+    });
+  });
+
   describe('ensure', () => {
     it('attaches a handler which runs when the task finishes normally', async () => {
       let task = run(sleep(10));


### PR DESCRIPTION
One useful bit of information that we might want to show in the debugger is what kind of operation the task is running. This adds a simple getter which allows us to read whether the task is running for example a promise or a generator