### PR TITLE
Make `Future` an operation type

### DIFF
--- a/.changeset/happy-elephants-rush.md
+++ b/.changeset/happy-elephants-rush.md
@@ -1,0 +1,6 @@
+---
+"@effection/core": minor
+"effection": minor
+---
+
+Allow futures as an operation type

--- a/.changeset/ten-ants-relax.md
+++ b/.changeset/ten-ants-relax.md
@@ -1,0 +1,6 @@
+---
+"@effection/core": minor
+"effection": minor
+---
+
+Enable tasks to resolve synchronously when used as an operation

--- a/packages/core/src/controller/controller.ts
+++ b/packages/core/src/controller/controller.ts
@@ -1,11 +1,12 @@
 import type { Task } from '../task';
 import type { Operation } from '../operation';
-import { isResource, isResolution, isPromise, isGenerator } from '../predicates';
+import { isResource, isResolution, isFuture, isPromise, isGenerator } from '../predicates';
 import { createFunctionController } from './function-controller';
 import { createSuspendController } from './suspend-controller';
 import { createPromiseController } from './promise-controller';
 import { createIteratorController } from './iterator-controller';
 import { createResolutionController } from './resolution-controller';
+import { createFutureController } from './future-controller';
 import { createResourceController } from './resource-controller';
 import { Future } from '../future';
 
@@ -23,7 +24,9 @@ export function createController<T>(task: Task<T>, operation: Operation<T>): Con
     return createSuspendController();
   } else if (isResource(operation)) {
     return createResourceController(task, operation);
-  } else if (isResolution(operation)) {
+  } else if (isFuture<T>(operation)) {
+    return createFutureController(task, operation);
+  } else if (isResolution<T>(operation)) {
     return createResolutionController(task, operation);
   } else if(isPromise(operation)) {
     return createPromiseController(task, operation);

--- a/packages/core/src/controller/future-controller.ts
+++ b/packages/core/src/controller/future-controller.ts
@@ -1,0 +1,17 @@
+import { Controller } from './controller';
+import { Task } from '../task';
+import { createFuture, FutureLike } from '../future';
+
+export function createFutureController<TOut>(task: Task<TOut>, future: FutureLike<TOut>): Controller<TOut> {
+  let { future: inner, resolve } = createFuture<TOut>();
+
+  function start() {
+    future.consume(resolve);
+  }
+
+  function halt() {
+    resolve({ state: 'halted' });
+  }
+
+  return { start, halt, future: inner, type: 'future' };
+}

--- a/packages/core/src/operation.ts
+++ b/packages/core/src/operation.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { Task } from './task';
-import { Labels } from './labels';
+import type { Task } from './task';
+import type { Labels } from './labels';
+import type { FutureLike } from './future';
 
 export interface Labelled {
   name?: string;
@@ -17,11 +18,14 @@ export interface OperationResolution<TOut> extends Labelled {
   perform(resolve: (value: TOut) => void, reject: (err: Error) => void): void | (() => void);
 };
 
+export interface OperationFuture<TOut> extends FutureLike<TOut>, Labelled {
+};
+
 export interface Resource<TOut> extends Labelled {
   init(scope: Task, local: Task): OperationIterator<TOut>;
 }
 
-export type OperationValue<TOut> = OperationPromise<TOut> | OperationIterator<TOut> | OperationResolution<TOut> | undefined;
+export type OperationValue<TOut> = OperationPromise<TOut> | OperationIterator<TOut> | OperationResolution<TOut> | OperationFuture<TOut> | undefined;
 
 export interface OperationFunction<TOut> extends Labelled {
   (task: Task<TOut>): OperationValue<TOut>;

--- a/packages/core/src/predicates.ts
+++ b/packages/core/src/predicates.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { OperationResolution, Resource } from "./operation";
+import type { OperationResolution, Resource } from "./operation";
+import type { FutureLike } from "./future";
 
 export function isPromise(value: any): value is PromiseLike<unknown> {
   return value && typeof(value.then) === 'function';
@@ -12,6 +13,10 @@ export function isGenerator(value: any): value is Iterator<unknown> {
 
 export function isResolution<T>(value: any): value is OperationResolution<T> {
   return value && typeof(value.perform) === 'function';
+}
+
+export function isFuture<T>(value: any): value is FutureLike<T> {
+  return value && typeof(value.consume) === 'function';
 }
 
 export function isResource<TOut>(value: any): value is Resource<TOut> {

--- a/packages/core/test/iterator.test.ts
+++ b/packages/core/test/iterator.test.ts
@@ -2,7 +2,7 @@ import { createNumber, blowUp } from './setup';
 import { describe, it } from 'mocha';
 import * as expect from 'expect';
 
-import { run, sleep, createFuture, Task } from '../src/index';
+import { run, sleep, Task, createFuture } from '../src/index';
 
 describe('generator function', () => {
   it('can compose multiple promises via generator', async () => {
@@ -184,13 +184,13 @@ describe('generator function', () => {
   });
 
   it('can be halted while in the generator', async () => {
+    let { future, resolve } = createFuture();
     let task = run(function*(inner) {
-      let reject: (error: Error) => void;
       inner.spawn(function*() {
         yield sleep(2);
-        reject && reject(new Error('boom'));
+        resolve({ state: 'errored', error: new Error('boom') });
       });
-      yield { perform: (_res, rej) => { reject = rej } };
+      yield future;
     });
 
     await expect(task).rejects.toHaveProperty('message', 'boom');

--- a/packages/core/test/labels.test.ts
+++ b/packages/core/test/labels.test.ts
@@ -46,12 +46,6 @@ describe('labels', () => {
     await expect(task.labels).toEqual({ name: "blahBlah" });
   });
 
-  it('applies name label from other name', async () => {
-    let task = run({ perform: () => { /* no op */ }, name: "doSomething" });
-
-    await expect(task.labels).toEqual({ name: "doSomething" });
-  });
-
   it('can change labels dynamically', async () => {
     let task = run(function*() {
       yield sleep(5);

--- a/packages/core/test/task.future.test.ts
+++ b/packages/core/test/task.future.test.ts
@@ -1,0 +1,56 @@
+import './setup';
+import { describe, it } from 'mocha';
+import * as expect from 'expect';
+
+import { run, sleep, createFuture } from '../src/index';
+
+describe('task with future', () => {
+  it('resolves when resolve is called', async () => {
+    let { future, resolve } = createFuture<number>();
+    let task = run(future);
+
+    await run(sleep(5));
+    resolve({ state: 'completed', value: 123 });
+
+    await expect(task).resolves.toEqual(123);
+    expect(task.state).toEqual('completed');
+  });
+
+  it('can resolve synchronously', async () => {
+    let { future, resolve } = createFuture<number>();
+    resolve({ state: 'completed', value: 123 });
+
+    let task = run(future);
+    expect(task.state).toEqual('completed');
+  });
+
+  it('can resolve task synchronously', async () => {
+    let { future, resolve } = createFuture<number>();
+    resolve({ state: 'completed', value: 123 });
+
+    let task = run(future);
+    let other = run(task);
+    expect(other.state).toEqual('completed');
+  });
+
+  it('rejects when reject is called', async () => {
+    let { future, resolve } = createFuture<number>();
+    let task = run(future);
+
+    await run(sleep(5));
+    resolve({ state: 'errored', error: new Error('boom') });
+
+    await expect(task).rejects.toHaveProperty('message', 'boom');
+    expect(task.state).toEqual('errored');
+  });
+
+  it('can be halted', async () => {
+    let { future } = createFuture<number>();
+    let task = run(future);
+
+    await task.halt();
+
+    await expect(task).rejects.toHaveProperty('message', 'halted')
+    expect(task.state).toEqual('halted');
+  });
+});

--- a/packages/core/test/task.test.ts
+++ b/packages/core/test/task.test.ts
@@ -2,12 +2,14 @@ import './setup';
 import { describe, it } from 'mocha';
 import * as expect from 'expect';
 
-import { run, sleep, createTask, Task } from '../src/index';
+import { run, sleep, createTask, Task, createFuture } from '../src/index';
 
 describe('Task', () => {
   describe('consume', () => {
     it('can be consumed as future', async () => {
-      let task = run({ perform: (resolve) => resolve(123) });
+      let { future, resolve } = createFuture();
+      resolve({ state: 'completed', value: 123 });
+      let task = run(future);
       let result;
       task.consume(value => result = value);
       expect(result).toEqual({ state: 'completed', value: 123 });
@@ -51,6 +53,7 @@ describe('Task', () => {
       expect(run((function*() { /* no op */ })()).type).toEqual('generator');
       expect(run().type).toEqual('suspend');
       expect(run({ perform() { /* no op */ } }).type).toEqual('resolution');
+      expect(run(createFuture().future).type).toEqual('future');
       expect(run({ *init() { /* no op */ } }).type).toEqual('resource');
     });
   });


### PR DESCRIPTION
Depends on #355 

## Motivation

Resolution functions where introduced because writing leaf nodes as generators is not always easy, for example formulating `sleep` as a generator is basically impossible. And while it might be possible to write an iterator by hand this is not convenient. The alternative leaf node is a Promise, but promises have the problem that they always resolve asynchronously. This is a problem for example for `@effection/events`, where synchronous resolution is very important to prevent race conditions.

However, resolution functions are awkward. Not only do they require this rather odd `perform` function, but they just feel like a thing which was tacked on to solve a need, without really being excellent in their design.

## Approach

Enter: Futures. Futures were introduced in #350 as a new way of structuring the internals of Effection. A future is in effect something similar to a synchronous promise. Doesn't this sound pretty similar to our resolution functions? What if we just got rid of resolution functions entirely and used only futures instead. This would mean our leaf nodes are always either a promise, or a future, which is in effect kinda-sorta a promise.

In this PR we add futures as an alternative to resolution functions, with an eye towards possibly removing resolution functions in the future.

### Alternate Designs

None

### Possible Drawbacks or Risks

Futures are a bit hard to understand, and their API is a little awkward, so it might be difficult for people to understand these? Then again having to work with them should be rare for user code.

### TODOs and Open Questions

<!-- OPTIONAL
- [ ] Is this a good idea? Should we do this?