### PR TITLE
Add labels to streams, queues, and events

### DIFF
--- a/.changeset/label-streams.md
+++ b/.changeset/label-streams.md
@@ -1,0 +1,7 @@
+---
+"effection": patch
+"@effection/subscription": patch
+"@effection/events": patch
+---
+- label events for visual inspection
+- label stream and queue operations

--- a/packages/core/src/controller/controller.ts
+++ b/packages/core/src/controller/controller.ts
@@ -25,7 +25,7 @@ export type Options = {
 
 export function createController<T>(task: Task<T>, operation: Operation<T>, options: Options = {}): Controller<T> {
   if (typeof(operation) === 'function') {
-    return createFunctionController(task, () => createController(task, operation(task), options));
+    return createFunctionController(task, operation, () => createController(task, operation(task), options));
   } else if(!operation) {
     return createSuspendController();
   } else if (isResource(operation)) {

--- a/packages/core/src/controller/function-controller.ts
+++ b/packages/core/src/controller/function-controller.ts
@@ -1,8 +1,9 @@
 import { Task } from '../task';
 import { Controller } from './controller';
 import { createFuture } from '../future';
+import { OperationFunction } from '../operation';
 
-export function createFunctionController<TOut>(task: Task<TOut>, createController: () => Controller<TOut>) {
+export function createFunctionController<TOut>(task: Task<TOut>, fn: OperationFunction<TOut>, createController: () => Controller<TOut>) {
   let delegate: Controller<TOut>;
   let { resolve, future } = createFuture<TOut>();
 
@@ -11,7 +12,8 @@ export function createFunctionController<TOut>(task: Task<TOut>, createControlle
       delegate = createController();
       task.setLabels({
         ...task.labels,
-        ...delegate.operation?.labels
+        ...delegate.operation?.labels,
+        ...fn.labels
       });
     } catch (error) {
       resolve({ state: 'errored', error });

--- a/packages/events/src/on.ts
+++ b/packages/events/src/on.ts
@@ -1,4 +1,3 @@
-import { label } from '@effection/core';
 import { createStream, Stream } from '@effection/subscription';
 import { EventSource, addListener, removeListener } from './event-source';
 

--- a/packages/events/src/on.ts
+++ b/packages/events/src/on.ts
@@ -39,7 +39,7 @@ export function on<T = unknown>(source: EventSource, name: string): Stream<T, vo
       addListener(source, name, listener);
       return () => removeListener(source, name, listener);
     }
-  }), `on('${name})`);
+  }), `on('${name}')`);
 }
 
 /**
@@ -78,5 +78,5 @@ export function onEmit<T extends Array<unknown> = unknown[]>(source: EventSource
       addListener(source, name, listener);
       return () => removeListener(source, name, listener);
     }
-  }), `onEmit('${name})`);
+  }), `onEmit('${name}')`);
 }

--- a/packages/events/src/on.ts
+++ b/packages/events/src/on.ts
@@ -1,5 +1,5 @@
+import { label } from '@effection/core';
 import { createStream, Stream } from '@effection/subscription';
-
 import { EventSource, addListener, removeListener } from './event-source';
 
 
@@ -32,7 +32,15 @@ import { EventSource, addListener, removeListener } from './event-source';
  * }));
  */
 export function on<T = unknown>(source: EventSource, name: string): Stream<T, void> {
-  return onEmit<[T]>(source, name).map(([event]) => event)
+  return createStream((publish) => ({
+    name: 'listen',
+    labels: { eventName: name, source: source.toString() },
+    perform() {
+      let listener = (...args: T[]) => publish(args[0]);
+      addListener(source, name, listener);
+      return () => removeListener(source, name, listener);
+    }
+  }), `on('${name})`);
 }
 
 /**
@@ -63,13 +71,13 @@ export function on<T = unknown>(source: EventSource, name: string): Stream<T, vo
  *
  */
 export function onEmit<T extends Array<unknown> = unknown[]>(source: EventSource, name: string): Stream<T, void> {
-  return createStream((publish) => function*() {
-    let listener = (...args: T) => publish(args);
-    try {
+    return createStream((publish) => ({
+    name: 'listen',
+    labels: { eventName: name, source: source.toString() },
+    perform() {
+      let listener = (...args: T) => publish(args);
       addListener(source, name, listener);
-      yield;
-    } finally {
-      removeListener(source, name, listener);
+      return () => removeListener(source, name, listener);
     }
-  });
+  }), `onEmit('${name})`);
 }

--- a/packages/events/src/once.ts
+++ b/packages/events/src/once.ts
@@ -25,9 +25,14 @@ import { EventSource, addListener, removeListener } from './event-source';
  * ```
  */
 export function once<T = unknown>(source: EventSource, eventName: string): Operation<T> {
-  return function*() {
-    let [event]: [T] = yield onceEmit<[T]>(source, eventName);
-    return event;
+  return {
+    name: `once`,
+    labels: { eventName, source: source.toString() },
+    perform(resolve) {
+      let listener = (...args: T[]) => { resolve(args[0]) };
+      addListener(source, eventName, listener);
+      return () => removeListener(source, eventName, listener)
+    }
   }
 }
 
@@ -56,6 +61,8 @@ export function once<T = unknown>(source: EventSource, eventName: string): Opera
  */
 export function onceEmit<TArgs extends unknown[] = unknown[]>(source: EventSource, eventName: string): Operation<TArgs> {
   return {
+    name: `onceEmit`,
+    labels: { eventName, source: source.toString() },
     perform(resolve) {
       let listener = (...args: unknown[]) => { resolve(args as TArgs) };
       addListener(source, eventName, listener);

--- a/packages/subscription/src/queue.ts
+++ b/packages/subscription/src/queue.ts
@@ -12,7 +12,7 @@ export interface Queue<T, TReturn = undefined> extends Subscription<T, TReturn> 
   subscription: Subscription<T, TReturn>;
 }
 
-export function createQueue<T, TReturn = undefined>(name: string = 'queue'): Queue<T, TReturn> {
+export function createQueue<T, TReturn = undefined>(name = 'queue'): Queue<T, TReturn> {
   let waiters: Waiter<T, TReturn>[] = [];
   let values: IteratorResult<T, TReturn>[] = [];
   let didClose = false;

--- a/packages/subscription/src/stream.ts
+++ b/packages/subscription/src/stream.ts
@@ -29,7 +29,7 @@ export interface StringBufferStream<TReturn = undefined> extends Stream<string, 
   value: string;
 }
 
-export function createStream<T, TReturn = undefined>(callback: Callback<T, TReturn>, name: string = 'stream'): Stream<T, TReturn> {
+export function createStream<T, TReturn = undefined>(callback: Callback<T, TReturn>, name = 'stream'): Stream<T, TReturn> {
   let subscribe = (task: Task) => {
     let queue = createQueue<T, TReturn>(name);
     task.spawn(function*() {


### PR DESCRIPTION
Motivation
----------

streams, and queues are core constructs that are completely anonymous right now. This means that it's totally impossible to find out what's going on when using them.

Approach
----------

This adds more labels to these things so that they can be visualized better. Also, the publisher for `on()` no longer delegates to `onEmit` since it involves creating an extra queue.

## Screenshots

Before:

![image](https://user-images.githubusercontent.com/4205/124034687-281f7d80-d9c1-11eb-8818-1a3fd1bf5632.png)


After:

![image](https://user-images.githubusercontent.com/4205/124197324-e4e20f00-da93-11eb-8893-40ebf6961a56.png)

