### PR TITLE
Remove `Controls` from Task

### DIFF
--- a/.changeset/itchy-knives-serve.md
+++ b/.changeset/itchy-knives-serve.md
@@ -1,0 +1,6 @@
+---
+"@effection/core": minor
+"effection": minor
+---
+
+Remove `Controls` and `getControls`. Make more parts of the task interface public

--- a/packages/core/src/controller/iterator-controller.ts
+++ b/packages/core/src/controller/iterator-controller.ts
@@ -1,6 +1,6 @@
 import { Controller } from './controller';
 import { OperationIterator } from '../operation';
-import { createTask, Task, getControls } from '../task';
+import { createTask, Task } from '../task';
 import { Operation } from '../operation';
 import { createFuture, Value } from '../future';
 import { createRunLoop } from '../run-loop';
@@ -52,8 +52,8 @@ export function createIteratorController<TOut>(task: Task<TOut>, iterator: Opera
         }
       } else {
         subTask = createTask(next.value, { resourceScope: options.resourceScope || task, ignoreError: true });
-        getControls(subTask).future.consume(trap);
-        getControls(subTask).start();
+        subTask.future.consume(trap);
+        subTask.start();
       }
     });
   }

--- a/packages/core/src/controller/resolution-controller.ts
+++ b/packages/core/src/controller/resolution-controller.ts
@@ -1,11 +1,10 @@
 import { Controller } from './controller';
 import { OperationResolution } from '../operation';
-import { Task, getControls } from '../task';
+import { Task } from '../task';
 import { createFuture } from '../future';
 
 export function createResolutionController<TOut>(task: Task<TOut>, resolution: OperationResolution<TOut>): Controller<TOut> {
   let { future, resolve } = createFuture<TOut>();
-  let controls = getControls(task);
 
   function start() {
     try {
@@ -15,7 +14,7 @@ export function createResolutionController<TOut>(task: Task<TOut>, resolution: O
       );
 
       if (atExit) {
-        controls.future.consume(atExit);
+        task.future.consume(atExit);
       }
     } catch(error) {
       resolve({ state: 'errored', error });

--- a/packages/core/src/effection.ts
+++ b/packages/core/src/effection.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { Task, createTask, getControls } from './task';
+import { Task, createTask } from './task';
 import { version } from '../package.json';
 
 const MAJOR_VERSION = version.split('.')[0];
@@ -7,7 +7,7 @@ const GLOBAL_PROPERTY = `__effectionV${MAJOR_VERSION}`;
 
 function createRootTask() {
   let task = createTask(undefined, { ignoreChildErrors: true });
-  getControls(task).start();
+  task.start();
   return task;
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,7 +3,7 @@ import { Task, TaskOptions } from './task';
 import { Effection } from './effection';
 
 export { State, StateTransition } from './state-machine';
-export { createTask, Task, TaskOptions, Controls, getControls } from './task';
+export { createTask, Task, TaskOptions } from './task';
 export { Operation, Resource } from './operation';
 export { Effection } from './effection';
 export { deprecated } from './deprecated';

--- a/packages/core/src/operations/label.ts
+++ b/packages/core/src/operations/label.ts
@@ -1,4 +1,3 @@
-import { getControls } from '../task';
 import { Resource } from '../operation';
 import { Labels } from '../labels';
 
@@ -6,7 +5,7 @@ export function label(labels: Labels): Resource<void> {
   return {
     name: 'label',
     *init(scope) {
-      getControls(scope).setLabels(labels);
+      scope.setLabels(labels);
     }
   }
 }

--- a/packages/core/test/labels.test.ts
+++ b/packages/core/test/labels.test.ts
@@ -2,7 +2,7 @@ import './setup';
 import { describe, it } from 'mocha';
 import * as expect from 'expect';
 
-import { withLabels, run, getControls, sleep, label, Labels } from '../src/index';
+import { withLabels, run, sleep, label, Labels } from '../src/index';
 
 describe('labels', () => {
   describe('withLabels', () => {
@@ -62,7 +62,7 @@ describe('labels', () => {
 
     let events: Labels[] = []
 
-    getControls(task).on('labels', (labels) => events.push(labels));
+    task.on('labels', (labels) => events.push(labels));
 
     expect(task.labels).toEqual({});
 

--- a/packages/core/test/run.test.ts
+++ b/packages/core/test/run.test.ts
@@ -2,11 +2,11 @@ import './setup';
 import { describe, it } from 'mocha';
 import * as expect from 'expect';
 
-import { run, Effection, Task, getControls } from '../src/index';
+import { run, Effection, Task } from '../src/index';
 
 describe('run', () => {
   it('adds the new task to the global task', () => {
     let task = run(Promise.resolve(123))
-    expect(getControls(Effection.root).children.has(task as Task)).toEqual(true);
+    expect(Effection.root.children.includes(task as Task)).toEqual(true);
   });
 });

--- a/packages/core/test/task.test.ts
+++ b/packages/core/test/task.test.ts
@@ -2,9 +2,28 @@ import './setup';
 import { describe, it } from 'mocha';
 import * as expect from 'expect';
 
-import { run, sleep, createTask, Task, getControls } from '../src/index';
+import { run, sleep, createTask, Task } from '../src/index';
 
 describe('Task', () => {
+  describe('children', () => {
+    it('returns the tasks children', async () => {
+      let task = run();
+      let child1 = task.spawn();
+      let child2 = task.spawn();
+      expect(task.children).toEqual([child1, child2]);
+    });
+  });
+
+  describe('start', () => {
+    it('is idempotent', async () => {
+      let task = run();
+      await task.start();
+      await task.start();
+      await task.start();
+      expect(task.state).toEqual('running');
+    });
+  });
+
   describe('halt', () => {
     it('is idempotent', async () => {
       let task = run();
@@ -68,8 +87,8 @@ describe('Task', () => {
       let events: { to: string; from: string }[] = []
       let task = createTask(function*() { sleep(5) });
 
-      getControls(task).on('state', (transition) => events.push(transition));
-      getControls(task).start();
+      task.on('state', (transition) => events.push(transition));
+      task.start();
 
       await task;
 
@@ -86,7 +105,7 @@ describe('Task', () => {
       let events: Task[] = []
       let task = run();
 
-      getControls(task).on('link', (child) => events.push(child));
+      task.on('link', (child) => events.push(child));
 
       let child = task.spawn();
 
@@ -99,7 +118,7 @@ describe('Task', () => {
       let events: Task[] = []
       let task = run();
 
-      getControls(task).on('unlink', (child) => events.push(child));
+      task.on('unlink', (child) => events.push(child));
 
       let child = task.spawn(function*() { yield sleep(5); return 1 });
 
@@ -112,7 +131,7 @@ describe('Task', () => {
       let events: Task[] = []
       let task = run();
 
-      getControls(task).on('unlink', (child) => events.push(child));
+      task.on('unlink', (child) => events.push(child));
 
       let child = task.spawn(function*() { yield sleep(5); return 1 });
 


### PR DESCRIPTION
The `Controls` no longer really have a purpose. The methods on `Controls` can be either made public or removed entirely now.