### PR TITLE
label the main entry point

### DIFF
--- a/.changeset/label-main-entry-point.md
+++ b/.changeset/label-main-entry-point.md
@@ -1,0 +1,4 @@
+---
+"@effection/main": patch
+---
+label the main entry point for use in the debugger

--- a/packages/main/src/browser.ts
+++ b/packages/main/src/browser.ts
@@ -1,4 +1,4 @@
-import { run, Task, Operation } from '@effection/core';
+import { run, withLabels, Task, Operation } from '@effection/core';
 import { isMainError } from './error';
 
 export * from './error';
@@ -8,7 +8,9 @@ export function main<T>(operation: Operation<T>): Task<T> {
     let interrupt = () => { task.halt(); };
     try {
       window.addEventListener('unload', interrupt);
-      return yield operation;
+      return yield withLabels(operation, {
+        name: operation?.name || 'entry point'
+      });
     } catch(error) {
       if(isMainError(error)) {
         if(error.message) {

--- a/packages/main/src/node.ts
+++ b/packages/main/src/node.ts
@@ -1,4 +1,4 @@
-import { run, Task, Operation } from '@effection/core';
+import { run, withLabels, Task, Operation } from '@effection/core';
 import { formatError } from './format-error-node';
 import { isMainError } from './error';
 
@@ -10,7 +10,9 @@ export function main<T>(operation: Operation<T>): Task<T> {
     try {
       process.on('SIGINT', interrupt);
       process.on('SIGTERM', interrupt);
-      return yield operation;
+      return yield withLabels(operation, {
+        name: operation?.name || 'entry point'
+      });
     } catch(error) {
       console.error(formatError(error));
       if(isMainError(error)) {


### PR DESCRIPTION
Motivation
-----------

It is very common to use an anonymous generate function as the entry point for a main operation. For example, let's take a program that run an http server and a websocket socket server. It might look like:

```js
main(function*() {
  yield createHttpServer();
  yield createWebSocketServer();
  yield sleep();
})
```

Currently, this would be visualized roughly in the inspector as:

```
- main platform=node
  - task
    - http server
    - websocket server
    - sleep
```

But what is that anonymous task? It's silly to have it just sitting there not saying what it is, when it is the entry point to the program.


Approach
----------

This change, implicitly labels the entry point as such when it does not have a label itself. If the entry point is labelled, then it defaults to that.

After:

```
- main platform=node
  - task
    - http server
    - websocket server
    - sleep
```