### PR TITLE
Upgrade ctrlc-windows to 2.0.0 for Effection v1

### DIFF
--- a/.changeset/witty-houses-sell.md
+++ b/.changeset/witty-houses-sell.md
@@ -1,0 +1,5 @@
+---
+"@effection/node": patch
+---
+
+Upgrade ctrlc-windows to 2.0.0

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -35,7 +35,7 @@
     "@effection/events": "^1.0.0",
     "@effection/subscription": "^1.0.0",
     "cross-spawn": "^7.0.3",
-    "ctrlc-windows": "^1.0.3",
+    "ctrlc-windows": "^2.0.0",
     "effection": "^1.0.0",
     "shellwords": "^0.1.1"
   },


### PR DESCRIPTION
## Motivation
To include changes introduced in [ctrlc-windows #26](https://github.com/thefrontside/ctrlc-windows/pull/26). Now it supports node 16 as well as node 14, 12, and 10.

## Approach
- Bump the dependency of `ctrlc-windows` inside `@effection/node` to `^2.0.0`
- Add patch changeset