### PR TITLE
Add websocket client package

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
       "packages/atom",
       "packages/node",
       "packages/fetch",
+      "packages/websocket-client",
       "packages/effection"
     ]
   },

--- a/packages/websocket-client/README.md
+++ b/packages/websocket-client/README.md
@@ -1,0 +1,23 @@
+# @effection/websocket-client
+
+A basic websocket client for sending and receiving messages over a websocket
+connection.  Works both in the browser and in node. The client is oppinionated
+in that it assumes that the messages are serialized as JSON.
+
+## Usage
+
+``` typescript
+import { createWebSocketClient, WebSocketClient } from '@effection/websocket-client';
+import { main } from '@effection/node';
+
+type Request = { value: string };
+type Response = { value: number };
+
+main(function* () {
+  let client: WebSocketClient<Request, Response> = yield createWebSocketClient('ws://localhost:1234');
+
+  yield client.forEach(({ value }) {
+    client.send({ value: parseInt(value) });
+  });
+});
+```

--- a/packages/websocket-client/package.json
+++ b/packages/websocket-client/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@effection/websocket-client",
+  "version": "2.0.0-preview.1",
+  "description": "A websocket client for Effection in node and browser",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "module": "dist/events.esm.js",
+  "repository": "https://github.com/thefrontside/bigtest.git",
+  "author": "Frontside Engineering <engineering@frontside.com>",
+  "license": "MIT",
+  "files": [
+    "README.md",
+    "CHANGELOG.md",
+    "dist/**/*",
+    "src/**/*"
+  ],
+  "scripts": {
+    "lint": "eslint '{src,tests}/**/*.ts'",
+    "test": "mocha -r ts-node/register test/**/*.test.ts",
+    "prepack": "tsdx build --tsconfig tsconfig.dist.json",
+    "mocha": "mocha -r ts-node/register"
+  },
+  "dependencies": {
+    "@effection/core": "2.0.0-preview.10",
+    "@effection/subscription": "2.0.0-preview.12",
+    "@effection/events": "2.0.0-preview.11",
+    "isomorphic-ws": "^4.0.1"
+  },
+  "devDependencies": {
+    "@effection/mocha": "2.0.0-preview.11",
+    "@frontside/tsconfig": "0.0.1",
+    "@types/node": "^13.13.5",
+    "@types/ws": "^7.4.4",
+    "expect": "^25.4.0",
+    "mocha": "^8.3.1",
+    "ts-node": "^8.9.0",
+    "tsdx": "0.13.2",
+    "typescript": "^3.7.0",
+    "ws": "^7.4.6"
+  },
+  "volta": {
+    "node": "12.16.0",
+    "yarn": "1.19.1"
+  }
+}

--- a/packages/websocket-client/src/index.ts
+++ b/packages/websocket-client/src/index.ts
@@ -1,0 +1,43 @@
+import * as WebSocket from 'isomorphic-ws';
+
+import { spawn, ensure, Resource, Operation } from '@effection/core'
+import { createQueue, Subscription } from '@effection/subscription';
+import { on, once } from '@effection/events';
+
+export interface WebSocketClient<TIncoming = unknown, TOutgoing = TIncoming> extends Subscription<TIncoming> {
+  send(message: TOutgoing): Operation<void>;
+}
+
+export function createWebSocketClient<TIncoming = unknown, TOutgoing = TIncoming>(url: string): Resource<WebSocketClient<TIncoming, TOutgoing>> {
+  return {
+    *init() {
+      let socket = new WebSocket(url);
+
+      yield once(socket, 'open');
+
+      let queue = createQueue<TIncoming>();
+
+      yield spawn(function*() {
+        yield spawn(on<{ data: string }>(socket, 'message').forEach((message) => {
+          queue.send(JSON.parse(message.data));
+        }));
+        yield ensure(() => { socket.close() });
+
+        let { wasClean, code, reason } = yield once(socket, 'close');
+
+        if(wasClean) {
+          queue.close();
+        } else {
+          throw new Error(`websocket server closed connection unexpectedly: [${code}] ${reason}`);
+        }
+      });
+
+      return {
+        ...queue.subscription,
+        *send(message: TOutgoing) {
+          socket.send(JSON.stringify(message));
+        }
+      }
+    }
+  }
+}

--- a/packages/websocket-client/test/websocket.test.ts
+++ b/packages/websocket-client/test/websocket.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, beforeEach } from '@effection/mocha';
+import * as expect from 'expect'
+import * as http from 'http'
+import type { AddressInfo } from 'net'
+import { spawn, ensure } from '@effection/core';
+import { on, once } from '@effection/events';
+
+import * as WebSocket from 'ws';
+import { Server as WebSocketServer } from 'ws';
+
+import { createWebSocketClient, WebSocketClient } from '../src/index';
+
+type Message = { value: string };
+
+describe("createWebSocketClient()", () => {
+  let server: http.Server;
+
+  beforeEach(function*() {
+    server = http.createServer();
+    let wss = new WebSocketServer({ server: server });
+
+    yield spawn(on<WebSocket>(wss, 'connection').forEach((connection) => (
+      on<{ data: string }>(connection, 'message').forEach((message) => {
+        let { value }: Message = JSON.parse(message.data);
+        connection.send(JSON.stringify({ value: value.toUpperCase() }));
+      })
+    )));
+
+    server.listen();
+
+    yield ensure(() => { server.close() });
+    yield once(server, 'listening');
+  });
+
+  it('can send and receive messages', function*() {
+    let { port } = server.address() as AddressInfo;
+    let client: WebSocketClient<Message> = yield createWebSocketClient<Message>(`ws://localhost:${port}`);
+
+    yield client.send({ value: 'hello' });
+    yield client.send({ value: 'world' });
+
+    expect(yield client.expect()).toEqual({ value: 'HELLO' });
+    expect(yield client.expect()).toEqual({ value: 'WORLD' });
+  });
+});

--- a/packages/websocket-client/tsconfig.dist.json
+++ b/packages/websocket-client/tsconfig.dist.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "module": "esnext"
+  },
+  "exclude": ["./test/*"]
+}

--- a/packages/websocket-client/tsconfig.json
+++ b/packages/websocket-client/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "@frontside/tsconfig",
+  "include": [
+    "src/**/*.ts",
+    "test/**/*.ts"
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1522,6 +1522,13 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.0.tgz#7036640b4e21cc2f259ae826ce843d277dad8cff"
   integrity sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==
 
+"@types/ws@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-7.4.4.tgz#93e1e00824c1de2608c30e6de4303ab3b4c0c9bc"
+  integrity sha512-d/7W23JAXPodQNbOZNXvl2K+bqAQrCMwlh/nuQsPSQk6Fq0opHoPrUw43aHsvSbIiQPr8Of2hkFbnz1XBFVyZQ==
+  dependencies:
+    "@types/node" "*"
+
 "@types/yargs-parser@*":
   version "20.2.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-20.2.0.tgz#dd3e6699ba3237f0348cd085e4698780204842f9"
@@ -4509,6 +4516,11 @@ isobject@^3.0.0, isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
+
+isomorphic-ws@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz#55fd4cd6c5e6491e76dc125938dd863f5cd4f2dc"
+  integrity sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==
 
 isstream@~0.1.2:
   version "0.1.2"
@@ -8215,6 +8227,11 @@ ws@^5.2.0:
   integrity sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==
   dependencies:
     async-limiter "~1.0.0"
+
+ws@^7.4.6:
+  version "7.4.6"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
+  integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==
 
 xml-name-validator@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
This is a websocket client using the `isomorphic-ws` package, which works on both node and the browser (in theory). So it should provide an implementation which works in either environment.