### PR TITLE
Add `toJSON` method to Task

### DIFF
--- a/.changeset/shiny-mails-complain.md
+++ b/.changeset/shiny-mails-complain.md
@@ -1,0 +1,6 @@
+---
+"@effection/core": minor
+"effection": minor
+---
+
+Add toJSON method to Task

--- a/packages/core/src/error.ts
+++ b/packages/core/src/error.ts
@@ -1,11 +1,4 @@
-import type { Task } from './task';
-import type { Labels } from './labels';
-
-export interface TaskInfo {
-  id: number;
-  type: string;
-  labels: Labels;
-}
+import type { Task, TaskInfo } from './task';
 
 export interface HasEffectionTrace {
   effectionTrace: TaskInfo[];
@@ -16,6 +9,7 @@ export function addTrace(error: Error & Partial<HasEffectionTrace>, task: Task):
     id: task.id,
     type: task.type,
     labels: task.labels,
+    state: task.state,
   };
 
   let properties = Object.getOwnPropertyDescriptors(error);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,12 +3,12 @@ import { Task, TaskOptions } from './task';
 import { Effection } from './effection';
 
 export { State, StateTransition } from './state-machine';
-export { createTask, Task, TaskOptions } from './task';
+export { createTask, Task, TaskOptions, TaskInfo, TaskTree } from './task';
 export { Operation, Resource } from './operation';
 export { Effection } from './effection';
 export { deprecated } from './deprecated';
 export { Labels, withLabels } from './labels';
-export { HasEffectionTrace, TaskInfo } from './error';
+export { HasEffectionTrace } from './error';
 export { createFuture, Future, FutureLike } from './future';
 
 export { sleep } from './operations/sleep';

--- a/packages/core/test/task.test.ts
+++ b/packages/core/test/task.test.ts
@@ -65,6 +65,38 @@ describe('Task', () => {
     });
   });
 
+  describe('toJSON', () => {
+    it('returns the full task information', async () => {
+      let task = run(function* theTask(inner) {
+        inner.spawn(undefined, { labels: { name: 'some-thing' } });
+        yield;
+      });
+
+      expect(task.toJSON()).toEqual({
+        id: task.id,
+        type: 'generator function',
+        labels: { name: 'theTask' },
+        state: 'running',
+        yieldingTo: {
+          id: task.yieldingTo?.id,
+          type: 'suspend',
+          labels: {},
+          yieldingTo: undefined,
+          state: 'running',
+          children: [],
+        },
+        children: [{
+          id: task.children[0]?.id,
+          type: 'suspend',
+          labels: { name: 'some-thing' },
+          yieldingTo: undefined,
+          state: 'running',
+          children: [],
+        }]
+      });
+    });
+  });
+
   describe('ensure', () => {
     it('attaches a handler which runs when the task finishes normally', async () => {
       let task = run(sleep(10));


### PR DESCRIPTION
Depends on #376 

## Motivation

It's nice to easily obtain a pure-data representation of a task. We can use this in the Debugger to serialize the Task, and we can also use it when working with tasks in the console, or print debugging.

## Approach

It uses the properties already available on `Task` to create a data-only representation of a task.

### Alternate Designs

None

### Possible Drawbacks or Risks

Further expands the Task API