### PR TITLE
fix inspect-server dependencies

### DIFF
--- a/.changeset/fix-inspect-deps.md
+++ b/.changeset/fix-inspect-deps.md
@@ -1,0 +1,5 @@
+---
+"@effection/inspect-server": patch
+---
+inspect server depended on inspect-ui and websocket-server, and now
+includes them in its dependencies

--- a/packages/inspect-server/package.json
+++ b/packages/inspect-server/package.json
@@ -26,9 +26,11 @@
     "@effection/atom": "2.0.0-beta.2",
     "@effection/channel": "2.0.0-beta.2",
     "@effection/core": "2.0.0-beta.2",
+    "@effection/inspect-ui": "2.0.0-beta.2",
     "@effection/inspect-utils": "2.0.0-beta.2",
     "@effection/events": "2.0.0-beta.2",
     "@effection/subscription": "2.0.0-beta.2",
+    "@effection/websocket-server": "2.0.0-beta.3",
     "node-static": "^0.7.11",
     "websocket": "^1.0.34"
   },


### PR DESCRIPTION
Motivation
-----------
We want to be able to just say `node -r @effection/inspect` and have it magically work, but the proper dependencies were not being correctly pulled in.

Approach
----------
This add the inspect-ui and websocket server to the dependencies of inpsect-server so that it can function properly.
