### PR TITLE
Upgrade tsconfig

### DIFF
--- a/packages/atom/package.json
+++ b/packages/atom/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@effection/mocha": "2.0.0-beta.1",
-    "@frontside/tsconfig": "^0.0.1",
+    "@frontside/tsconfig": "^1.2.0",
     "@types/node": "^13.13.5",
     "dtslint": "^4.0.7",
     "expect": "^25.4.0",

--- a/packages/atom/test/atom.test.ts
+++ b/packages/atom/test/atom.test.ts
@@ -1,5 +1,5 @@
 import { describe, beforeEach, it } from '@effection/mocha';
-import * as expect from 'expect';
+import expect from 'expect';
 import { createAtom } from '../src/atom';
 import { OperationIterator } from '@effection/subscription';
 import { Slice } from '../src/types';

--- a/packages/atom/test/slice.test.ts
+++ b/packages/atom/test/slice.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, beforeEach } from '@effection/mocha';
-import * as expect from 'expect';
+import expect from 'expect';
 import { createAtom } from '../src/atom';
 import { OperationIterator } from '@effection/subscription';
 import { Slice } from '../src/types';

--- a/packages/channel/package.json
+++ b/packages/channel/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@effection/mocha": "2.0.0-beta.1",
-    "@frontside/tsconfig": "^0.0.1",
+    "@frontside/tsconfig": "^1.2.0",
     "@types/node": "^13.13.5",
     "expect": "^25.4.0",
     "mocha": "^8.3.1",

--- a/packages/channel/test/channel.test.ts
+++ b/packages/channel/test/channel.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, beforeEach } from '@effection/mocha';
-import * as expect from 'expect';
+import expect from 'expect';
 
 import { sleep } from '@effection/core';
 import { createChannel, Channel } from '../src/index';

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,7 +17,7 @@
     "src/**/*"
   ],
   "devDependencies": {
-    "@frontside/tsconfig": "^0.0.1",
+    "@frontside/tsconfig": "^1.2.0",
     "@types/mocha": "^7.0.2",
     "@types/node": "^13.13.5",
     "eslint": "^6.8.0",

--- a/packages/core/test/error.test.ts
+++ b/packages/core/test/error.test.ts
@@ -1,6 +1,6 @@
 import './setup';
 import { describe, it } from 'mocha';
-import * as expect from 'expect';
+import expect from 'expect';
 
 import { run, sleep } from '../src/index';
 

--- a/packages/core/test/generator.test.ts
+++ b/packages/core/test/generator.test.ts
@@ -1,4 +1,4 @@
-import * as expect from 'expect';
+import expect from 'expect';
 import { describe, it } from 'mocha';
 import { run, Operation } from '../src/index';
 

--- a/packages/core/test/iterator.test.ts
+++ b/packages/core/test/iterator.test.ts
@@ -1,6 +1,6 @@
 import { createNumber, blowUp } from './setup';
 import { describe, it } from 'mocha';
-import * as expect from 'expect';
+import expect from 'expect';
 
 import { run, sleep, Task, createFuture } from '../src/index';
 

--- a/packages/core/test/labels.test.ts
+++ b/packages/core/test/labels.test.ts
@@ -1,6 +1,6 @@
 import './setup';
 import { describe, it } from 'mocha';
-import * as expect from 'expect';
+import expect from 'expect';
 
 import { withLabels, run, sleep, label, Labels } from '../src/index';
 

--- a/packages/core/test/operations/all.test.ts
+++ b/packages/core/test/operations/all.test.ts
@@ -1,6 +1,6 @@
 import { asyncResolve, asyncReject, syncResolve, syncReject } from '../setup';
 import { describe, it } from 'mocha';
-import * as expect from 'expect';
+import expect from 'expect';
 
 import { all, run, sleep } from '../../src/index';
 

--- a/packages/core/test/operations/ensure.test.ts
+++ b/packages/core/test/operations/ensure.test.ts
@@ -1,6 +1,6 @@
 import '../setup';
 import { describe, it } from 'mocha';
-import * as expect from 'expect';
+import expect from 'expect';
 
 import { run, sleep, ensure } from '../../src/index';
 

--- a/packages/core/test/operations/race.test.ts
+++ b/packages/core/test/operations/race.test.ts
@@ -1,6 +1,6 @@
 import { asyncResolve, asyncReject, syncResolve, syncReject } from '../setup';
 import { describe, it } from 'mocha';
-import * as expect from 'expect';
+import expect from 'expect';
 
 import { race, run } from '../../src/index';
 

--- a/packages/core/test/operations/sleep.test.ts
+++ b/packages/core/test/operations/sleep.test.ts
@@ -1,6 +1,6 @@
 import '../setup';
 import { describe, it } from 'mocha';
-import * as expect from 'expect';
+import expect from 'expect';
 
 import { run, sleep } from '../../src/index';
 

--- a/packages/core/test/operations/spawn.test.ts
+++ b/packages/core/test/operations/spawn.test.ts
@@ -1,6 +1,6 @@
 import '../setup';
 import { describe, it } from 'mocha';
-import * as expect from 'expect';
+import expect from 'expect';
 
 import { run, spawn, sleep, createFuture } from '../../src/index';
 

--- a/packages/core/test/operations/timeout.test.ts
+++ b/packages/core/test/operations/timeout.test.ts
@@ -1,6 +1,6 @@
 import '../setup';
 import { describe, it } from 'mocha';
-import * as expect from 'expect';
+import expect from 'expect';
 
 import { run, sleep, timeout } from '../../src/index';
 

--- a/packages/core/test/operations/with-timeout.test.ts
+++ b/packages/core/test/operations/with-timeout.test.ts
@@ -1,6 +1,6 @@
 import '../setup';
 import { describe, it } from 'mocha';
-import * as expect from 'expect';
+import expect from 'expect';
 
 import { run, sleep, withTimeout } from '../../src/index';
 

--- a/packages/core/test/promise.test.ts
+++ b/packages/core/test/promise.test.ts
@@ -1,6 +1,6 @@
 import './setup';
 import { describe, it } from 'mocha';
-import * as expect from 'expect';
+import expect from 'expect';
 
 import { run } from '../src/index';
 

--- a/packages/core/test/resolution.test.ts
+++ b/packages/core/test/resolution.test.ts
@@ -1,6 +1,6 @@
 import './setup';
 import { describe, it } from 'mocha';
-import * as expect from 'expect';
+import expect from 'expect';
 
 import { run } from '../src/index';
 

--- a/packages/core/test/resource.test.ts
+++ b/packages/core/test/resource.test.ts
@@ -1,6 +1,6 @@
 import './setup';
 import { describe, it } from 'mocha';
-import * as expect from 'expect';
+import expect from 'expect';
 
 import { Task, Resource, run, sleep } from '../src/index';
 

--- a/packages/core/test/run.test.ts
+++ b/packages/core/test/run.test.ts
@@ -1,6 +1,6 @@
 import './setup';
 import { describe, it } from 'mocha';
-import * as expect from 'expect';
+import expect from 'expect';
 
 import { run, Effection, Task } from '../src/index';
 

--- a/packages/core/test/spawn.test.ts
+++ b/packages/core/test/spawn.test.ts
@@ -1,6 +1,6 @@
 import './setup';
 import { describe, it } from 'mocha';
-import * as expect from 'expect';
+import expect from 'expect';
 
 import { run, sleep, Task } from '../src/index';
 

--- a/packages/core/test/suspend.test.ts
+++ b/packages/core/test/suspend.test.ts
@@ -1,6 +1,6 @@
 import './setup';
 import { describe, it } from 'mocha';
-import * as expect from 'expect';
+import expect from 'expect';
 
 import { run, sleep } from '../src/index';
 

--- a/packages/core/test/task.future.test.ts
+++ b/packages/core/test/task.future.test.ts
@@ -1,6 +1,6 @@
 import './setup';
 import { describe, it } from 'mocha';
-import * as expect from 'expect';
+import expect from 'expect';
 
 import { run, sleep, createFuture } from '../src/index';
 

--- a/packages/core/test/task.test.ts
+++ b/packages/core/test/task.test.ts
@@ -1,6 +1,6 @@
 import './setup';
 import { describe, it } from 'mocha';
-import * as expect from 'expect';
+import expect from 'expect';
 
 import { run, sleep, createTask, Task, createFuture, withLabels } from '../src/index';
 

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@effection/mocha": "2.0.0-beta.1",
-    "@frontside/tsconfig": "0.0.1",
+    "@frontside/tsconfig": "^1.2.0",
     "@types/node": "^13.13.5",
     "expect": "^25.4.0",
     "mocha": "^8.3.1",

--- a/packages/events/test/on.test.ts
+++ b/packages/events/test/on.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, beforeEach } from '@effection/mocha';
-import * as expect from 'expect'
+import expect from 'expect'
 
 import { sleep } from '@effection/core';
 import { OperationIterator } from '@effection/subscription';

--- a/packages/events/test/once.test.ts
+++ b/packages/events/test/once.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, beforeEach } from '@effection/mocha';
-import * as expect from 'expect'
+import expect from 'expect'
 
 import { sleep, Task } from '@effection/core';
 import { EventEmitter } from 'events';

--- a/packages/events/test/throw-on-error-event.test.ts
+++ b/packages/events/test/throw-on-error-event.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, beforeEach, captureError } from '@effection/mocha';
-import * as expect from 'expect'
+import expect from 'expect'
 
 import { Task } from '@effection/core';
 import { EventEmitter } from 'events';

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@effection/mocha": "2.0.0-beta.1",
-    "@frontside/tsconfig": "^0.0.1",
+    "@frontside/tsconfig": "^1.2.0",
     "@types/node": "^13.13.5",
     "expect": "26.0.1",
     "mocha": "8.3.1",

--- a/packages/fetch/test/fetch.test.ts
+++ b/packages/fetch/test/fetch.test.ts
@@ -2,7 +2,7 @@ import { IncomingMessage } from 'http';
 import { EchoServer } from "./echo-server";
 import { when, never } from "./helpers";
 import { fetch } from "../src";
-import * as expect from 'expect';
+import expect from 'expect';
 
 import { describe, it, beforeEach } from '@effection/mocha';
 

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@effection/mocha": "2.0.0-beta.1",
     "@effection/process": "2.0.0-beta.1",
-    "@frontside/tsconfig": "0.0.1",
+    "@frontside/tsconfig": "^1.2.0",
     "@types/node": "^13.13.5",
     "expect": "^25.4.0",
     "mocha": "^8.3.1",

--- a/packages/main/src/format-error-node.ts
+++ b/packages/main/src/format-error-node.ts
@@ -1,7 +1,7 @@
 import { HasEffectionTrace } from '@effection/core';
 import { isMainError } from './error';
-import * as chalk from 'chalk';
-import * as stackTraceParser from 'stacktrace-parser';
+import chalk from 'chalk';
+import { parse as parseStackTrace } from 'stacktrace-parser';
 
 export function formatName(error: Error): string {
   return chalk.bgRed.white.bold(error.name);
@@ -32,7 +32,7 @@ export function formatEffection(error: Error & Partial<HasEffectionTrace>): stri
 
 export function formatStack(error: Error): string | undefined {
   if(error.stack) {
-    let stack = stackTraceParser.parse(error.stack).map((item) => {
+    let stack = parseStackTrace(error.stack).map((item) => {
       return [
         chalk.grey('  -'),
         item.methodName && chalk.cyan(item.methodName),

--- a/packages/main/test/node.test.ts
+++ b/packages/main/test/node.test.ts
@@ -1,5 +1,5 @@
-import * as path from 'path';
-import * as expect from 'expect';
+import path from 'path';
+import expect from 'expect';
 import { describe, it, beforeEach } from '@effection/mocha';
 
 import { exec, Process, ProcessResult } from '@effection/process';

--- a/packages/mocha/package.json
+++ b/packages/mocha/package.json
@@ -25,7 +25,7 @@
     "mocha": "^8.0.0"
   },
   "devDependencies": {
-    "@frontside/tsconfig": "0.0.1",
+    "@frontside/tsconfig": "^1.2.0",
     "@types/mocha": "^8.0.3",
     "expect": "^25.4.0",
     "mocha": "^8.0.0",

--- a/packages/mocha/src/index.ts
+++ b/packages/mocha/src/index.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion,@typescript-eslint/no-explicit-any */
-import * as mocha from 'mocha';
+import mocha from 'mocha';
 import { run, Task, Effection, Operation } from '@effection/core';
 
 let world: Task | undefined;

--- a/packages/mocha/test/mocha.test.ts
+++ b/packages/mocha/test/mocha.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, beforeEach, captureError } from '../src/index';
-import * as expect from 'expect';
+import expect from 'expect';
 
 import { Task, Resource, sleep } from '@effection/core';
 

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -20,7 +20,7 @@
     "prepack": "tsdx build --target node --format cjs --tsconfig tsconfig.dist.json"
   },
   "devDependencies": {
-    "@frontside/tsconfig": "0.0.1",
+    "@frontside/tsconfig": "^1.2.0",
     "ts-node": "^8.9.0",
     "tsdx": "0.13.2",
     "typedoc": "^0.20.36",

--- a/packages/process/package.json
+++ b/packages/process/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@effection/mocha": "2.0.0-beta.1",
-    "@frontside/tsconfig": "0.0.1",
+    "@frontside/tsconfig": "^1.2.0",
     "@types/cross-spawn": "^6.0.2",
     "@types/node": "^13.13.5",
     "@types/node-fetch": "^2.5.7",

--- a/packages/process/test/daemon.test.ts
+++ b/packages/process/test/daemon.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, beforeEach, afterEach } from '@effection/mocha';
-import * as expect from 'expect';
+import expect from 'expect';
 import fetch from 'node-fetch';
 
 import '@effection/mocha';

--- a/packages/process/test/exec.test.ts
+++ b/packages/process/test/exec.test.ts
@@ -1,6 +1,6 @@
 import { Task } from '@effection/core';
 import { describe, it, beforeEach, captureError } from '@effection/mocha';
-import * as expect from 'expect';
+import expect from 'expect';
 
 import { exec, Process, ProcessResult } from '../src';
 import fetch from 'node-fetch';

--- a/packages/process/test/helpers.ts
+++ b/packages/process/test/helpers.ts
@@ -1,6 +1,6 @@
 import { performance } from 'perf_hooks';
 import { beforeEach } from 'mocha';
-import * as expect from 'expect';
+import expect from 'expect';
 import { run, Task } from '@effection/core';
 import { Channel } from '@effection/channel';
 import { ctrlc } from 'ctrlc-windows';

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@effection/mocha": "2.0.0-beta.1",
-    "@frontside/tsconfig": "0.0.1",
+    "@frontside/tsconfig": "^1.2.0",
     "@types/node": "^13.13.5",
     "@types/react": "^17.0.8",
     "@types/react-test-renderer": "^17.0.1",

--- a/packages/react/test/helpers.tsx
+++ b/packages/react/test/helpers.tsx
@@ -1,7 +1,7 @@
-import * as TestRenderer from 'react-test-renderer';
+import TestRenderer from 'react-test-renderer';
 import { ensure, Effection, Resource } from '@effection/core';
 import { EffectionContext } from '../src/index';
-import * as React from 'react';
+import React from 'react';
 
 export function render(element: JSX.Element): Resource<TestRenderer.ReactTestRenderer> {
   return {

--- a/packages/react/test/use-subscription.test.tsx
+++ b/packages/react/test/use-subscription.test.tsx
@@ -1,9 +1,9 @@
 import { describe, it } from '@effection/mocha';
-import * as expect from 'expect';
+import expect from 'expect';
 import { createQueue, Subscription } from '@effection/subscription';
 import { sleep } from '@effection/core';
 import { useSubscription } from '../src/index';
-import * as React from 'react';
+import React from 'react';
 import { ReactTestRenderer } from 'react-test-renderer';
 import { render } from './helpers';
 

--- a/packages/subscription/package.json
+++ b/packages/subscription/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@effection/mocha": "2.0.0-beta.1",
-    "@frontside/tsconfig": "0.0.1",
+    "@frontside/tsconfig": "^1.2.0",
     "@types/mocha": "^8.0.3",
     "expect": "^25.4.0",
     "mocha": "^8.3.1",

--- a/packages/subscription/test/queue.test.ts
+++ b/packages/subscription/test/queue.test.ts
@@ -1,4 +1,4 @@
-import * as expect from 'expect';
+import expect from 'expect';
 import { describe, it, beforeEach, captureError } from '@effection/mocha';
 
 import { createQueue, Queue } from '../src/index';

--- a/packages/subscription/test/stream.test.ts
+++ b/packages/subscription/test/stream.test.ts
@@ -1,4 +1,4 @@
-import * as expect from 'expect';
+import expect from 'expect';
 import { describe, it, beforeEach, captureError } from '@effection/mocha';
 import { EventEmitter } from 'events';
 

--- a/packages/websocket-client/package.json
+++ b/packages/websocket-client/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@effection/mocha": "2.0.0-beta.1",
-    "@frontside/tsconfig": "0.0.1",
+    "@frontside/tsconfig": "^1.2.0",
     "@types/node": "^13.13.5",
     "@types/ws": "^7.4.4",
     "expect": "^25.4.0",

--- a/packages/websocket-client/src/index.ts
+++ b/packages/websocket-client/src/index.ts
@@ -1,4 +1,4 @@
-import * as WebSocket from 'isomorphic-ws';
+import WebSocket from 'isomorphic-ws';
 
 import { spawn, ensure, Resource, Operation } from '@effection/core'
 import { createQueue, Subscription } from '@effection/subscription';

--- a/packages/websocket-client/test/websocket.test.ts
+++ b/packages/websocket-client/test/websocket.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, beforeEach } from '@effection/mocha';
-import * as expect from 'expect'
-import * as http from 'http'
+import expect from 'expect'
+import http from 'http'
 import type { AddressInfo } from 'net'
 import { spawn, ensure } from '@effection/core';
 import { on, once } from '@effection/events';
 
-import * as WebSocket from 'ws';
+import WebSocket from 'ws';
 import { Server as WebSocketServer } from 'ws';
 
 import { createWebSocketClient, WebSocketClient } from '../src/index';

--- a/packages/websocket-server/package.json
+++ b/packages/websocket-server/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@effection/mocha": "2.0.0-beta.1",
-    "@frontside/tsconfig": "0.0.1",
+    "@frontside/tsconfig": "^1.2.0",
     "@types/node": "^13.13.5",
     "@types/ws": "^7.4.4",
     "expect": "^25.4.0",

--- a/packages/websocket-server/src/index.ts
+++ b/packages/websocket-server/src/index.ts
@@ -3,7 +3,7 @@ import { Server } from 'ws';
 import { spawn, ensure, Resource, Operation } from '@effection/core'
 import { createQueue, Subscription } from '@effection/subscription';
 import { on, once } from '@effection/events';
-import * as http from 'http'
+import http from 'http'
 import { AddressInfo } from 'net'
 
 export interface WebSocketConnection<TIncoming = unknown, TOutgoing = TIncoming> extends Subscription<TIncoming> {

--- a/packages/websocket-server/test/websocket.test.ts
+++ b/packages/websocket-server/test/websocket.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, beforeEach } from '@effection/mocha';
-import * as expect from 'expect'
+import expect from 'expect'
 import { createServer } from 'http'
 import { AddressInfo } from 'net'
 import { spawn, ensure } from '@effection/core';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1079,10 +1079,10 @@
     "@typescript-eslint/parser" "^3.5.0"
     eslint-plugin-prefer-let "^1.0.2"
 
-"@frontside/tsconfig@0.0.1", "@frontside/tsconfig@^0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@frontside/tsconfig/-/tsconfig-0.0.1.tgz#f7481d8681fed3d2274991271e6f36fa5e3ed32f"
-  integrity sha512-BQyLcpBIV9WQsBFQQqK/SIoEeKImWYMmu7kqLYpE3SCbCjY6ZN/yBpY63AMCCrv7V70Z5itATHTWvMAlkzkJPQ==
+"@frontside/tsconfig@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@frontside/tsconfig/-/tsconfig-1.2.0.tgz#4faf77841e9a3ff9159cd9e0ff8f10d336a84cfe"
+  integrity sha512-Ua/q/M99ohPLdNtMNuJ1EToTjVkuiUECqQTZB7jsKLpGIn0dazon1KyqNtWYfMExMYXdk4uZimxljoVtFxM/OQ==
 
 "@jest/console@^24.7.1", "@jest/console@^24.9.0":
   version "24.9.0"


### PR DESCRIPTION
Update to the latest version of `@frontside/tsconfig` which sets `esModuleInterop` to `true`, necessitating some changes to how we import packages.