### PR TITLE
Increase max listeners on task

### DIFF
--- a/.changeset/heavy-shoes-brake.md
+++ b/.changeset/heavy-shoes-brake.md
@@ -1,0 +1,6 @@
+---
+"@effection/core": minor
+"effection": minor
+---
+
+Increase max listeners on task

--- a/packages/core/src/task.ts
+++ b/packages/core/src/task.ts
@@ -42,6 +42,8 @@ export function createTask<TOut = unknown>(operation: Operation<TOut>, options: 
   let children = new Set<Task>();
   let emitter = new EventEmitter();
 
+  emitter.setMaxListeners(100000);
+
   let stateMachine = new StateMachine(emitter);
 
   let { resolve, future } = createFuture<TOut>();


### PR DESCRIPTION
The default number is too low as we know. Let's bump this to a very high number.