### PR TITLE
Improve Error output with Effection Trace and Colors

### DIFF
--- a/.changeset/seven-ducks-attend.md
+++ b/.changeset/seven-ducks-attend.md
@@ -3,4 +3,4 @@
 "effection": minor
 ---
 
-Add EffectionError and wrap errors in this error automatically
+Collect trace of effection operations and propagate them along with the raised error

--- a/.changeset/seven-ducks-attend.md
+++ b/.changeset/seven-ducks-attend.md
@@ -1,0 +1,6 @@
+---
+"@effection/core": minor
+"effection": minor
+---
+
+Add EffectionError and wrap errors in this error automatically

--- a/.changeset/wild-spoons-kick.md
+++ b/.changeset/wild-spoons-kick.md
@@ -1,0 +1,6 @@
+---
+"@effection/main": minor
+"effection": minor
+---
+
+Remove `verbose` option from MainError

--- a/.changeset/wise-pots-laugh.md
+++ b/.changeset/wise-pots-laugh.md
@@ -1,0 +1,7 @@
+---
+"@effection/core": minor
+"@effection/main": minor
+"effection": minor
+---
+
+Improve error output by including an Effection trace

--- a/packages/core/src/controller/function-controller.ts
+++ b/packages/core/src/controller/function-controller.ts
@@ -24,7 +24,11 @@ export function createFunctionController<TOut>(task: Task<TOut>, createControlle
 
   return {
     get type() {
-      return delegate.type === 'promise' ? 'async function' : `${delegate.type} function`;
+      if(delegate) {
+        return delegate.type === 'promise' ? 'async function' : `${delegate.type} function`;
+      } else {
+        return 'function';
+      }
     },
     start,
     halt,

--- a/packages/core/src/error.ts
+++ b/packages/core/src/error.ts
@@ -1,41 +1,27 @@
 import type { Task } from './task';
 import type { Labels } from './labels';
 
-interface TaskInfo {
+export interface TaskInfo {
   id: number;
   type: string;
   labels: Labels;
 }
 
-export class EffectionError extends Error {
-  name = 'EffectionError';
-
-  static wrap(error: Error, task: Task): EffectionError {
-    let info: TaskInfo = {
-      id: task.id,
-      type: task.type,
-      labels: task.labels,
-    };
-    if(error instanceof EffectionError) {
-      return new EffectionError(error.source, [...error.trace, info]);
-    } else {
-      return new EffectionError(error, [info]);
-    }
-  }
-
-  constructor(public source: Error, public trace: TaskInfo[]) {
-    super(source.message);
-  }
+export interface HasEffectionTrace {
+  effectionTrace: TaskInfo[];
 }
 
-export function isEffectionError(error: Error): error is EffectionError {
-  return error.name === 'EffectionError';
-}
+export function addTrace(error: Error & Partial<HasEffectionTrace>, task: Task): Error & HasEffectionTrace {
+  let info: TaskInfo = {
+    id: task.id,
+    type: task.type,
+    labels: task.labels,
+  };
 
-export function unwrapError(error: Error): Error {
-  if(isEffectionError(error)) {
-    return error.source;
-  } else {
-    return error;
+  let properties = Object.getOwnPropertyDescriptors(error);
+  properties.effectionTrace = {
+    value: [...(error.effectionTrace || []), info],
+    enumerable: true,
   }
+  return Object.create(Object.getPrototypeOf(error), properties);
 }

--- a/packages/core/src/error.ts
+++ b/packages/core/src/error.ts
@@ -1,0 +1,41 @@
+import type { Task } from './task';
+import type { Labels } from './labels';
+
+interface TaskInfo {
+  id: number;
+  type: string;
+  labels: Labels;
+}
+
+export class EffectionError extends Error {
+  name = 'EffectionError';
+
+  static wrap(error: Error, task: Task): EffectionError {
+    let info: TaskInfo = {
+      id: task.id,
+      type: task.type,
+      labels: task.labels,
+    };
+    if(error instanceof EffectionError) {
+      return new EffectionError(error.source, [...error.trace, info]);
+    } else {
+      return new EffectionError(error, [info]);
+    }
+  }
+
+  constructor(public source: Error, public trace: TaskInfo[]) {
+    super(source.message);
+  }
+}
+
+export function isEffectionError(error: Error): error is EffectionError {
+  return error.name === 'EffectionError';
+}
+
+export function unwrapError(error: Error): Error {
+  if(isEffectionError(error)) {
+    return error.source;
+  } else {
+    return error;
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,6 +9,7 @@ export { Effection } from './effection';
 export { deprecated } from './deprecated';
 export { Deferred } from './deferred';
 export { Labels, withLabels } from './labels';
+export { EffectionError, isEffectionError, unwrapError } from './error';
 
 export { sleep } from './operations/sleep';
 export { ensure } from './operations/ensure';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,7 +9,7 @@ export { Effection } from './effection';
 export { deprecated } from './deprecated';
 export { Deferred } from './deferred';
 export { Labels, withLabels } from './labels';
-export { EffectionError, isEffectionError, unwrapError } from './error';
+export { HasEffectionTrace, TaskInfo } from './error';
 
 export { sleep } from './operations/sleep';
 export { ensure } from './operations/ensure';

--- a/packages/core/src/task.ts
+++ b/packages/core/src/task.ts
@@ -8,6 +8,7 @@ import { EventEmitter } from 'events';
 import { StateMachine, State } from './state-machine';
 import { HaltError } from './halt-error';
 import { Labels } from './labels';
+import { EffectionError } from './error';
 
 let COUNTER = 0;
 const CONTROLS = Symbol.for('effection/v2/controls');
@@ -121,7 +122,7 @@ export function createTask<TOut = unknown>(operation: Operation<TOut>, options: 
     reject: (error: Error) => {
       stateMachine.reject();
       controls.result = undefined; // clear result if it has previously been set
-      controls.error = error;
+      controls.error = EffectionError.wrap(error, task);
       haltChildren(true);
       resume();
     },

--- a/packages/core/src/task.ts
+++ b/packages/core/src/task.ts
@@ -8,7 +8,7 @@ import { EventEmitter } from 'events';
 import { StateMachine, State } from './state-machine';
 import { HaltError } from './halt-error';
 import { Labels } from './labels';
-import { EffectionError } from './error';
+import { addTrace } from './error';
 
 let COUNTER = 0;
 const CONTROLS = Symbol.for('effection/v2/controls');
@@ -122,7 +122,7 @@ export function createTask<TOut = unknown>(operation: Operation<TOut>, options: 
     reject: (error: Error) => {
       stateMachine.reject();
       controls.result = undefined; // clear result if it has previously been set
-      controls.error = EffectionError.wrap(error, task);
+      controls.error = addTrace(error, task);
       haltChildren(true);
       resume();
     },

--- a/packages/core/test/error.test.ts
+++ b/packages/core/test/error.test.ts
@@ -1,0 +1,27 @@
+import './setup';
+import { describe, it } from 'mocha';
+import * as expect from 'expect';
+
+import { run } from '../src/index';
+
+class ExplodeError extends Error {
+  name = 'ExplodeError';
+}
+
+describe('error', () => {
+  it('wraps the error in an effection error', async () => {
+    let error = await run(function *root() {
+      yield function *child() {
+        throw new ExplodeError('boom');
+      }
+    }).then(null, (err) => err);
+
+    expect(error.name).toEqual('EffectionError');
+    expect(error.message).toEqual('boom');
+    expect(error.source.name).toEqual('ExplodeError');
+    expect(error.source.message).toEqual('boom');
+    expect(error.trace.length).toEqual(2);
+    expect(error.trace[0].labels.name).toEqual('child');
+    expect(error.trace[1].labels.name).toEqual('root');
+  });
+});

--- a/packages/core/test/generator.test.ts
+++ b/packages/core/test/generator.test.ts
@@ -17,12 +17,12 @@ describe('generators', () => {
       let result = add(2, 2);
       yield result;
       yield result;
-    })).rejects.toMatchObject({ source: { name: 'DoubleEvalError' } });
+    })).rejects.toHaveProperty('name', 'DoubleEvalError');
   });
 
   it('is an error to run the same iterator more than once', async () => {
     let addition = add(2,2);
     await run(addition);
-    expect(run(addition)).rejects.toMatchObject({ name: 'DoubleEvalError' });
+    expect(run(addition)).rejects.toHaveProperty('name', 'DoubleEvalError');
   });
 })

--- a/packages/core/test/generator.test.ts
+++ b/packages/core/test/generator.test.ts
@@ -17,7 +17,7 @@ describe('generators', () => {
       let result = add(2, 2);
       yield result;
       yield result;
-    })).rejects.toMatchObject({ name: 'DoubleEvalError' });
+    })).rejects.toMatchObject({ source: { name: 'DoubleEvalError' } });
   });
 
   it('is an error to run the same iterator more than once', async () => {

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -20,11 +20,13 @@
     "mocha": "mocha -r ts-node/register"
   },
   "dependencies": {
-    "@effection/core": "2.0.0-preview.11"
+    "@effection/core": "2.0.0-preview.11",
+    "chalk": "^4.1.1",
+    "stacktrace-parser": "^0.1.10"
   },
   "devDependencies": {
-    "@effection/node": "2.0.0-preview.15",
     "@effection/mocha": "2.0.0-preview.12",
+    "@effection/node": "2.0.0-preview.15",
     "@frontside/tsconfig": "0.0.1",
     "@types/node": "^13.13.5",
     "expect": "^25.4.0",

--- a/packages/main/src/browser.ts
+++ b/packages/main/src/browser.ts
@@ -1,4 +1,5 @@
 import { run, Task, Operation } from '@effection/core';
+import { isMainError } from './error';
 
 export * from './error';
 
@@ -8,17 +9,14 @@ export function main<T>(operation: Operation<T>): Task<T> {
     try {
       window.addEventListener('unload', interrupt);
       return yield operation;
-    } catch(e) {
-      if(e.name === 'EffectionMainError') {
-        if(e.options.message) {
-          console.error(e.options.message);
-        }
-        if(e.options.verbose) {
-          console.error(e.stack);
+    } catch(error) {
+      if(isMainError(error)) {
+        if(error.message) {
+          console.error(error.message);
         }
       } else {
-        console.error(e);
-        throw e;
+        console.error(error);
+        throw error;
       }
     } finally {
       window.removeEventListener('unload', interrupt);

--- a/packages/main/src/error.ts
+++ b/packages/main/src/error.ts
@@ -1,13 +1,19 @@
 export interface MainErrorOptions {
   exitCode?: number;
-  verbose?: boolean;
   message?: string;
 }
 
 export class MainError extends Error {
   name = "EffectionMainError"
 
-  constructor(public options: MainErrorOptions = {}) {
-    super(options.message || "error");
+  public exitCode: number;
+
+  constructor(options: MainErrorOptions = {}) {
+    super(options.message || "");
+    this.exitCode = options.exitCode || -1;
   }
+}
+
+export function isMainError(error: Error): error is MainError {
+  return error.name === 'EffectionMainError';
 }

--- a/packages/main/src/format-error-node.ts
+++ b/packages/main/src/format-error-node.ts
@@ -1,0 +1,59 @@
+import { HasEffectionTrace } from '@effection/core';
+import { isMainError } from './error';
+import * as chalk from 'chalk';
+import * as stackTraceParser from 'stacktrace-parser';
+
+export function formatName(error: Error): string {
+  return chalk.bgRed.white.bold(error.name);
+}
+
+export function formatMessage(error: Error): string {
+  return error.message;
+}
+
+export function formatEffection(error: Error & Partial<HasEffectionTrace>): string | undefined {
+  if(error.effectionTrace) {
+    let stack = error.effectionTrace.map((task) => {
+      let labels = Object.entries(task.labels).filter(([key]) => key !== 'name').map(([key, value]) => {
+        return `${key}=${chalk.bold(value)}`;
+      });
+
+      return [
+        chalk.grey('  -'),
+        chalk.yellow(task.labels.name || 'task'),
+        ...labels,
+        chalk.grey(task.type),
+        chalk.grey(`[${task.id}]`),
+      ].join(' ');
+    });
+    return chalk.whiteBright.bold("Effection:\n") + stack.join('\n');
+  }
+}
+
+export function formatStack(error: Error): string | undefined {
+  if(error.stack) {
+    let stack = stackTraceParser.parse(error.stack).map((item) => {
+      return [
+        chalk.grey('  -'),
+        item.methodName && chalk.cyan(item.methodName),
+        item.file && chalk.grey(`${item.file}:${item.lineNumber}:${item.column}`),
+      ].filter(Boolean).join(' ');
+    });
+    return chalk.whiteBright.bold("Stacktrace:\n") + stack.join('\n');
+  }
+}
+
+export function formatError(error: Error): string {
+  if(isMainError(error)) {
+    return [
+      error.message && formatMessage(error),
+    ].filter(Boolean).join('\n\n');
+  } else {
+    return [
+      formatName(error),
+      formatMessage(error),
+      formatEffection(error),
+      formatStack(error),
+    ].filter(Boolean).join('\n\n');
+  }
+}

--- a/packages/main/src/node.ts
+++ b/packages/main/src/node.ts
@@ -1,4 +1,6 @@
 import { run, Task, Operation } from '@effection/core';
+import { formatError } from './format-error-node';
+import { isMainError } from './error';
 
 export * from './error';
 
@@ -9,17 +11,11 @@ export function main<T>(operation: Operation<T>): Task<T> {
       process.on('SIGINT', interrupt);
       process.on('SIGTERM', interrupt);
       return yield operation;
-    } catch(e) {
-      if(e.name === 'EffectionMainError') {
-        if(e.options.message) {
-          console.error(e.options.message);
-        }
-        if(e.options.verbose) {
-          console.error(e.stack);
-        }
-        process.exit(e.options.exitCode || -1);
+    } catch(error) {
+      console.error(formatError(error));
+      if(isMainError(error)) {
+        process.exit(error.exitCode || -1);
       } else {
-        console.error(e);
         process.exit(1);
       }
     } finally {

--- a/packages/main/test.ts
+++ b/packages/main/test.ts
@@ -1,0 +1,16 @@
+import { main } from './src/node';
+import { sleep, spawn, withLabels } from '@effection/core';
+
+class CustomError extends Error {
+  name = "CustomError";
+}
+
+main(function* main() {
+  yield withLabels(function*() {
+    yield spawn(function*() {
+      yield sleep(10);
+      throw new CustomError('moo');
+    }, { labels: { name: "request", path: '/foobar' } });
+    yield
+  }, { name: 'server' })
+});

--- a/packages/main/test/node.test.ts
+++ b/packages/main/test/node.test.ts
@@ -2,7 +2,7 @@ import * as path from 'path';
 import * as expect from 'expect';
 import { describe, it, beforeEach } from '@effection/mocha';
 
-import { exec, Process } from '@effection/node';
+import { exec, Process, ProcessResult } from '@effection/node';
 import { terminate, interrupt } from './helpers';
 
 describe('main', () => {
@@ -40,22 +40,19 @@ describe('main', () => {
 
   describe('with failing process', () => {
     it('sets exit code and prints error', function*() {
-      let child: Process = yield exec(`ts-node ./test/fixtures/main-failed.ts`, { buffered: true });
-      let status = yield child.join();
-      let stderr = yield child.stderr.expect();
+      let result: ProcessResult = yield exec(`ts-node ./test/fixtures/main-failed.ts`).join();
 
-      expect(stderr).toContain('Error: moo');
-      expect(status.code).toEqual(1);
+      expect(result.stderr).toContain('Error');
+      expect(result.stderr).toContain('moo');
+      expect(result.code).toEqual(1);
     });
 
     it('sets custom exit code and hides error', function*() {
-      let child: Process = yield exec(`ts-node ./test/fixtures/main-failed-custom.ts`, { buffered: true });
-      let status = yield child.join();
-      let stderr = yield child.stderr.expect();
+      let result: ProcessResult = yield exec(`ts-node ./test/fixtures/main-failed-custom.ts`).join();
 
-      expect(stderr).toContain('It all went horribly wrong');
-      expect(stderr).not.toContain('EffectionMainError');
-      expect(status.code).toEqual(23);
+      expect(result.stderr).toContain('It all went horribly wrong');
+      expect(result.stderr).not.toContain('EffectionMainError');
+      expect(result.code).toEqual(23);
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2470,6 +2470,14 @@ chalk@^4.0.0, chalk@^4.1.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+chalk@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.1.tgz#c80b3fab28bf6371e6863325eee67e618b77e6ad"
+  integrity sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
@@ -7253,6 +7261,13 @@ stack-utils@^2.0.2:
   dependencies:
     escape-string-regexp "^2.0.0"
 
+stacktrace-parser@^0.1.10:
+  version "0.1.10"
+  resolved "https://registry.yarnpkg.com/stacktrace-parser/-/stacktrace-parser-0.1.10.tgz#29fb0cae4e0d0b85155879402857a1639eb6051a"
+  integrity sha512-KJP1OCML99+8fhOHxwwzyWrlUuVX5GQ0ZpJTd1DFXhdkrvg1szxfHhawXUZ3g9TkXORQd4/WG68jMlQZ2p8wlg==
+  dependencies:
+    type-fest "^0.7.1"
+
 static-extend@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
@@ -7854,6 +7869,11 @@ type-fest@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.6.0.tgz#8d2a2370d3df886eb5c90ada1c5bf6188acf838b"
   integrity sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==
+
+type-fest@^0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.7.1.tgz#8dda65feaf03ed78f0a3f9678f1869147f7c5c48"
+  integrity sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==
 
 type-fest@^0.8.1:
   version "0.8.1"


### PR DESCRIPTION
## Motivation

We would really like to have more readable and useful error output. When things go wrong in Effection it can be really hard to figure out what's going on. Stack traces are decidedly less useful with Effection.

## Approach

When an error is thrown in an Effection context, we wrap this error in an EffectionError. When errors percolate upwards, we continually expand the trace property of the EffectionError, so it keeps track of the stack of tasks that it percolated through. This way we get a sort of stack trace of operations. With the addion of #330 and #331, we can actually print some useful information here.

We use this wrapped error in @effection/main to print a nice colorized stacktrace and Effection trace. By putting this in @effection/main, we avoid pulling in terminal colorization packages in the browser, where it wouldn't make sense. In this PR  we don't yet to anything to print any diagnostic infomation in the browser, but node environments seem like a higher priority and easier to iterate on.

### Alternate Designs

We could set a property on the error, instead of wrapping them, this would mean you would get the original exception and wouldn't have to unwrap it.

### Possible Drawbacks or Risks

Wrapping the error in an EffectionError, could be a little confusing, since when using `catch` on a task, you wouldn't get the original error.

## Screenshots

Before:

<img width="1204" alt="Screenshot 2021-05-28 at 17 31 01" src="https://user-images.githubusercontent.com/134/120100892-7b44ad00-c143-11eb-8701-3bb3b7fd2db3.png">

After:

<img width="1153" alt="Screenshot 2021-05-28 at 17 32 04" src="https://user-images.githubusercontent.com/134/120100899-84ce1500-c143-11eb-9698-3b46c1b048d3.png">

