### PR TITLE
Allow anything labellable.

### DIFF
--- a/.changeset/with-label-any-labelled.md
+++ b/.changeset/with-label-any-labelled.md
@@ -1,0 +1,5 @@
+---
+"@effection/core": patch
+"effection": patch
+---
+label anything with the `Labelled` interface

--- a/packages/core/src/labels.ts
+++ b/packages/core/src/labels.ts
@@ -1,10 +1,11 @@
-import { Operation } from './operation';
+import { Operation, Labelled } from './operation';
 
 export type Labels = Record<string, string | number | boolean>;
 
-export function withLabels<T>(operation: Operation<T>, labels: Labels): Operation<T> {
-  if(operation) {
-    operation.labels = { ...(operation.labels || {}), ...labels };
+export function withLabels<T>(operation: Operation<T>, labels: Labels): Operation<T>;
+export function withLabels<T extends Labelled>(labelled: T, labels: Labels): T {
+  if(labelled) {
+    labelled.labels = { ...(labelled.labels || {}), ...labels };
   }
-  return operation;
+  return labelled;
 }


### PR DESCRIPTION
Motivation
----------

As part of making everything labelled, it became obvious that there are certain things which are _not_ opeartions that need to be labelled in order to make the operations that they give rise to be labelled. For example, a `Stream` is not an operation, but `stream.forEach` is. Therefore, we want to make sure we can name the stream, and then label that stream's operations. E.g.

```
on('message').forEach()
```


Approach
----------

This relaxes the constraint that the only thing that can be used with `withLabels` is an Operation, and instead says, if it is labelable, then you can label it. This will allow us to label things like streams, subscriptions and channels.