### PR TITLE
Begin release 2 beta series

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,21 +1,7 @@
 {
   "mode": "pre",
-  "tag": "preview",
-  "initialVersions": {
-    "@effection/channel": "1.0.0",
-    "effection": "1.0.0",
-    "@effection/events": "1.0.0",
-    "@effection/fetch": "1.0.0",
-    "@effection/node": "1.0.0",
-    "@effection/subscription": "1.0.0",
-    "@effection/core": "2.0.0-preview.0",
-    "@effection/atom": "2.0.0-preview.3",
-    "@effection/mocha": "2.0.0-preview.2",
-    "@effection/main": "2.0.0-preview.1",
-    "@effection/websocket-client": "2.0.0-preview.1",
-    "@effection/websocket-server": "2.0.0-preview.1",
-    "@effection/react": "2.0.0-preview.1"
-  },
+  "tag": "beta",
+  "initialVersions": {},
   "changesets": [
     "atom-stream-initial-state",
     "blue-plants-lie",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       uses: thefrontside/actions/synchronize-with-npm@v1.7
       with:
         before_all: yarn prepack
-        npm_publish: yarn publish --tag v2-beta
+        npm_publish: yarn publish --tag latest
       env:
         GITHUB_TOKEN: ${{ secrets.FRONTSIDEJACK_GITHUB_TOKEN }}
         NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}


### PR DESCRIPTION
> depends on #369 and #370
## Motivation
We've made `v2` the default branch, the README is almost in place, and so we want the npm package that you download and install to be compatible with what you see when you visit the page and the documentation.

## Approach
This changes the prelease tag to be "beta", and when we publish, now the beta release gets the 'latest' tag, which is what will be selected when somebody just says `yarn add effection`