### PR TITLE
Allow function operations to return function operations

### DIFF
--- a/.changeset/recursive-higher-order-operations.md
+++ b/.changeset/recursive-higher-order-operations.md
@@ -1,0 +1,5 @@
+---
+"@effection/core": patch
+---
+function operations can now also return function operations, and not
+just value operations

--- a/.changeset/toll-free-streams.md
+++ b/.changeset/toll-free-streams.md
@@ -1,0 +1,5 @@
+---
+"@effection/subscription": patch
+---
+stream operations like `forEach` and `expect` no longer create
+intermediate delegation tasks

--- a/packages/core/src/operation.ts
+++ b/packages/core/src/operation.ts
@@ -25,10 +25,15 @@ export interface Resource<TOut> extends Labelled {
   init(scope: Task, local: Task): OperationIterator<TOut>;
 }
 
-export type OperationValue<TOut> = OperationPromise<TOut> | OperationIterator<TOut> | OperationResolution<TOut> | OperationFuture<TOut> | undefined;
-
 export interface OperationFunction<TOut> extends Labelled {
-  (task: Task<TOut>): OperationValue<TOut>;
+  (task: Task<TOut>): Operation<TOut>;
 }
 
-export type Operation<TOut> = OperationValue<TOut> | OperationFunction<TOut> | Resource<TOut>;
+export type Operation<TOut> =
+  OperationPromise<TOut> |
+  OperationIterator<TOut> |
+  OperationResolution<TOut> |
+  OperationFuture<TOut> |
+  OperationFunction<TOut> |
+  Resource<TOut> |
+  undefined;

--- a/packages/subscription/src/stream.ts
+++ b/packages/subscription/src/stream.ts
@@ -73,39 +73,27 @@ export function createStream<T, TReturn = undefined>(callback: Callback<T, TRetu
     },
 
     first(): Operation<T | undefined> {
-      return function*(task) {
-        return yield subscribe(task).first();
-      };
+      return task => subscribe(task).first();
     },
 
     expect(): Operation<T> {
-      return function*(task) {
-        return yield subscribe(task).expect();
-      }
+      return task => subscribe(task).expect();
     },
 
     forEach(visit: (value: T) => (Operation<void> | void)): Operation<TReturn> {
-      return function*(task) {
-        return yield subscribe(task).forEach(visit);
-      }
+      return task => subscribe(task).forEach(visit);
     },
 
     join(): Operation<TReturn> {
-      return function*(task) {
-        return yield subscribe(task).join();
-      }
+      return task => subscribe(task).join();
     },
 
     collect(): Operation<Iterator<T, TReturn>> {
-      return function*(task) {
-        return yield subscribe(task).collect();
-      }
+      return task => subscribe(task).collect();
     },
 
     toArray(): Operation<T[]> {
-      return function*(task) {
-        return yield subscribe(task).toArray();
-      }
+      return task => subscribe(task).toArray();
     },
 
     buffer(scope: Task): Stream<T, TReturn> {


### PR DESCRIPTION
## Motivation

With the introduction of the visual inspector, one of the first things that we noticed upon trying it out with simulacrum, was that event streams were constructing an extra task just to do delegation. In other words, when the websocket is iterating over its messages, the task tree looked like:

```
- websocket
   - task (delegator)
     - task (forEach)
       - task (message)
```

Not only is this noise in the visualization that distracts from the main purpose, but it's actually inefficient in that we're setting up an entire scope and controller, and task just do do nothing except delegate.

This is because the `forEach` operation is defined like this:

```ts
  forEach(visit: (value: T) => (Operation<void> | void)): Operation<TReturn> {
    return function*(task) {
      return yield subscribe(task).forEach(visit);
    }
  },
```

We create an operation returning a generator that generates a single operation which is the thing we want to delegate too. However, if we could just delegate directly to this, then we could completely eliminate the need for this intermediate task. What we want to do instead is say:

```ts
  forEach(visit: (value: T) => (Operation<void> | void)): Operation<TReturn> {
    return subscribe(task).forEach(visit);
  },
```

However this won't work as-is because subscription.forEach is itself a Function Operation and function operations only work for one level. In other words, a function operation is not a function that can return _any_ operation. It is a function that can return only an iterator, promise, resolution, or future.

## Approach

This relaxes that constraint requiring that function operations not return function operations and makes a function operation something fully recursive. This makes higher order programming with functions possible since an function operation can now return any kind of operation, no matter the type. Which means that delegation can be transparent without requiring an intervening task.

Oddly enough this passed all tests, and did not cause any build errors.

### TODOs and Open Questions

Some work will need to be done to make sure that the labelling of such recursively defined operations are handled correctly. This will be addressed in a follow on PR.
