### PR TITLE
WebsocketServer can accept HTTP server and port can be omitted

### DIFF
--- a/.changeset/heavy-walls-stare.md
+++ b/.changeset/heavy-walls-stare.md
@@ -1,0 +1,5 @@
+---
+"@effection/websocket-server": minor
+---
+
+Can accept an HTTP server and use random port if none given

--- a/packages/websocket-server/src/index.ts
+++ b/packages/websocket-server/src/index.ts
@@ -4,18 +4,30 @@ import { spawn, ensure, Resource, Operation } from '@effection/core'
 import { createQueue, Subscription } from '@effection/subscription';
 import { on, once } from '@effection/events';
 import * as http from 'http'
+import { AddressInfo } from 'net'
 
 export interface WebSocketConnection<TIncoming = unknown, TOutgoing = TIncoming> extends Subscription<TIncoming> {
   send(message: TOutgoing): Operation<void>;
 }
 
-export type WebSocketServer<TIncoming = unknown, TOutgoing = TIncoming> = Subscription<WebSocketConnection<TIncoming, TOutgoing>>;
+export type WebSocketSubscription<TIncoming = unknown, TOutgoing = TIncoming> = Subscription<WebSocketConnection<TIncoming, TOutgoing>>;
 
-export function createWebSocketServer<TIncoming = unknown, TOutgoing = TIncoming>(port: number): Resource<WebSocketServer<TIncoming, TOutgoing>> {
+export interface WebSocketServer<TIncoming = unknown, TOutgoing = TIncoming> extends WebSocketSubscription<TIncoming, TOutgoing> {
+  port: number;
+}
+
+type CreateOptions = {
+  http: http.Server;
+}
+
+type StartOptions = {
+  port?: number;
+};
+
+export function createWebSocketSubscription<TIncoming = unknown, TOutgoing = TIncoming>(options: CreateOptions): Resource<WebSocketSubscription<TIncoming, TOutgoing>> {
   return {
     *init(scope) {
-      let server = http.createServer();
-      let wss = new Server({ server: server });
+      let wss = new Server({ server: options.http });
 
       let queue = createQueue<WebSocketConnection<TIncoming, TOutgoing>>();
 
@@ -36,15 +48,33 @@ export function createWebSocketServer<TIncoming = unknown, TOutgoing = TIncoming
         });
       }));
 
-      server.listen(port);
+      yield ensure(() => { wss.close(); });
 
-      yield ensure(() => {
-        wss.close();
-        server.close();
+      return queue.subscription;
+    }
+  }
+}
+
+export function createWebSocketServer<TIncoming = unknown, TOutgoing = TIncoming>(options: StartOptions = {}): Resource<WebSocketServer<TIncoming, TOutgoing>> {
+  return {
+    *init() {
+      let httpServer = http.createServer();
+      httpServer.listen(options.port);
+      yield ensure(() => { httpServer.close(); });
+
+      let server = yield createWebSocketSubscription({ http: httpServer });
+
+      if(!httpServer.listening) {
+        yield once(httpServer, 'listening');
+      }
+
+      Object.defineProperty(server, 'port', {
+        get() {
+          return (httpServer.address() as AddressInfo).port;
+        }
       });
-      yield once(server, 'listening');
 
-      return queue.subscription
+      return server;
     }
   }
 }

--- a/packages/websocket-server/test/websocket.test.ts
+++ b/packages/websocket-server/test/websocket.test.ts
@@ -1,25 +1,52 @@
 import { describe, it, beforeEach } from '@effection/mocha';
 import * as expect from 'expect'
-import { spawn } from '@effection/core';
+import { createServer } from 'http'
+import { AddressInfo } from 'net'
+import { spawn, ensure } from '@effection/core';
+import { once } from '@effection/events';
 
 import { createWebSocketClient } from '@effection/websocket-client';
-import { createWebSocketServer, WebSocketServer } from '../src/index';
+import { createWebSocketServer, createWebSocketSubscription, WebSocketServer } from '../src/index';
 
 type Message = { value: string };
 
 describe("createWebSocketServer()", () => {
-  beforeEach(function*() {
-    let server: WebSocketServer<Message> = yield createWebSocketServer(47000);
+  it('can send and receive messages', function*() {
+    let server: WebSocketServer<Message> = yield createWebSocketServer();
 
     yield spawn(server.forEach(function*(connection) {
       yield connection.forEach(({ value }) => function*() {
         yield connection.send({ value: value.toUpperCase() });
       });
     }));
+
+    let client = yield createWebSocketClient<Message>(`ws://localhost:${server.port}`);
+
+    yield client.send({ value: 'hello' });
+    yield client.send({ value: 'world' });
+
+    expect(yield client.expect()).toEqual({ value: 'HELLO' });
+    expect(yield client.expect()).toEqual({ value: 'WORLD' });
   });
 
-  it('can send and receive messages', function*() {
-    let client = yield createWebSocketClient<Message>('ws://localhost:47000');
+  it('can provide own http server', function*() {
+    let http = createServer();
+
+    let server: WebSocketServer<Message> = yield createWebSocketSubscription({ http });
+
+    http.listen();
+    yield ensure(() => { http.close(); });
+    yield once(http, 'listening');
+
+    let port = (http.address() as AddressInfo).port;
+
+    yield spawn(server.forEach(function*(connection) {
+      yield connection.forEach(({ value }) => function*() {
+        yield connection.send({ value: value.toUpperCase() });
+      });
+    }));
+
+    let client = yield createWebSocketClient<Message>(`ws://localhost:${port}`);
 
     yield client.send({ value: 'hello' });
     yield client.send({ value: 'world' });


### PR DESCRIPTION
## Motivation

Rather than the websocket server always supplying its own http server, we can also send in our own, this makes it possible to use both websocket connections and other HTTP services on the same server.