### PR TITLE
Require node >= 14 for development

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "docs": "yarn workspaces run docs"
   },
   "volta": {
-    "node": "12.11.1",
+    "node": "14.17.1",
     "yarn": "1.22.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Motivation
-----------

With the introduction of the effection inspector UI, we depend on parcel@next which in turn depends on source-map@2.0.0 which in turn requires node > 14. Yarn installing will fail on node < 14 with the following error:

```text
$ yarn
yarn install v1.22.4
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
warning Pattern ["@definitelytyped/typescript-versions@latest"] is trying to unpack in the same destination "/Users/cowboyd/Library/Caches/Yarn/v6/npm-@definitelytyped-typescript-versions-0.0.71-08c791e3bf3c2861611edee8f28c72d2db0fb02e-integrity/node_modules/@definitelytyped/typescript-versions" as pattern ["@definitelytyped/typescript-versions@^0.0.71","@definitelytyped/typescript-versions@^0.0.71","@definitelytyped/typescript-versions@^0.0.71"]. This could result in non-deterministic behavior, skipping.
error @parcel/source-map@2.0.0-rc.1.0: The engine "node" is incompatible with this module. Expected version "^12.18.3 || >=14". Got "12.11.1"
error Found incompatible module.
```

Approach
----------
We upgrade the volta config for the base project to require node < 14. Note that once the code is _Built_, it will still work on node 12, but development on effection itself requires 14 or greater.