### PR TITLE
Revert "Allow anything labellable."

### DIFF
--- a/.changeset/with-label-any-labelled.md
+++ b/.changeset/with-label-any-labelled.md
@@ -1,5 +1,0 @@
----
-"@effection/core": patch
-"effection": patch
----
-label anything with the `Labelled` interface

--- a/packages/core/src/labels.ts
+++ b/packages/core/src/labels.ts
@@ -1,11 +1,10 @@
-import { Operation, Labelled } from './operation';
+import { Operation } from './operation';
 
 export type Labels = Record<string, string | number | boolean>;
 
-export function withLabels<T>(operation: Operation<T>, labels: Labels): Operation<T>;
-export function withLabels<T extends Labelled>(labelled: T, labels: Labels): T {
-  if(labelled) {
-    labelled.labels = { ...(labelled.labels || {}), ...labels };
+export function withLabels<T>(operation: Operation<T>, labels: Labels): Operation<T> {
+  if(operation) {
+    operation.labels = { ...(operation.labels || {}), ...labels };
   }
-  return labelled;
+  return operation;
 }


### PR DESCRIPTION
Reverts thefrontside/effection#412

While maybe great in concept, there are other ways of labelling streams that maybe don't mess with the type system so much.