### PR TITLE
Refactor internals to use futures and run loop

### DIFF
--- a/.changeset/cool-brooms-bathe.md
+++ b/.changeset/cool-brooms-bathe.md
@@ -1,0 +1,6 @@
+---
+"@effection/core": minor
+"effection": minor
+---
+
+Rewrite internals to using futures

--- a/packages/core/src/controller/controller.ts
+++ b/packages/core/src/controller/controller.ts
@@ -7,18 +7,20 @@ import { createPromiseController } from './promise-controller';
 import { createIteratorController } from './iterator-controller';
 import { createResolutionController } from './resolution-controller';
 import { createResourceController } from './resource-controller';
+import { Future } from '../future';
 
 export interface Controller<TOut> {
   type: string;
   start(): void;
   halt(): void;
+  future: Future<TOut>;
 }
 
 export function createController<T>(task: Task<T>, operation: Operation<T>): Controller<T> {
   if (typeof(operation) === 'function') {
     return createFunctionController(task, () => createController(task, operation(task)));
   } else if(!operation) {
-    return createSuspendController(task);
+    return createSuspendController();
   } else if (isResource(operation)) {
     return createResourceController(task, operation);
   } else if (isResolution(operation)) {

--- a/packages/core/src/controller/resource-controller.ts
+++ b/packages/core/src/controller/resource-controller.ts
@@ -1,12 +1,13 @@
 import { Controller } from './controller';
 import { createIteratorController } from './iterator-controller';
 import { Resource } from '../operation';
-import { Task, getControls } from '../task';
+import { Task } from '../task';
+import { createFuture } from '../future';
 
 export function createResourceController<TOut>(task: Task<TOut>, resource: Resource<TOut>): Controller<TOut> {
-  let controls = getControls(task);
   let delegate: Controller<TOut>;
   let { resourceScope } = task.options;
+  let { resolve, future } = createFuture<TOut>();
 
   function start() {
     if(!resourceScope) {
@@ -16,10 +17,13 @@ export function createResourceController<TOut>(task: Task<TOut>, resource: Resou
     try {
       init = resource.init(resourceScope, task);
     } catch(error) {
-      controls.reject(error);
+      resolve({ state: 'errored', error });
       return;
     }
     delegate = createIteratorController(task, init, { resourceScope });
+    delegate.future.consume((value) => {
+      resolve(value);
+    });
     delegate.start();
   }
 
@@ -27,5 +31,5 @@ export function createResourceController<TOut>(task: Task<TOut>, resource: Resou
     delegate.halt();
   }
 
-  return { start, halt, type: 'resource' };
+  return { start, halt, future, type: 'resource' };
 }

--- a/packages/core/src/controller/suspend-controller.ts
+++ b/packages/core/src/controller/suspend-controller.ts
@@ -1,16 +1,16 @@
 import { Controller } from './controller';
-import { getControls, Task } from '../task';
+import { createFuture } from '../future';
 
-export function createSuspendController<TOut>(task: Task<TOut>): Controller<TOut> {
-  let controls = getControls(task);
+export function createSuspendController<TOut>(): Controller<TOut> {
+  let { resolve, future } = createFuture<TOut>();
 
   function start() {
     // no op
   }
 
   function halt() {
-    controls.halted();
+    resolve({ state: 'halted' });
   }
 
-  return { start, halt, type: 'suspend' };
+  return { start, halt, future, type: 'suspend' };
 }

--- a/packages/core/src/future.ts
+++ b/packages/core/src/future.ts
@@ -1,0 +1,83 @@
+import { HaltError } from './halt-error';
+import { createRunLoop } from './run-loop';
+
+export type State = 'pending' | 'errored' | 'completed' | 'halted';
+
+export type Value<T> =
+  | { state: 'errored'; error: Error }
+  | { state: 'completed'; value: T }
+  | { state: 'halted' };
+
+export interface Consumer<T> {
+  (value: Value<T>): void;
+}
+
+export interface Future<T> extends Promise<T> {
+  state: State;
+  consume<R>(consumer: Consumer<T>): void;
+}
+
+export interface NewFuture<T> {
+  future: Future<T>;
+  resolve(value: Value<T>): void;
+}
+
+export function createFuture<T>(): NewFuture<T> {
+  let runLoop = createRunLoop();
+  let consumers: Consumer<T>[] = [];
+  let result: Value<T>;
+
+  function consume(consumer: Consumer<T>) {
+    consumers.push(consumer);
+    runLoop.run(run);
+  }
+
+  function run() {
+    if(result) {
+      while(true) {
+        let consumer = consumers.shift();
+        if(consumer) {
+          consumer(result);
+        } else {
+          break;
+        }
+      }
+    }
+  }
+
+  function resolve(value: Value<T>) {
+    if(!result) {
+      result = value;
+      runLoop.run(run);
+    }
+  }
+
+
+  let promise: Promise<T>;
+
+  function getPromise(): Promise<T> {
+    return promise || (promise = new Promise<T>((resolve, reject) => {
+      consume((value) => {
+        if(value.state === 'completed') {
+          resolve(value.value);
+        } else if(value.state === 'errored') {
+          reject(value.error);
+        } else if(value.state === 'halted') {
+          reject(new HaltError());
+        }
+      });
+    }));
+  }
+
+  return {
+    resolve,
+    future: {
+      get state() { return result?.state || 'pending' },
+      consume,
+      then: (...args) => getPromise().then(...args),
+      catch: (...args) => getPromise().catch(...args),
+      finally: (...args) => getPromise().finally(...args),
+      [Symbol.toStringTag]: '[continuation]',
+    }
+  }
+}

--- a/packages/core/src/run-loop.ts
+++ b/packages/core/src/run-loop.ts
@@ -1,0 +1,40 @@
+export type Runnable = () => void;
+
+export interface RunLoop {
+  run(fn: Runnable): void;
+}
+
+// A run loop protects against reentrant code, where synchronous callbacks end
+// up calling into themselves. This causes problems because it becomes very
+// difficult to reason about the underlying state. This could be seen as a sort
+// of synchronous mutex
+export function createRunLoop(): RunLoop {
+  let didEnter = false;
+  let runnables: Runnable[] = [];
+
+  function run(fn: Runnable) {
+    runnables.push(fn);
+    if(!didEnter) {
+      didEnter = true;
+      try {
+        while(true) {
+          let runnable = runnables.shift();
+          if(runnable) {
+            try {
+              runnable();
+            } catch(e) {
+              console.error("Caught error in run loop:");
+              console.error(e);
+            }
+          } else {
+            break;
+          }
+        }
+      } finally {
+        didEnter = false;
+      }
+    }
+  }
+
+  return { run };
+}

--- a/packages/core/src/state-machine.ts
+++ b/packages/core/src/state-machine.ts
@@ -12,10 +12,6 @@ export type StateTransition = {
 export class StateMachine {
   current: State = 'pending';
 
-  get isFinishing(): boolean {
-    return ['completing', 'halting', 'erroring'].includes(this.current);
-  }
-
   constructor(private emitter: EventEmitter) {}
 
   private transition(event: string, validTransitions: Partial<Record<State, State>>) {
@@ -37,17 +33,14 @@ export class StateMachine {
     });
   }
 
-  resolve() {
-    this.transition('resolve', {
+  completing() {
+    this.transition('completing', {
       'running': 'completing',
-      'completing': 'completing',
-      'erroring': 'erroring',
-      'halting': 'halting',
     });
   }
 
-  reject() {
-    this.transition('reject', {
+  erroring() {
+    this.transition('erroring', {
       'running': 'erroring',
       'completing': 'erroring',
       'halting': 'erroring',
@@ -55,15 +48,11 @@ export class StateMachine {
     });
   }
 
-  halt() {
-    this.transition('halt', {
+  halting() {
+    this.transition('halting', {
       'running': 'halting',
       'completing': 'halting',
       'halting': 'halting',
-      'erroring': 'erroring',
-      'halted': 'halted',
-      'completed': 'completed',
-      'errored': 'errored',
     });
   }
 

--- a/packages/core/test/task.test.ts
+++ b/packages/core/test/task.test.ts
@@ -5,6 +5,16 @@ import * as expect from 'expect';
 import { run, sleep, createTask, Task, getControls } from '../src/index';
 
 describe('Task', () => {
+  describe('halt', () => {
+    it('is idempotent', async () => {
+      let task = run();
+      await task.halt();
+      await task.halt();
+      await task.halt();
+      expect(task.state).toEqual('halted');
+    });
+  });
+
   describe('type', () => {
     it('returns the type of the task', async () => {
       expect(run(Promise.resolve(123)).type).toEqual('promise');


### PR DESCRIPTION
There are a lot of problems which occur with re-entrancy in Effection. Additionally, the code around task shutdown is hard to understand and the relationship between the controller and the task is unclear. This change attempts to clean up some of these internals by introducing a `Continuation` a sort of synchronously resolving promise. Additionally we introduce a run loop, a sort of synchronous mutex. This is used internally by the continuation, as well as by other components directly.