### PR TITLE
Add FutureLike interface and implement it for Task

### DIFF
--- a/.changeset/selfish-mangos-repeat.md
+++ b/.changeset/selfish-mangos-repeat.md
@@ -1,0 +1,6 @@
+---
+"@effection/core": minor
+"effection": minor
+---
+
+Add `FutureLike` interface and implement it for `Task`

--- a/packages/core/src/controller/iterator-controller.ts
+++ b/packages/core/src/controller/iterator-controller.ts
@@ -52,7 +52,7 @@ export function createIteratorController<TOut>(task: Task<TOut>, iterator: Opera
         }
       } else {
         subTask = createTask(next.value, { resourceScope: options.resourceScope || task, ignoreError: true });
-        subTask.future.consume(trap);
+        subTask.consume(trap);
         subTask.start();
       }
     });

--- a/packages/core/src/controller/resolution-controller.ts
+++ b/packages/core/src/controller/resolution-controller.ts
@@ -14,7 +14,7 @@ export function createResolutionController<TOut>(task: Task<TOut>, resolution: O
       );
 
       if (atExit) {
-        task.future.consume(atExit);
+        task.consume(atExit);
       }
     } catch(error) {
       resolve({ state: 'errored', error });

--- a/packages/core/src/future.ts
+++ b/packages/core/src/future.ts
@@ -12,9 +12,12 @@ export interface Consumer<T> {
   (value: Value<T>): void;
 }
 
-export interface Future<T> extends Promise<T> {
-  state: State;
+export interface FutureLike<T> {
   consume<R>(consumer: Consumer<T>): void;
+}
+
+export interface Future<T> extends Promise<T>, FutureLike<T> {
+  state: State;
 }
 
 export interface NewFuture<T> {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,7 +9,7 @@ export { Effection } from './effection';
 export { deprecated } from './deprecated';
 export { Labels, withLabels } from './labels';
 export { HasEffectionTrace, TaskInfo } from './error';
-export { createFuture, Future } from './future';
+export { createFuture, Future, FutureLike } from './future';
 
 export { sleep } from './operations/sleep';
 export { ensure } from './operations/ensure';

--- a/packages/core/test/task.test.ts
+++ b/packages/core/test/task.test.ts
@@ -5,6 +5,15 @@ import * as expect from 'expect';
 import { run, sleep, createTask, Task } from '../src/index';
 
 describe('Task', () => {
+  describe('consume', () => {
+    it('can be consumed as future', async () => {
+      let task = run({ perform: (resolve) => resolve(123) });
+      let result;
+      task.consume(value => result = value);
+      expect(result).toEqual({ state: 'completed', value: 123 });
+    });
+  });
+
   describe('children', () => {
     it('returns the tasks children', async () => {
       let task = run();


### PR DESCRIPTION
This adds a minimal interface, similar to the `PromiseLike` interface. This skips the `state` property, as well as the requirement of extending promise. This interface is implemented for `Task` so that `Task` can act as a future. We cannot implement the full `Future` interface, since the `state` properties conflict.