### PR TITLE
Add yieldingTo property to Task

### DIFF
--- a/.changeset/nasty-forks-raise.md
+++ b/.changeset/nasty-forks-raise.md
@@ -1,0 +1,6 @@
+---
+"@effection/core": minor
+"effection": minor
+---
+
+Add `yieldingTo` property to task

--- a/packages/core/src/controller/controller.ts
+++ b/packages/core/src/controller/controller.ts
@@ -17,9 +17,14 @@ export interface Controller<TOut> {
   future: Future<TOut>;
 }
 
-export function createController<T>(task: Task<T>, operation: Operation<T>): Controller<T> {
+export type Options = {
+  resourceScope?: Task;
+  onYieldingToChange?: (task: Task | undefined) => void;
+}
+
+export function createController<T>(task: Task<T>, operation: Operation<T>, options: Options = {}): Controller<T> {
   if (typeof(operation) === 'function') {
-    return createFunctionController(task, () => createController(task, operation(task)));
+    return createFunctionController(task, () => createController(task, operation(task), options));
   } else if(!operation) {
     return createSuspendController();
   } else if (isResource(operation)) {
@@ -31,7 +36,7 @@ export function createController<T>(task: Task<T>, operation: Operation<T>): Con
   } else if(isPromise(operation)) {
     return createPromiseController(task, operation);
   } else if (isGenerator(operation)) {
-    return createIteratorController(task, operation);
+    return createIteratorController(task, operation, options);
   }
 
   throw new Error(`unkown type of operation: ${operation}`);

--- a/packages/core/src/task.ts
+++ b/packages/core/src/task.ts
@@ -27,6 +27,7 @@ export interface Task<TOut = unknown> extends Promise<TOut>, FutureLike<TOut> {
   readonly labels: Labels;
   readonly children: Task[];
   readonly future: Future<TOut>;
+  readonly yieldingTo: Task | undefined;
   catchHalt(): Promise<TOut | undefined>;
   setLabels(labels: Labels): void;
   spawn<R>(operation?: Operation<R>, options?: TaskOptions): Task<R>;
@@ -51,6 +52,7 @@ export function createTask<TOut = unknown>(operation: Operation<TOut>, options: 
   let controller: Controller<TOut>;
 
   let labels: Labels = { ...operation?.labels, ...options.labels }
+  let yieldingTo: Task | undefined;
 
   if(!labels.name && operation?.name) {
     labels.name = operation?.name;
@@ -70,6 +72,8 @@ export function createTask<TOut = unknown>(operation: Operation<TOut>, options: 
     get type() { return controller.type },
 
     get children() { return Array.from(children); },
+
+    get yieldingTo() { return yieldingTo },
 
     catchHalt() {
       return future.catch(swallowHalt);
@@ -117,7 +121,12 @@ export function createTask<TOut = unknown>(operation: Operation<TOut>, options: 
     [Symbol.toStringTag]: `[Task ${id}]`,
   }
 
-  controller = createController(task, operation);
+  controller = createController(task, operation, {
+    onYieldingToChange(value) {
+      yieldingTo = value;
+      emitter.emit('yieldingTo', value);
+    }
+  });
 
   controller.future.consume((value) => {
     if(value.state === 'completed') {


### PR DESCRIPTION
## Motivation

The task an iterator controller is currently yielding to is an important piece of information about a task. This property will be used by the debugger to read the currently yielding to task.

## Approach

Since we want to implement this without coupling the task and controller and without adding a method to the task to set the Task, we implement it via a callback. This isn't super elegant, but I'm unsure of a better approach.

### Alternate Designs

~~I'd really like to bikeshed the name of this, since it starts to leak out into public APIs and `subTask` isn't a great name. I've been racking my brain trying to come up with a better name, but I haven't come up with a decent alternative.~~

### Possible Drawbacks or Risks

It further expands the scope of the Task API