### PR TITLE
Simplify EventEmitter types on controls

### DIFF
--- a/.changeset/lemon-plums-sparkle.md
+++ b/.changeset/lemon-plums-sparkle.md
@@ -1,0 +1,6 @@
+---
+"@effection/core": minor
+"effection": minor
+---
+
+Simplify EventEmitter types on Controls.

--- a/packages/core/src/task.ts
+++ b/packages/core/src/task.ts
@@ -5,7 +5,7 @@ import { Deferred } from './deferred';
 import { Trapper } from './trapper';
 import { swallowHalt } from './halt-error';
 import { EventEmitter } from 'events';
-import { StateMachine, State, StateTransition } from './state-machine';
+import { StateMachine, State } from './state-machine';
 import { HaltError } from './halt-error';
 import { Labels } from './labels';
 
@@ -49,14 +49,8 @@ export interface Controls<TOut = unknown> {
   removeTrapper(trapper: Trapper): void;
   trap: Trapper;
   setLabels(labels: Labels): void;
-  on(name: 'state', listener: (transition: StateTransition) => void): void;
-  on(name: 'link', listener: (child: Task) => void): void;
-  on(name: 'unlink', listener: (child: Task) => void): void;
-  on(name: string, listener: (...args: any[]) => void): void;
-  off(name: 'state', listener: (transition: StateTransition) => void): void;
-  off(name: 'link', listener: (child: Task) => void): void;
-  off(name: 'unlink', listener: (child: Task) => void): void;
-  off(name: string, listener: (...args: any[]) => void): void;
+  on: EventEmitter['on'];
+  off: EventEmitter['off'];
 }
 
 export function createTask<TOut = unknown>(operation: Operation<TOut>, options: TaskOptions = {}): Task<TOut> {
@@ -182,8 +176,8 @@ export function createTask<TOut = unknown>(operation: Operation<TOut>, options: 
       emitter.emit('labels', labels);
     },
 
-    on: (name: string, listener: (...args: any[]) => void) => { emitter.on(name, listener) },
-    off: (name: string, listener: (...args: any[]) => void) => { emitter.off(name, listener) },
+    on: (...args) => emitter.on(...args),
+    off: (...args) => emitter.off(...args),
   };
 
   let controller: Controller<TOut>;


### PR DESCRIPTION
These types do not fully conform to the EventEmitter interface and make the controls unusable with @effection/events. While it is nice to have the types annotated, when using these methods from `@effection/events`, we need to annotate the types anyway, so it has no benefit to type these explicitly.