### PR TITLE
Inherit labels from delegate operations.

### DIFF
--- a/packages/core/src/controller/controller.ts
+++ b/packages/core/src/controller/controller.ts
@@ -12,6 +12,7 @@ import { Future } from '../future';
 
 export interface Controller<TOut> {
   type: string;
+  operation: Operation<TOut>;
   start(): void;
   halt(): void;
   future: Future<TOut>;

--- a/packages/core/src/controller/function-controller.ts
+++ b/packages/core/src/controller/function-controller.ts
@@ -9,6 +9,10 @@ export function createFunctionController<TOut>(task: Task<TOut>, createControlle
   function start() {
     try {
       delegate = createController();
+      task.setLabels({
+        ...task.labels,
+        ...delegate.operation?.labels
+      });
     } catch (error) {
       resolve({ state: 'errored', error });
       return;
@@ -30,6 +34,9 @@ export function createFunctionController<TOut>(task: Task<TOut>, createControlle
       } else {
         return 'function';
       }
+    },
+    get operation() {
+      return delegate?.operation;
     },
     future,
     start,

--- a/packages/core/src/controller/future-controller.ts
+++ b/packages/core/src/controller/future-controller.ts
@@ -13,5 +13,5 @@ export function createFutureController<TOut>(task: Task<TOut>, future: FutureLik
     resolve({ state: 'halted' });
   }
 
-  return { start, halt, future: inner, type: 'future' };
+  return { start, halt, future: inner, type: 'future', operation: future };
 }

--- a/packages/core/src/controller/iterator-controller.ts
+++ b/packages/core/src/controller/iterator-controller.ts
@@ -82,5 +82,5 @@ export function createIteratorController<TOut>(task: Task<TOut>, iterator: Opera
     }
   }
 
-  return { start, halt, future, type: 'generator' };
+  return { start, halt, future, type: 'generator', operation: iterator };
 }

--- a/packages/core/src/controller/promise-controller.ts
+++ b/packages/core/src/controller/promise-controller.ts
@@ -20,5 +20,5 @@ export function createPromiseController<TOut>(task: Task<TOut>, promise: Promise
     resolve({ state: 'halted' });
   }
 
-  return { start, halt, future, type: 'promise' };
+  return { start, halt, future, type: 'promise', operation: promise };
 }

--- a/packages/core/src/controller/resolution-controller.ts
+++ b/packages/core/src/controller/resolution-controller.ts
@@ -25,5 +25,5 @@ export function createResolutionController<TOut>(task: Task<TOut>, resolution: O
     resolve({ state: 'halted' });
   }
 
-  return { start, halt, future, type: 'resolution' };
+  return { start, halt, future, type: 'resolution', operation: resolution };
 }

--- a/packages/core/src/controller/resource-controller.ts
+++ b/packages/core/src/controller/resource-controller.ts
@@ -31,5 +31,5 @@ export function createResourceController<TOut>(task: Task<TOut>, resource: Resou
     delegate.halt();
   }
 
-  return { start, halt, future, type: 'resource' };
+  return { start, halt, future, type: 'resource', operation: resource };
 }

--- a/packages/core/src/controller/suspend-controller.ts
+++ b/packages/core/src/controller/suspend-controller.ts
@@ -12,5 +12,5 @@ export function createSuspendController<TOut>(): Controller<TOut> {
     resolve({ state: 'halted' });
   }
 
-  return { start, halt, future, type: 'suspend' };
+  return { start, halt, future, type: 'suspend', operation: undefined };
 }

--- a/packages/core/test/labels.test.ts
+++ b/packages/core/test/labels.test.ts
@@ -2,7 +2,7 @@ import './setup';
 import { describe, it } from 'mocha';
 import expect from 'expect';
 
-import { withLabels, run, sleep, label, Labels, createFuture, Operation } from '../src/index';
+import { withLabels, run, sleep, label, Labels, Operation } from '../src/index';
 
 describe('labels', () => {
   describe('withLabels', () => {

--- a/packages/core/test/labels.test.ts
+++ b/packages/core/test/labels.test.ts
@@ -2,7 +2,7 @@ import './setup';
 import { describe, it } from 'mocha';
 import expect from 'expect';
 
-import { withLabels, run, sleep, label, Labels } from '../src/index';
+import { withLabels, run, sleep, label, Labels, createFuture, Operation } from '../src/index';
 
 describe('labels', () => {
   describe('withLabels', () => {
@@ -70,4 +70,25 @@ describe('labels', () => {
     expect(task.labels).toEqual({ foo: "bar", quox: "quox" });
     expect(events).toEqual([{ foo: "bar" }, { foo: "bar", quox: "quox" }]);
   });
+
+  it('applies labels of the resolved operation to a function operation', async () => {
+    let task = run((() => () => () => withLabels(sleep(), { one: 1 })) as Operation<void>);
+
+    task.consume(value => console.log({ value }));
+
+    expect(task.labels).toMatchObject({
+      name: 'sleep',
+      one: 1
+    });
+  });
+
+  it('can change labels of a resolved function operation dynamically', async () => {
+    let task = run(() => function*() {
+      yield label({ foo: 'bar' });
+    });
+
+    await task;
+
+    expect(task.labels).toMatchObject({ foo: 'bar' });
+  })
 });


### PR DESCRIPTION
Motivation
----------
A function operation is a fundamentally delegating construct. It is a function that takes a scope, and returns an operation that actually does the work. Currently however, when this happens the labels of the actual operation are lost if that operation is the destination of a function operation.

In other words, if I have an operation:

```ts
run(() => ({
  name: 'console.log',
  labels: {
    platforms: ['node', 'browsers']
  },
  perform() {
    console.log("I log therefore I am");
  }
}));
```

This operation will _not_ actually have any labels associated with it and will just show up as `task` in the inspector tree. Instead, we'd like to have those labels of the actual operation available for inspection.

Approach
----------

We can fix this by having function controllers "lift" the labels of their source operation into their own task. This is feasible because when a function controller starts, the first thing it does is recursively resolve the destination controller into a controller that has a concrete operation.

This changes the `Controller` API to expose its operation, so that no matter what kind of controller is delegated to by the function controller, it can import the labels of that operation.
