### PR TITLE
Don't require full EventEmitter interface

### DIFF
--- a/.changeset/four-hornets-lay.md
+++ b/.changeset/four-hornets-lay.md
@@ -1,0 +1,6 @@
+---
+"@effection/events": minor
+"effection": minor
+---
+
+Do not require implementation of full EventEmitter interface

--- a/packages/events/src/event-source.ts
+++ b/packages/events/src/event-source.ts
@@ -1,9 +1,9 @@
 import { EventEmitter } from 'events';
 
-export type EventSource = EventEmitter | DOMEventTarget
+export type EventSource = EventEmitterSource | EventTargetSource
 
-function isEventTarget(target: EventSource): target is DOMEventTarget {
-  return typeof (target as DOMEventTarget).addEventListener === 'function';
+function isEventTarget(target: EventSource): target is EventTargetSource {
+  return typeof (target as EventTargetSource).addEventListener === 'function';
 }
 
 export function addListener(source: EventSource, name: string, listener: () => void) {
@@ -22,7 +22,12 @@ export function removeListener(source: EventSource, name: string, listener: () =
   }
 }
 
-interface DOMEventTarget {
+interface EventTargetSource {
   addEventListener: EventTarget["addEventListener"];
   removeEventListener: EventTarget["removeEventListener"];
+}
+
+interface EventEmitterSource {
+  on: EventEmitter["on"];
+  off: EventEmitter["off"];
 }


### PR DESCRIPTION
The EventEmitter interface is large, but types may implement part of the EventEmitter API and still be usable as event sources, we really only need `on` and `off`.