### PR TITLE
Publish npm packages from `v0` branch using the `r0` tag.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,15 @@
+version: 2.1
+
+# Define the jobs we want to run for this project
+jobs:
+  empty:
+    docker:
+      image: alpine:latest
+    steps:
+      - run: echo "we believe in nothing Lebowski... Nothing!"
+
+# Orchestrate our job to absolutely nothing
+workflows:
+  default:
+    jobs:
+      - empty

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 jobs:
   empty:
     docker:
-      image: alpine:latest
+      - image: alpine:latest
     steps:
       - run: echo "we believe in nothing Lebowski... Nothing!"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       uses: thefrontside/actions/synchronize-with-npm@v1.7
       with:
         before_all: yarn prepack
-        npm_publish: yarn publish
+        npm_publish: yarn publish --tag r0
       env:
         GITHUB_TOKEN: ${{ secrets.FRONTSIDEJACK_GITHUB_TOKEN }}
         NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}


### PR DESCRIPTION
## Motivation
It is very unlikely that we would publish an Effection npm package from the `v0` branch, but as configured, this will make it the `latest` version on npm which is almost certainly not what we want.

## Approach
If, on the offhand chance that, that we would need to publish a patch from the `v0` branch, it would be published under the `r0` tags (standing for "release 0"). I would have like to have made this `v0`, but tags cannot be valid semver values, and TIL semver specs may optionally start with `v`, so that makes `v0` illegal.

Also, this disable preview releases for `v0` since this branch is in maintenance mode
