### PR TITLE
Add @effection/react package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,6 +117,10 @@ workflows:
                 - node
                 - atom
                 - mocha
+                - main
+                - react
+                - websocket-client
+                - websocket-server
           requires:
             - prepack
       - lint:

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
       "packages/atom",
       "packages/node",
       "packages/fetch",
+      "packages/react",
       "packages/websocket-client",
       "packages/websocket-server",
       "packages/effection"

--- a/packages/react/.eslintrc.json
+++ b/packages/react/.eslintrc.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../.eslintrc.json",
+  "plugins": ["react-hooks"],
+  "rules": {
+    "react-hooks/rules-of-hooks": "error",
+    "react-hooks/exhaustive-deps": "error"
+  }
+}

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,0 +1,1 @@
+# @effection/debug-ui

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,1 +1,1 @@
-# @effection/debug-ui
+# @effection/react

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@effection/react",
+  "version": "2.0.0-preview.1",
+  "description": "Hooks for integrating effection into react applications",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "module": "dist/debug.esm.js",
+  "repository": "https://github.com/thefrontside/bigtest.git",
+  "author": "Frontside Engineering <engineering@frontside.com>",
+  "license": "MIT",
+  "files": [
+    "README.md",
+    "CHANGELOG.md",
+    "dist/**/*",
+    "src/**/*"
+  ],
+  "scripts": {
+    "lint": "eslint '{src,tests}/**/*.ts'",
+    "test": "mocha -r ts-node/register 'test/**/*.test.{ts,tsx}'",
+    "prepack": "tsdx build --tsconfig tsconfig.dist.json",
+    "mocha": "mocha -r ts-node/register"
+  },
+  "dependencies": {
+    "@effection/core": "2.0.0-preview.11",
+    "@effection/subscription": "2.0.0-preview.13",
+    "react": "^17.0.2"
+  },
+  "devDependencies": {
+    "@effection/mocha": "2.0.0-preview.12",
+    "@frontside/tsconfig": "0.0.1",
+    "@types/node": "^13.13.5",
+    "@types/react": "^17.0.8",
+    "expect": "^25.4.0",
+    "mocha": "^8.3.1",
+    "react-test-renderer": "^17.0.2",
+    "ts-node": "^8.9.0",
+    "tsdx": "0.13.2",
+    "typescript": "^3.7.0"
+  },
+  "volta": {
+    "node": "12.16.0",
+    "yarn": "1.19.1"
+  }
+}

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -30,6 +30,8 @@
     "@frontside/tsconfig": "0.0.1",
     "@types/node": "^13.13.5",
     "@types/react": "^17.0.8",
+    "@types/react-test-renderer": "^17.0.1",
+    "eslint-plugin-react-hooks": "^4.2.0",
     "expect": "^25.4.0",
     "mocha": "^8.3.1",
     "react-test-renderer": "^17.0.2",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "module": "dist/debug.esm.js",
-  "repository": "https://github.com/thefrontside/bigtest.git",
+  "repository": "https://github.com/thefrontside/effection.git",
   "author": "Frontside Engineering <engineering@frontside.com>",
   "license": "MIT",
   "files": [

--- a/packages/react/src/context.ts
+++ b/packages/react/src/context.ts
@@ -1,0 +1,4 @@
+import { createContext } from 'react';
+import { Task, Effection } from '@effection/core';
+
+export const EffectionContext = createContext<Task>(Effection.root);

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,0 +1,2 @@
+export { useSubscription } from './use-subscription';
+export { EffectionContext } from './context';

--- a/packages/react/src/use-subscription.ts
+++ b/packages/react/src/use-subscription.ts
@@ -1,0 +1,15 @@
+import { useState, useEffect, useContext } from 'react';
+import { Subscription } from '@effection/subscription';
+import { EffectionContext } from './context';
+
+export function useSubscription<T>(subscription: Subscription<T>): T | undefined {
+  let scope = useContext(EffectionContext);
+  let [state, setState] = useState<T>();
+
+  useEffect(() => {
+    let task = scope.spawn(subscription.forEach((value) => { setState(value) }));
+    return () => { task.halt() };
+  });
+
+  return state;
+}

--- a/packages/react/src/use-subscription.ts
+++ b/packages/react/src/use-subscription.ts
@@ -9,7 +9,7 @@ export function useSubscription<T>(subscription: Subscription<T>): T | undefined
   useEffect(() => {
     let task = scope.spawn(subscription.forEach((value) => { setState(value) }));
     return () => { task.halt() };
-  });
+  }, [subscription, scope]);
 
   return state;
 }

--- a/packages/react/test.ts
+++ b/packages/react/test.ts
@@ -1,0 +1,9 @@
+import { sleep } from '@effection/core';
+import { main } from '@effection/main';
+
+main(function*() {
+  while(true) {
+    yield sleep(1000);
+    console.log('ping');
+  }
+});

--- a/packages/react/test/helpers.tsx
+++ b/packages/react/test/helpers.tsx
@@ -1,0 +1,18 @@
+import * as TestRenderer from 'react-test-renderer';
+import { ensure, Effection, Resource } from '@effection/core';
+import { EffectionContext } from '../src/index';
+import * as React from 'react';
+
+export function render(element: JSX.Element): Resource<TestRenderer.ReactTestRenderer> {
+  return {
+    *init() {
+      let renderer = TestRenderer.create(
+        <EffectionContext.Provider value={Effection.root}>
+          {element}
+        </EffectionContext.Provider>
+      );
+      yield ensure(() => { renderer.unmount() });
+      return renderer;
+    }
+  }
+}

--- a/packages/react/test/use-subscription.test.tsx
+++ b/packages/react/test/use-subscription.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it } from '@effection/mocha';
+import * as expect from 'expect';
+import { createQueue, Subscription } from '@effection/subscription';
+import { sleep } from '@effection/core';
+import { useSubscription } from '../src/index';
+import * as React from 'react';
+import { ReactTestRenderer } from 'react-test-renderer';
+import { render } from './helpers';
+
+type TestComponentProps = {
+  subscription: Subscription<string>;
+}
+
+function TestComponent(props: TestComponentProps): JSX.Element {
+  let value = useSubscription(props.subscription);
+  return (
+    <h1>{value}</h1>
+  )
+}
+
+describe('useSubscription', () => {
+  it('updates the component when a new value is pushed to the subscription', function*() {
+    let queue = createQueue<string>();
+    let renderer: ReactTestRenderer = yield render(
+      <TestComponent subscription={queue.subscription}/>
+    );
+
+    expect(renderer.toJSON()).toMatchObject({ type: 'h1', children: null });
+
+    queue.send("hello")
+    yield sleep(5);
+
+    expect(renderer.toJSON()).toMatchObject({ type: 'h1', children: ['hello'] });
+
+    queue.send("world")
+    yield sleep(5);
+
+    expect(renderer.toJSON()).toMatchObject({ type: 'h1', children: ['world'] });
+  });
+});

--- a/packages/react/tsconfig.dist.json
+++ b/packages/react/tsconfig.dist.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "module": "esnext"
+  },
+  "exclude": ["./test/*"]
+}

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@frontside/tsconfig",
+  "compilerOptions": {
+    "jsx": "react"
+  },
+  "include": [
+    "src/**/*.ts",
+    "test/**/*.ts"
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1520,7 +1520,14 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
   integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
 
-"@types/react@^17.0.8":
+"@types/react-test-renderer@^17.0.1":
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-17.0.1.tgz#3120f7d1c157fba9df0118dae20cb0297ee0e06b"
+  integrity sha512-3Fi2O6Zzq/f3QR9dRnlnHso9bMl7weKCviFmfF6B4LS1Uat6Hkm15k0ZAQuDz+UBq6B3+g+NM6IT2nr5QgPzCw==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react@*", "@types/react@^17.0.8":
   version "17.0.8"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.8.tgz#fe76e3ba0fbb5602704110fd1e3035cf394778e3"
   integrity sha512-3sx4c0PbXujrYAKwXxNONXUtRp9C+hE2di0IuxFyf5BELD+B+AXL8G7QrmSKhVwKZDbv0igiAjQAMhXj8Yg3aw==
@@ -3289,6 +3296,11 @@ eslint-plugin-react-hooks@^2.2.0:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-2.5.1.tgz#4ef5930592588ce171abeb26f400c7fbcbc23cd0"
   integrity sha512-Y2c4b55R+6ZzwtTppKwSmK/Kar8AdLiC2f9NADCuxbcTgPPg41Gyqa6b9GppgXSvCtkRw43ZE86CT5sejKC6/g==
+
+eslint-plugin-react-hooks@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz#8c229c268d468956334c943bb45fc860280f5556"
+  integrity sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==
 
 eslint-plugin-react@^7.14.3:
   version "7.22.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1515,12 +1515,31 @@
   resolved "https://registry.yarnpkg.com/@types/parsimmon/-/parsimmon-1.10.6.tgz#8fcf95990514d2a7624aa5f630c13bf2427f9cdd"
   integrity sha512-FwAQwMRbkhx0J6YELkwIpciVzCcgEqXEbIrIn3a2P5d3kGEHQ3wVhlN3YdVepYP+bZzCYO6OjmD4o9TGOZ40rA==
 
+"@types/prop-types@*":
+  version "15.7.3"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
+  integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
+
+"@types/react@^17.0.8":
+  version "17.0.8"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.8.tgz#fe76e3ba0fbb5602704110fd1e3035cf394778e3"
+  integrity sha512-3sx4c0PbXujrYAKwXxNONXUtRp9C+hE2di0IuxFyf5BELD+B+AXL8G7QrmSKhVwKZDbv0igiAjQAMhXj8Yg3aw==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
 "@types/resolve@0.0.8":
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-0.0.8.tgz#f26074d238e02659e323ce1a13d041eee280e194"
   integrity sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==
   dependencies:
     "@types/node" "*"
+
+"@types/scheduler@*":
+  version "0.16.1"
+  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.1.tgz#18845205e86ff0038517aab7a18a62a6b9f71275"
+  integrity sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA==
 
 "@types/semver@^6.0.0":
   version "6.2.2"
@@ -2807,6 +2826,11 @@ cssstyle@^1.0.0:
   integrity sha512-GBrLZYZ4X4x6/QEoBnIrqb8B/f5l4+8me2dkom/j1Gtbxy0kBv6OGzKuAsGM75bkGwGAFkt56Iwg28S3XTZgSA==
   dependencies:
     cssom "0.3.x"
+
+csstype@^3.0.2:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.8.tgz#d2266a792729fb227cd216fb572f43728e1ad340"
+  integrity sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw==
 
 csv-generate@^3.2.4:
   version "3.3.0"
@@ -5386,7 +5410,7 @@ log-update@^2.3.0:
     cli-cursor "^2.0.0"
     wrap-ansi "^3.0.1"
 
-loose-envify@^1.0.0, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -6451,10 +6475,41 @@ react-is@^16.12.0, react-is@^16.8.1, react-is@^16.8.4:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
+"react-is@^16.12.0 || ^17.0.0", react-is@^17.0.2:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
+  integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
+
 react-is@^17.0.1:
   version "17.0.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.1.tgz#5b3531bd76a645a4c9fb6e693ed36419e3301339"
   integrity sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==
+
+react-shallow-renderer@^16.13.1:
+  version "16.14.1"
+  resolved "https://registry.yarnpkg.com/react-shallow-renderer/-/react-shallow-renderer-16.14.1.tgz#bf0d02df8a519a558fd9b8215442efa5c840e124"
+  integrity sha512-rkIMcQi01/+kxiTE9D3fdS959U1g7gs+/rborw++42m1O9FAQiNI/UNRZExVUoAOprn4umcXf+pFRou8i4zuBg==
+  dependencies:
+    object-assign "^4.1.1"
+    react-is "^16.12.0 || ^17.0.0"
+
+react-test-renderer@^17.0.2:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-17.0.2.tgz#4cd4ae5ef1ad5670fc0ef776e8cc7e1231d9866c"
+  integrity sha512-yaQ9cB89c17PUb0x6UfWRs7kQCorVdHlutU1boVPEsB8IDZH6n9tHxMacc3y0JoXOJUsZb/t/Mb8FUWMKaM7iQ==
+  dependencies:
+    object-assign "^4.1.1"
+    react-is "^17.0.2"
+    react-shallow-renderer "^16.13.1"
+    scheduler "^0.20.2"
+
+react@^17.0.2:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
+  integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
 
 read-pkg-up@^2.0.0:
   version "2.0.0"
@@ -6951,6 +7006,14 @@ sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
+
+scheduler@^0.20.2:
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.2.tgz#4baee39436e34aa93b4874bddcbf0fe8b8b50e91"
+  integrity sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
 
 "semver@2 >=2.2.1 || 3.x || 4 || 5", "semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5, semver@^5.5.0, semver@^5.6.0:
   version "5.7.1"


### PR DESCRIPTION
This currently only contains a hook called `useSubscription`, making it possible to subscribe to a subscription from within react.

## Motivation

React is by far the most popular client-side framework. Integrating with React would be great.

## Approach

It seems that hooks are the standard way of writing React apps these days, so this PR adds a hook. The most natural effection primitive to map to React is a subscription, so that's where we start out. This has come up as a usecase in building the debug UI.

### Alternate Designs

One question is how we obtain an Effection task to spawn off of, there are a few options for this:

1. Explicitly pass it in and down as a prop
2. Use `Effection.root`
3. Set it as a React context and have it be passed down implicitly

This PR chooses the third approach, since it seems like a nice combination of low ceremony and flexibility.

### Possible Drawbacks or Risks

This is not a full-fledged react integration and it might be a bit of a red-herring for someone looking to integrate Effection and React. On the other hand we do need to start somewhere.