### PR TITLE
Simplify README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,15 +27,6 @@ Using Effection provides many benefits over using plain Promises and
   composes easily, and there  are no nasty surprises when trying to
   fit different pieces together.
 
-JavaScript has gone through multiple evolutionary steps in how to deal
-with concurrency: from callbacks and events, to promises, and then
-finally to `async/await`. Yet it can still be difficult to write
-concurrent code which is both correct and composable, and unless
-you're very careful, it is still easy to leak resources. Also, most
-JavaScript code and libraries do not handle cancellation very well,
-and failure conditions can easily lead to dangling promises and other
-unexpected behavior.
-
 Effection leverages the idea of [structured concurrency][structured concurrency]
 to ensure that you don't leak any resources, and that cancellation is
 properly handled. It helps you build concurrent code that feels rock
@@ -43,115 +34,32 @@ solid and behaves well under all failure conditions. In essence,
 Effection allows you to compose concurrent code so that you can reason
 about its behavior.
 
+[Learn how to use Effection in your own project](https://frontside.com/effection)
 
-## Replacing async/await
+## Contributing
 
-If you know how to use `async/await`, then you're already familiar with most of
-what you need to know to use Effection. The only difference is that instead
-of [async functions][async functions], you use
-[generators][generators] and replace:
+Currently, Effection development happens using `yarn`. While `npm` may
+work, it is not tested so your mileage may vary.
 
-1. `await` with `yield`
-1. `async function()` with `function*()`
+To build, run the `prepack` command from the root directory.
 
-
-For example, with `async`/`await`:
-
-``` javascript
-import { fetch } from 'isomorphic-fetch';
-
-export async function fetchWeekDay() {
-  let response = await fetch("http://worldclockapi.com/api/json/est/now");
-  let time = await response.json();
-  return time.dayOfTheWeek;
-}
+``` text
+$ yarn prepack
 ```
 
-With Effection:
+You can also run the `prepack` command within each sub directory to
+only build that package.
 
-``` javascript
-import { fetch } from '@effection/fetch';
+### Testing
 
-export function *fetchWeekDay() {
-  let response = yield fetch("http://worldclockapi.com/api/json/est/now");
-  let time = yield response.json();
-  return time.dayOfTheWeek;
-}
+To run tests:
+
+``` text
+$ yarn test
 ```
 
-## Getting started.
-
-To start using Effection, use the `main` function as an entry
-point. In this example, we'll use the previously defined
-`getWeekDay`.
-
-``` javascript
-import { main } from 'effection';
-import { getWeekDay } from './get-week-day';
-
-main(function*() {
-  let dayOfTheWeek = yield fetchWeekDay();
-  console.log(`It is ${dayOfTheWeek}, my friends!`);
-});
-```
-
-Let's go through what's going on here:
-
-* The argument to `main` is what's called an `Operation`.
-* One example of an operation is a generator function.
-* Promises are also operations.
-* Inside the generator function we can `yield` to other operations.
-* In this case, we yield to the `fetchWeekDay()` operation, which
-  itself yields to the `fetch()` operation and the `response.json()`
-  operation.
-* When the operation passed to `main` completes, the program exits.
-
-Even with such a simple program, Effection is still providing critical
-power-ups to you behind the scenes that you don't get with callbacks,
-promises, or `async/await`. For example, if you run the above in
-NodeJS and hit `CTRL-C` while the request to `http://worldclockapi.com` is
-still in progress, it will properly cancel the in-flight request
-as a well-behaved HTTP client should. All without you ever having to
-think about it. This is because every Effection operation contains
-the information on how to dispose of itself, and so the actual act of
-cancellation can be automated.
-
-This has powerful consequences when it comes to composing new
-operations out of existing ones. For example, we can add a time out of
-1000 milliseconds to our `fetchWeekDay` operation (or any operation
-for that matter) by wrapping it with the `withTimeout` operation from
-the standard `effection` module.
-
-``` javascript
-import { main, withTimeout } from 'effection';
-import { getWeekDay } from './get-week-day';
-
-main(function*() {
-  let dayOfTheWeek = yield withTimeout(fetchWeekDay(), 1000);
-  console.log(`It is ${dayOfTheWeek}, my friends!`);
-});
-```
-
-If more than 1000 milliseconds passes before the `fetchWeekDay()`
-operation completes, then an error will be raised.
-
-What's important to note however, is that when we actually defined our
-`fetchWeekDay()` operation, we never once had to worry about timeouts,
-or request cancellation. And in order to achieve both we didn't have
-to gum up our API by passing around cancellation tokens or [abort
-controllers][abort controller]. We just got it all for free.
-
-## Discover more
-
-This is just the tip of the iceberg when it comes to the seemingly complex
-things that can Effection make simple. To find out more, jump
-into the conversation [in our discord server][discord]. We're really
-excited about the things that Effection has enabled us to accomplish,
-and we'd love to hear your thoughts on it, and how you might see
-it working for you.
+Most test suites use the [`@effection/mocha`](packages/mocha) to
+leverage Effection to test itself.
 
 [structured concurrency]: https://vorpus.org/blog/notes-on-structured-concurrency-or-go-statement-considered-harmful/
-[generators]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Generator
-[async functions]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function
-[abort controller]: https://developer.mozilla.org/en-US/docs/Web/API/AbortController
 [discord]: https://discord.gg/Ug5nWH8


### PR DESCRIPTION
Motivation
----------

Now that we have a [website](https://frontside.com/effection), we don't actually need to have major content inside the README since it would be duplicating our efforts.


Approach
----------
Instead, this removes most of the "howto" guide-style aspect of the README, and instead just provides a very short introduction to Effection, and then links to the documentation site.

A brief introduction to contribution is included, but it is expected that it will be fleshed out more later

[rendered README.md](https://github.com/thefrontside/effection/blob/bfee527de8fe31c0b0562d751ad82accc53f30b1/README.md)