### PR TITLE
Label the suspend operation

### DIFF
--- a/.changeset/label-suspend.md
+++ b/.changeset/label-suspend.md
@@ -1,0 +1,5 @@
+---
+"effection": patch
+"@effection/core": patch
+---
+label the "suspend" operation that is created with a bare `yield` statement;

--- a/packages/core/src/task.ts
+++ b/packages/core/src/task.ts
@@ -69,8 +69,13 @@ export function createTask<TOut = unknown>(operation: Operation<TOut>, options: 
   let labels: Labels = { ...operation?.labels, ...options.labels }
   let yieldingTo: Task | undefined;
 
-  if(!labels.name && operation?.name) {
-    labels.name = operation?.name;
+
+  if (!labels.name) {
+    if (operation?.name) {
+      labels.name = operation?.name;
+    } else if (!operation) {
+      labels.name = 'suspend';
+    }
   }
 
   let task: Task<TOut> = {

--- a/packages/core/test/task.test.ts
+++ b/packages/core/test/task.test.ts
@@ -80,7 +80,7 @@ describe('Task', () => {
         yieldingTo: {
           id: task.yieldingTo?.id,
           type: 'suspend',
-          labels: {},
+          labels: { name: 'suspend' },
           yieldingTo: undefined,
           state: 'running',
           children: [],


### PR DESCRIPTION
Motivation
-----------

Currently in the inspector, whenever you are suspended indefinitely, it just shows us as 'task'. This is not particularly helpful since it's unclear what exactly is going on. Instead, we'd like a clear indicator that the operation is a suspend operation and will never, ever return by itself.


Approach
----------

We handle this in the create task and check if the operation is undefined, if so, we assign it the `suspend` label.