### PR TITLE
rename task.spawn -> task.run()

### DIFF
--- a/.changeset/spawn-is-run.md
+++ b/.changeset/spawn-is-run.md
@@ -1,0 +1,5 @@
+---
+"@effection/core": patch
+"effection": patch
+---
+rename Task.spawn() -> Task.run()

--- a/packages/atom/test/atom.test.ts
+++ b/packages/atom/test/atom.test.ts
@@ -1,6 +1,7 @@
 import { describe, beforeEach, it } from '@effection/mocha';
 import expect from 'expect';
 import { createAtom } from '../src/atom';
+import { spawn } from '@effection/core';
 import { OperationIterator } from '@effection/subscription';
 import { Slice } from '../src/types';
 
@@ -81,7 +82,7 @@ describe('@bigtest/atom createAtom', () => {
     describe('with listener which modifies atom', () => {
       it('shoule be reentrant', function*(world) {
         let atom = createAtom({ status: 'idle' });
-        world.spawn(atom.forEach(({ status }) => {
+        yield spawn(atom.forEach(({ status }) => {
           if(status === 'pending') {
             atom.set({ status: 'active' });
           }
@@ -174,7 +175,7 @@ describe('@bigtest/atom createAtom', () => {
     describe('when initial state matches', () => {
       beforeEach(function*(world) {
         subject = createAtom({foo: 'bar'});
-        result = world.spawn(subject.once((state) => state.foo === 'bar'));
+        result = world.run(subject.once((state) => state.foo === 'bar'));
 
         subject.update(() => ({ foo: 'baz' }));
       });
@@ -187,7 +188,7 @@ describe('@bigtest/atom createAtom', () => {
 
     describe('when initial state does not match', () => {
       beforeEach(function*(world) {
-        result = world.spawn(subject.once((state) => state.foo === 'baz'));
+        result = world.run(subject.once((state) => state.foo === 'baz'));
 
         subject.update(() => ({ foo: 'bar' }));
         subject.update(() => ({ foo: 'baz' }));

--- a/packages/atom/test/slice.test.ts
+++ b/packages/atom/test/slice.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, beforeEach } from '@effection/mocha';
 import expect from 'expect';
 import { createAtom } from '../src/atom';
+import { spawn } from '@effection/core';
 import { OperationIterator } from '@effection/subscription';
 import { Slice } from '../src/types';
 
@@ -103,8 +104,8 @@ describe('@bigtest/atom Slice', () => {
     });
 
     describe('when initial state matches', () => {
-      beforeEach(function*(world) {
-        result = world.spawn(slice.once((state) => state === 'foo'));
+      beforeEach(function*() {
+        result = yield spawn(slice.once((state) => state === 'foo'));
 
         slice.update(() => 'bar');
       });
@@ -116,8 +117,8 @@ describe('@bigtest/atom Slice', () => {
     });
 
     describe('when initial state does not match', () => {
-      beforeEach(function*(world) {
-        result = world.spawn(slice.once((state) => state === 'baz'));
+      beforeEach(function*() {
+        result = yield spawn(slice.once((state) => state === 'baz'));
 
         slice.update(() => 'bar');
         slice.update(() => 'baz');

--- a/packages/channel/test/channel.test.ts
+++ b/packages/channel/test/channel.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, beforeEach } from '@effection/mocha';
 import expect from 'expect';
 
-import { sleep } from '@effection/core';
+import { sleep, spawn } from '@effection/core';
 import { createChannel, Channel } from '../src/index';
 
 describe('Channel', () => {
@@ -25,7 +25,7 @@ describe('Channel', () => {
     describe('blocking on next', () => {
       it('receives message on subscription done', function*(task) {
         let subscription = channel.subscribe(task);
-        let result = task.spawn(subscription.next());
+        let result = yield spawn(subscription.next());
         yield sleep(10);
         channel.send('hello');
         expect(yield result).toHaveProperty('value', 'hello');

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -21,5 +21,5 @@ export { all } from './operations/all';
 export { label } from './operations/label';
 
 export function run<TOut>(operation?: Operation<TOut>, options?: TaskOptions): Task<TOut> {
-  return Effection.root.spawn(operation, options);
+  return Effection.root.run(operation, options);
 }

--- a/packages/core/src/operations/all.ts
+++ b/packages/core/src/operations/all.ts
@@ -13,7 +13,7 @@ export function all<T extends Operation<any>[]>(operations: T): Operation<All<T>
     let results: unknown[] = [];
     for (let operation of operations) {
       if(scope.state === 'running') {
-        tasks.push(scope.spawn(operation));
+        tasks.push(scope.run(operation));
       }
     }
     for (let task of tasks) {

--- a/packages/core/src/operations/ensure.ts
+++ b/packages/core/src/operations/ensure.ts
@@ -1,10 +1,12 @@
 import { Operation, Resource } from '../operation';
+import { spawn } from './spawn';
+
 
 export function ensure<T>(fn: () => Operation<T> | void): Resource<undefined> {
   return {
     name: 'ensure',
-    *init(scope) {
-      scope.spawn(function*() {
+    *init() {
+      yield spawn(function*() {
         try {
           yield
         } finally {

--- a/packages/core/src/operations/race.ts
+++ b/packages/core/src/operations/race.ts
@@ -6,7 +6,7 @@ export function race<T>(operations: Operation<T>[]): Operation<T> {
     perform: (resolve, reject) => {
       for (let operation of operations) {
         if(scope.state === 'running') {
-          scope.spawn(function*() {
+          scope.run(function*() {
             try {
               resolve(yield operation);
             } catch (e) {

--- a/packages/core/src/operations/spawn.ts
+++ b/packages/core/src/operations/spawn.ts
@@ -7,7 +7,7 @@ interface Spawn<T> extends Resource<Task<T>> {
 
 export function spawn<T>(operation?: Operation<T>, options?: TaskOptions): Spawn<T> {
   function* init(scope: Task) {
-    return scope.spawn(operation, options);
+    return scope.run(operation, options);
   }
 
   function within(scope: Task) {

--- a/packages/core/src/operations/with-timeout.ts
+++ b/packages/core/src/operations/with-timeout.ts
@@ -1,10 +1,11 @@
 import { Operation } from '../operation';
 import { timeout } from './timeout';
+import { spawn } from './spawn';
 import { withLabels } from '../labels';
 
 export function withTimeout<T>(duration: number, operation: Operation<T>): Operation<T> {
-  return withLabels(function*(task) {
-    task.spawn(timeout(duration));
+  return withLabels(function*() {
+    yield spawn(timeout(duration));
     return yield operation;
   }, { name: 'withTimeout', duration });
 }

--- a/packages/core/src/task.ts
+++ b/packages/core/src/task.ts
@@ -43,6 +43,7 @@ export interface Task<TOut = unknown> extends Promise<TOut>, FutureLike<TOut> {
   catchHalt(): Promise<TOut | undefined>;
   setLabels(labels: Labels): void;
   run<R>(operation?: Operation<R>, options?: TaskOptions): Task<R>;
+  spawn<R>(operation?: Operation<R>, options?: TaskOptions): Task<R>;
   halt(): Promise<void>;
   start(): void;
   toJSON(): TaskTree;
@@ -112,6 +113,11 @@ export function createTask<TOut = unknown>(operation: Operation<TOut>, options: 
       link(child as Task);
       child.start();
       return child;
+    },
+
+    spawn(operation?, options = {}) {
+      console.warn(`DEPRECATED: task.spawn() is deprecated and will be changed or removed prior to the release of effection 2.0\nuse task.run() instead`);
+      return task.run(operation, options);
     },
 
     start() {

--- a/packages/core/src/task.ts
+++ b/packages/core/src/task.ts
@@ -43,6 +43,7 @@ export interface Task<TOut = unknown> extends Promise<TOut>, FutureLike<TOut> {
   catchHalt(): Promise<TOut | undefined>;
   setLabels(labels: Labels): void;
   run<R>(operation?: Operation<R>, options?: TaskOptions): Task<R>;
+  /** @deprecated Use run() instead */
   spawn<R>(operation?: Operation<R>, options?: TaskOptions): Task<R>;
   halt(): Promise<void>;
   start(): void;

--- a/packages/core/src/task.ts
+++ b/packages/core/src/task.ts
@@ -42,7 +42,7 @@ export interface Task<TOut = unknown> extends Promise<TOut>, FutureLike<TOut> {
   readonly yieldingTo: Task | undefined;
   catchHalt(): Promise<TOut | undefined>;
   setLabels(labels: Labels): void;
-  spawn<R>(operation?: Operation<R>, options?: TaskOptions): Task<R>;
+  run<R>(operation?: Operation<R>, options?: TaskOptions): Task<R>;
   halt(): Promise<void>;
   start(): void;
   toJSON(): TaskTree;
@@ -104,7 +104,7 @@ export function createTask<TOut = unknown>(operation: Operation<TOut>, options: 
       emitter.emit('labels', labels);
     },
 
-    spawn(operation?, options = {}) {
+    run(operation?, options = {}) {
       if(stateMachine.current !== 'running') {
         throw new Error('cannot spawn a child on a task which is not running');
       }

--- a/packages/core/test/iterator.test.ts
+++ b/packages/core/test/iterator.test.ts
@@ -186,7 +186,7 @@ describe('generator function', () => {
   it('can be halted while in the generator', async () => {
     let { future, resolve } = createFuture();
     let task = run(function*(inner) {
-      inner.spawn(function*() {
+      inner.run(function*() {
         yield sleep(2);
         resolve({ state: 'errored', error: new Error('boom') });
       });
@@ -210,7 +210,7 @@ describe('generator function', () => {
     let task = run(function*(inner) {
       yield sleep(1);
 
-      inner.spawn(function*() {
+      inner.run(function*() {
         inner.halt();
       });
 
@@ -224,7 +224,7 @@ describe('generator function', () => {
   it('can delay halt if child fails', async () => {
     let didRun = false;
     let task = run(function*(inner) {
-      inner.spawn(function* willBoom() {
+      inner.run(function* willBoom() {
         yield sleep(5);
         throw new Error('boom');
       });
@@ -246,7 +246,7 @@ describe('generator function', () => {
 
   it('can throw error when child blows up', async () => {
     let task = run(function*(inner) {
-      inner.spawn(function* willBoom() {
+      inner.run(function* willBoom() {
         yield sleep(5);
         throw new Error('boom');
       });

--- a/packages/core/test/resource.test.ts
+++ b/packages/core/test/resource.test.ts
@@ -7,7 +7,7 @@ import { Task, Resource, run, sleep } from '../src/index';
 export const myResource: Resource<{ status: string }> = {
   *init(scope: Task) {
     let container = { status: 'pending' }
-    scope.spawn(function*() {
+    scope.run(function*() {
       yield sleep(5);
       container.status = 'active';
     });
@@ -18,7 +18,7 @@ export const myResource: Resource<{ status: string }> = {
 
 export const metaResource: Resource<{ status: string }> = {
   *init(scope: Task) {
-    return yield scope.spawn(myResource);
+    return yield scope.run(myResource);
   }
 }
 
@@ -32,7 +32,7 @@ describe('resource', () => {
   describe('with spawned resource', () => {
     it('runs resource in task scope', async () => {
       await run(function*(task) {
-        let result = yield task.spawn(myResource);
+        let result = yield task.run(myResource);
         expect(result.status).toEqual('pending');
         yield sleep(10);
         expect(result.status).toEqual('active');
@@ -41,7 +41,7 @@ describe('resource', () => {
 
     it('terminates resource when task completes', async () => {
       let result: { status: string } = await run(function*(task) {
-        return yield task.spawn(myResource);
+        return yield task.run(myResource);
       });
       expect(result.status).toEqual('pending');
       await run(sleep(10));

--- a/packages/core/test/spawn.test.ts
+++ b/packages/core/test/spawn.test.ts
@@ -7,7 +7,7 @@ import { run, sleep, Task } from '../src/index';
 describe('spawn', () => {
   it('can spawn a new child task', async () => {
     let root = run(function*(context: Task) {
-      let child = context.spawn(function*() {
+      let child = context.run(function*() {
         let one: number = yield Promise.resolve(12);
         let two: number = yield Promise.resolve(55);
 
@@ -23,7 +23,7 @@ describe('spawn', () => {
   it('halts child when halted', async () => {
     let child: Task<void> | undefined;
     let root = run(function*(context: Task) {
-      child = context.spawn(function*() {
+      child = context.run(function*() {
         yield;
       });
 
@@ -40,7 +40,7 @@ describe('spawn', () => {
   it('halts child when finishing normally', async () => {
     let child: Task<void> | undefined;
     let root = run(function*(context: Task) {
-      child = context.spawn(function*() {
+      child = context.run(function*() {
         yield;
       });
 
@@ -56,7 +56,7 @@ describe('spawn', () => {
   it('halts child when errored', async () => {
     let child;
     let root = run(function*(context: Task) {
-      child = context.spawn(function*() {
+      child = context.run(function*() {
         yield;
       });
 
@@ -71,7 +71,7 @@ describe('spawn', () => {
     let child;
     let error = new Error("moo");
     let root = run(function*(context: Task) {
-      child = context.spawn(function*() {
+      child = context.run(function*() {
         throw error;
       });
 
@@ -86,7 +86,7 @@ describe('spawn', () => {
   it('finishes normally when child halts', async () => {
     let child;
     let root = run(function*(context: Task<string>) {
-      child = context.spawn();
+      child = context.run();
       yield child.halt();
 
       return "foo";
@@ -100,7 +100,7 @@ describe('spawn', () => {
   it('rejects when child errors during completing', async () => {
     let child;
     let root = run(function*(context: Task<string>) {
-      child = context.spawn(function*() {
+      child = context.run(function*() {
         try {
           yield
         } finally {
@@ -118,7 +118,7 @@ describe('spawn', () => {
   it('rejects when child errors during halting', async () => {
     let child;
     let root = run(function*(context: Task<string>) {
-      child = context.spawn(function*() {
+      child = context.run(function*() {
         try {
           yield
         } finally {
@@ -138,20 +138,20 @@ describe('spawn', () => {
 
   it('throws an error when called after controller finishes', async () => {
     let root = run(function*(context: Task) {
-      context.spawn(sleep(100), { blockParent: true });
+      context.run(sleep(100), { blockParent: true });
 
       yield sleep(10);
     });
 
     await run(sleep(20));
 
-    expect(() => root.spawn()).toThrowError('cannot spawn a child on a task which is not running');
+    expect(() => root.run()).toThrowError('cannot spawn a child on a task which is not running');
   });
 
   it('halts when child finishes during asynchronous halt', async () => {
     let didFinish = false;
     let root = run(function*(context: Task) {
-      context.spawn(function*() {
+      context.run(function*() {
         yield sleep(5)
       });
       try {
@@ -170,7 +170,7 @@ describe('spawn', () => {
   it('runs destructors in reverse order and in series', async () => {
     let result: string[] = [];
     let root = run(function*(context: Task) {
-      context.spawn(function*() {
+      context.run(function*() {
         try {
           yield
         } finally {
@@ -179,7 +179,7 @@ describe('spawn', () => {
           result.push('first done');
         }
       });
-      context.spawn(function*() {
+      context.run(function*() {
         try {
           yield
         } finally {
@@ -199,7 +199,7 @@ describe('spawn', () => {
     it('blocks on child when finishing normally', async () => {
       let child: Task<string> | undefined;
       let root = run(function*(context: Task) {
-        child = context.spawn(function*() {
+        child = context.run(function*() {
           yield sleep(5);
           return 'foo';
         }, { blockParent: true });

--- a/packages/core/test/task.test.ts
+++ b/packages/core/test/task.test.ts
@@ -26,8 +26,8 @@ describe('Task', () => {
   describe('children', () => {
     it('returns the tasks children', async () => {
       let task = run();
-      let child1 = task.spawn();
-      let child2 = task.spawn();
+      let child1 = task.run();
+      let child2 = task.run();
       expect(task.children).toEqual([child1, child2]);
     });
   });
@@ -68,7 +68,7 @@ describe('Task', () => {
   describe('toJSON', () => {
     it('returns the full task information', async () => {
       let task = run(function* theTask(inner) {
-        inner.spawn(undefined, { labels: { name: 'some-thing' } });
+        inner.run(undefined, { labels: { name: 'some-thing' } });
         yield;
       });
 
@@ -179,7 +179,7 @@ describe('Task', () => {
 
       task.on('link', (child) => events.push(child));
 
-      let child = task.spawn();
+      let child = task.run();
 
       expect(events).toEqual([child]);
     });
@@ -192,7 +192,7 @@ describe('Task', () => {
 
       task.on('unlink', (child) => events.push(child));
 
-      let child = task.spawn(function*() { yield sleep(5); return 1 });
+      let child = task.run(function*() { yield sleep(5); return 1 });
 
       expect(events).toEqual([]);
       await child;
@@ -205,7 +205,7 @@ describe('Task', () => {
 
       task.on('unlink', (child) => events.push(child));
 
-      let child = task.spawn(function*() { yield sleep(5); return 1 });
+      let child = task.run(function*() { yield sleep(5); return 1 });
 
       expect(events).toEqual([]);
       await child.halt();

--- a/packages/events/test/once.test.ts
+++ b/packages/events/test/once.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, beforeEach } from '@effection/mocha';
 import expect from 'expect'
 
-import { sleep, Task } from '@effection/core';
+import { sleep, spawn, Task } from '@effection/core';
 import { EventEmitter } from 'events';
 
 import { once, onceEmit } from '../src/index';
@@ -10,9 +10,9 @@ describe("once()", () => {
   let task: Task;
   let source: EventEmitter;
 
-  beforeEach(function*(t) {
+  beforeEach(function*() {
     source = new EventEmitter();
-    task = t.spawn(once(source, 'event'));
+    task = yield spawn(once(source, 'event'));
   });
 
   it('pauses before the event is received', function*() {
@@ -45,9 +45,9 @@ describe('onceEmit()', () => {
   let task: Task;
   let source: EventEmitter;
 
-  beforeEach(function*(t) {
+  beforeEach(function*() {
     source = new EventEmitter();
-    task = t.spawn(onceEmit(source, 'event'))
+    task = yield spawn(onceEmit(source, 'event'))
     source.emit('event', 1,2,3);
   });
 

--- a/packages/events/test/throw-on-error-event.test.ts
+++ b/packages/events/test/throw-on-error-event.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, beforeEach, captureError } from '@effection/mocha';
 import expect from 'expect'
 
-import { Task } from '@effection/core';
+import { Task, spawn } from '@effection/core';
 import { EventEmitter } from 'events';
 
 import { throwOnErrorEvent } from '../src/index';
@@ -11,10 +11,10 @@ describe("throwOnErrorEvent", () => {
   let task: Task;
   let error: Error;
 
-  beforeEach(function*(t) {
+  beforeEach(function*() {
     emitter = new EventEmitter();
-    task = t.spawn(captureError(function*(inner) {
-      inner.spawn(throwOnErrorEvent(emitter));
+    task = yield spawn(captureError(function*(inner) {
+      yield spawn(throwOnErrorEvent(emitter));
       yield;
     }));
   });
@@ -30,4 +30,3 @@ describe("throwOnErrorEvent", () => {
     });
   });
 });
-

--- a/packages/fetch/src/fetch.ts
+++ b/packages/fetch/src/fetch.ts
@@ -1,4 +1,4 @@
-import { Task, Operation, Resource } from '@effection/core';
+import { spawn, Operation, Resource } from '@effection/core';
 import { fetch as nativeFetch } from 'cross-fetch';
 import { AbortController } from 'abort-controller';
 
@@ -11,10 +11,10 @@ export interface Fetch extends Resource<Response> {
 }
 
 export function fetch(info: RequestInfo, requestInit: RequestInit = {}): Fetch {
-  function* init(scope: Task) {
+  function* init() {
     let controller = new AbortController();
 
-    scope.spawn(function*() {
+    yield spawn(function*() {
       try {
         yield;
       } finally {

--- a/packages/fetch/test/echo-server.ts
+++ b/packages/fetch/test/echo-server.ts
@@ -1,4 +1,4 @@
-import { Operation, Task } from '@effection/core';
+import { Operation, Task, spawn } from '@effection/core';
 import { throwOnErrorEvent, once } from '@effection/events';
 import { AddressInfo } from 'net';
 import { createServer, Server, IncomingMessage, ServerResponse } from 'http';
@@ -54,14 +54,14 @@ export class EchoServer {
         throw e;
       }
 
-      scope.spawn(throwOnErrorEvent(http));
-      scope.spawn(function*() {
+      yield spawn(throwOnErrorEvent(http)).within(scope);
+      yield spawn(function*() {
         try {
           yield;
         } finally {
           http.close();
         }
-      });
+      }).within(scope);
     }
   }
 }

--- a/packages/fetch/test/fetch.test.ts
+++ b/packages/fetch/test/fetch.test.ts
@@ -1,4 +1,6 @@
 import { IncomingMessage } from 'http';
+import { spawn } from '@effection/core';
+
 import { EchoServer } from "./echo-server";
 import { when, never } from "./helpers";
 import { fetch } from "../src";
@@ -17,8 +19,8 @@ describe("fetch in node", () => {
   });
 
   describe('calling the server and posting a body', () => {
-    beforeEach(function*(task) {
-      response = task.spawn(fetch(`${app.address}`, {
+    beforeEach(function*() {
+      response = yield spawn(fetch(`${app.address}`, {
         method: 'POST',
         body: JSON.stringify({
           hello: 'world'
@@ -81,8 +83,8 @@ describe("fetch in node", () => {
   })
 
   describe('.text', () => {
-    it('returns text response', function*(task) {
-      let response = task.spawn(fetch(`${app.address}`).text());
+    it('returns text response', function*() {
+      let response = yield spawn(fetch(`${app.address}`).text());
 
       yield when(() => expect(app.lastResponse).toBeDefined());
       app.lastResponse.writeHead(200, 'ok', { 'Content-Type': 'text/plain' });
@@ -95,8 +97,8 @@ describe("fetch in node", () => {
   });
 
   describe('.json', () => {
-    it('returns json response', function*(task) {
-      let response = task.spawn(fetch(`${app.address}`).json());
+    it('returns json response', function*() {
+      let response = yield spawn(fetch(`${app.address}`).json());
 
       yield when(() => expect(app.lastResponse).toBeDefined());
       app.lastResponse.writeHead(200, 'ok', { 'Content-Type': 'application/json' });

--- a/packages/inspect-server/test/server.test.ts
+++ b/packages/inspect-server/test/server.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from '@effection/mocha';
 import expect from 'expect'
 
+import { spawn } from '@effection/core';
 import { ClientMessage } from '@effection/inspect-utils';
 import { createWebSocketClient } from '@effection/websocket-client';
 import { createInspectServer, InspectServer } from '../src/index';
@@ -8,9 +9,10 @@ import { createInspectServer, InspectServer } from '../src/index';
 type Message = { value: string };
 
 describe("createInspectServer()", () => {
-  it('sreams inspect trees', function*(world) {
-    let task = world.spawn(undefined, { labels: { name: 'foo' } });
-    let child = task.spawn(undefined, { labels: { name: 'bar' } });
+  it('sreams inspect trees', function*() {
+    let task = yield spawn(undefined, { labels: { name: 'foo' } });
+    let child = yield spawn(undefined, { labels: { name: 'bar' } })
+      .within(task);
     let server: InspectServer = yield createInspectServer({ task });
 
     let client = yield createWebSocketClient<Message>(`ws://localhost:${server.port}`);

--- a/packages/inspect-utils/src/inspect.ts
+++ b/packages/inspect-utils/src/inspect.ts
@@ -35,8 +35,8 @@ export function inspect(rootTask: Task): Resource<Slice<InspectTree>> {
       yield spawn(linkChild(child));
     }
 
-    yield spawn(on<Task>(task, 'link').forEach((child) => {
-      scope.spawn(linkChild(child));
+    yield spawn(on<Task>(task, 'link').forEach(child => {
+      return spawn(linkChild(child)).within(scope) as Operation<void>;
     }));
 
     yield spawn(on<StateTransition>(task, 'state').forEach((transition) => {

--- a/packages/inspect-utils/test/debug.test.ts
+++ b/packages/inspect-utils/test/debug.test.ts
@@ -1,21 +1,23 @@
-import { describe, it, beforeEach } from '@effection/mocha';
+import { describe, it } from '@effection/mocha';
 import expect from 'expect'
 
-import { sleep } from '@effection/core';
+import { Task, sleep, spawn } from '@effection/core';
 import { Slice } from '@effection/atom';
 import { inspect, InspectTree } from '../src/index';
 
 describe("inspect()", () => {
-  it('returns a slice of the task tree', function*(world) {
-    let task = world.spawn();
+  it('returns a slice of the task tree', function*() {
+    let task: Task<void> = yield spawn();
+
 
     let tree: Slice<InspectTree> = yield inspect(task);
 
-    let child = task.spawn(function*(scope) {
-      scope.spawn();
-      scope.spawn(function*() { /* no op */});
+    let child = yield spawn(function*() {
+      yield spawn()
+      yield spawn(function*() { /* no op */});
       yield sleep();
-    }, { labels: { name: 'root' } });
+    }, { labels: { name: 'root' } })
+      .within(task);
 
     yield sleep(10);
 

--- a/packages/mocha/test/mocha.test.ts
+++ b/packages/mocha/test/mocha.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, beforeEach, captureError } from '../src/index';
 import expect from 'expect';
 
-import { Task, Resource, sleep } from '@effection/core';
+import { Task, Resource, spawn } from '@effection/core';
 
 let captured: Task;
 
@@ -10,8 +10,8 @@ function* boom() {
 }
 
 const myResource: Resource<Task> = {
-  *init(scope) {
-    return scope.spawn();
+  *init() {
+    return yield spawn();
   }
 }
 
@@ -42,7 +42,7 @@ describe('@effection/mocha', () => {
 
   describe('cleaning up tasks', () => {
     it('sets up task', function*(task) {
-      captured = task.spawn();
+      captured = yield spawn().within(task);
     });
 
     it('and cleans it up', function*() {
@@ -62,7 +62,7 @@ describe('@effection/mocha', () => {
 
   describe('spawning in world', () => {
     beforeEach(function*(world) {
-      captured = world.spawn();
+      captured = yield spawn().within(world);
     });
 
     it('does not halt the spawned task before it block', function*() {
@@ -71,8 +71,8 @@ describe('@effection/mocha', () => {
   });
 
   describe('spawning in scope', () => {
-    beforeEach(function*(world, scope) {
-      captured = scope.spawn();
+    beforeEach(function*(_world, scope) {
+      captured = yield spawn().within(scope);
     });
 
     it('halts the spawned task before it block', function*() {

--- a/packages/process/src/daemon.ts
+++ b/packages/process/src/daemon.ts
@@ -1,4 +1,4 @@
-import { Task, Resource } from '@effection/core';
+import { spawn, Resource } from '@effection/core';
 
 import { exec, Process, ExecOptions, ExitStatus, DaemonExitError } from './exec';
 
@@ -13,10 +13,10 @@ export interface Daemon extends Resource<Process> {}
 
 export function daemon(command: string, options: ExecOptions = {}): Daemon {
   return {
-    *init(scope: Task) {
+    *init() {
       let process = yield exec(command, options);
 
-      scope.spawn(function*() {
+      yield spawn(function*() {
         let status: ExitStatus = yield process.join();
         throw new DaemonExitError(status, command, options);
       });

--- a/packages/process/src/exec.ts
+++ b/packages/process/src/exec.ts
@@ -37,8 +37,8 @@ export function exec(command: string, options: ExecOptions = {}): Exec {
       return createProcess(cmd, opts).init(scope, local);
     },
     join() {
-      return function*(scope: Task) {
-        let process = yield scope.spawn(createProcess(cmd, { ...opts, buffered: true }));
+      return function*() {
+        let process = yield createProcess(cmd, { ...opts, buffered: true });
 
         let status = yield process.join();
         let stdout = yield process.stdout.expect();
@@ -48,8 +48,8 @@ export function exec(command: string, options: ExecOptions = {}): Exec {
       };
     },
     expect() {
-      return function*(scope: Task) {
-        let process = yield scope.spawn(createProcess(cmd, { ...opts, buffered: true }));
+      return function*() {
+        let process = yield createProcess(cmd, { ...opts, buffered: true });
 
         let status = yield process.expect();
         let stdout = yield process.stdout.expect();

--- a/packages/process/src/exec/posix.ts
+++ b/packages/process/src/exec/posix.ts
@@ -1,4 +1,4 @@
-import { Task, Operation, createFuture } from '@effection/core';
+import { spawn, Task, Operation, createFuture } from '@effection/core';
 import { createChannel } from '@effection/channel';
 import { on, once, onceEmit } from '@effection/events';
 import { spawn as spawnProcess } from 'child_process';
@@ -58,14 +58,14 @@ export const createPosixProcess: CreateOSProcess = (command, options) => {
         }
       };
 
-      scope.spawn(function*(task) {
-        task.spawn(function*() {
+      yield spawn(function*(task) {
+        yield spawn(function*() {
           let value: Error = yield once(childProcess, 'error');
           resolve({ state: 'completed', value: { type: 'error', value } });
-        });
+        }).within(task);
 
-        task.spawn(on<Buffer>(childProcess.stdout, 'data').map((c) => c.toString()).forEach(stdoutChannel.send));
-        task.spawn(on<Buffer>(childProcess.stderr, 'data').map((c) => c.toString()).forEach(stderrChannel.send));
+        yield spawn(on<Buffer>(childProcess.stdout, 'data').map((c) => c.toString()).forEach(stdoutChannel.send)).within(task);
+        yield spawn(on<Buffer>(childProcess.stderr, 'data').map((c) => c.toString()).forEach(stderrChannel.send)).within(task);
 
         try {
           let value = yield onceEmit(childProcess, 'exit');

--- a/packages/process/test/exec.test.ts
+++ b/packages/process/test/exec.test.ts
@@ -1,4 +1,4 @@
-import { Task } from '@effection/core';
+import { Task, spawn } from '@effection/core';
 import { describe, it, beforeEach, captureError } from '@effection/mocha';
 import expect from 'expect';
 
@@ -73,15 +73,15 @@ describe('exec', () => {
       let joinStdout: Task;
       let joinStderr: Task;
 
-      beforeEach(function*(task) {
+      beforeEach(function*() {
         proc = yield exec("node './fixtures/echo-server.js'", {
           env: { PORT: '29000', PATH: process.env.PATH as string },
           cwd: __dirname,
           buffered: true,
         });
 
-        joinStdout = task.spawn(proc.stdout.join());
-        joinStderr = task.spawn(proc.stderr.join());
+        joinStdout = yield spawn(proc.stdout.join());
+        joinStderr = yield spawn(proc.stderr.join());
 
         yield proc.stdout.filter((v) => v.includes('listening')).expect();
       });

--- a/packages/react/src/use-subscription.ts
+++ b/packages/react/src/use-subscription.ts
@@ -7,7 +7,7 @@ export function useSubscription<T>(subscription: Subscription<T>): T | undefined
   let [state, setState] = useState<T>();
 
   useEffect(() => {
-    let task = scope.spawn(subscription.forEach((value) => { setState(value) }));
+    let task = scope.run(subscription.forEach((value) => { setState(value) }));
     return () => { task.halt() };
   }, [subscription, scope]);
 

--- a/packages/subscription/src/stream.ts
+++ b/packages/subscription/src/stream.ts
@@ -32,7 +32,7 @@ export interface StringBufferStream<TReturn = undefined> extends Stream<string, 
 export function createStream<T, TReturn = undefined>(callback: Callback<T, TReturn>, name = 'stream'): Stream<T, TReturn> {
   let subscribe = (task: Task) => {
     let queue = createQueue<T, TReturn>(name);
-    task.spawn(function*() {
+    task.run(function*() {
       let result = yield callback(queue.send);
       queue.closeWith(result);
     }, { labels: { name: `publisher`}});
@@ -99,7 +99,7 @@ export function createStream<T, TReturn = undefined>(callback: Callback<T, TRetu
     buffer(scope: Task): Stream<T, TReturn> {
       let buffer: T[] = [];
 
-      scope.spawn(stream.forEach((m) => { buffer.push(m) }));
+      scope.run(stream.forEach((m) => { buffer.push(m) }));
 
       return createStream((publish) => function*() {
         buffer.forEach(publish);
@@ -110,7 +110,7 @@ export function createStream<T, TReturn = undefined>(callback: Callback<T, TRetu
     stringBuffer(scope: Task): StringBufferStream<TReturn> {
       let buffer = "";
 
-      scope.spawn(stream.forEach((m) => { buffer += `${m}` }));
+      scope.run(stream.forEach((m) => { buffer += `${m}` }));
 
       let result = createStream<string, TReturn>((publish) => function*() {
         let internalBuffer = buffer;

--- a/packages/subscription/test/queue.test.ts
+++ b/packages/subscription/test/queue.test.ts
@@ -1,5 +1,6 @@
 import expect from 'expect';
 import { describe, it, beforeEach, captureError } from '@effection/mocha';
+import { spawn } from '@effection/core';
 
 import { createQueue, Queue } from '../src/index';
 import { abortAfter } from './helpers';
@@ -24,17 +25,17 @@ describe('Queue', () => {
   });
 
   describe('send', () => {
-    it('sends value to an already waiting listener', function*(world) {
+    it('sends value to an already waiting listener', function*() {
       let anotherQueue = createQueue<string>();
-      let listener = world.spawn(anotherQueue.expect());
+      let listener = yield spawn(anotherQueue.expect());
       anotherQueue.send('hello');
       expect(yield listener).toEqual('hello');
     });
 
-    it('only sends value to one listener if there are multiple', function*(world) {
+    it('only sends value to one listener if there are multiple', function*() {
       let anotherQueue = createQueue<string>();
-      let listener1 = world.spawn(abortAfter(anotherQueue.expect(), 10));
-      let listener2 = world.spawn(abortAfter(anotherQueue.expect(), 10));
+      let listener1 = yield spawn(abortAfter(anotherQueue.expect(), 10));
+      let listener2 = yield spawn(abortAfter(anotherQueue.expect(), 10));
       anotherQueue.send('hello');
       expect([yield listener1, yield listener2].filter(Boolean)).toEqual(['hello']);
     });
@@ -45,9 +46,9 @@ describe('Queue', () => {
       expect(yield anotherQueue.expect()).toEqual('hello');
     });
 
-    it('can be destructured', function*(world) {
+    it('can be destructured', function*() {
       let { send, subscription } = createQueue<string>();
-      let listener = world.spawn(subscription.expect());
+      let listener = yield spawn(subscription.expect());
       send('hello');
       expect(yield listener).toEqual('hello');
     });

--- a/packages/websocket-server/src/index.ts
+++ b/packages/websocket-server/src/index.ts
@@ -31,8 +31,8 @@ export function createWebSocketSubscription<TIncoming = unknown, TOutgoing = TIn
 
       let queue = createQueue<WebSocketConnection<TIncoming, TOutgoing>>();
 
-      yield spawn(on<WebSocket>(wss, 'connection').forEach((raw) => {
-        scope.spawn(function*() {
+      yield spawn(on<WebSocket>(wss, 'connection').forEach(function* (raw) {
+        yield spawn(function*() {
           let messageQueue = createQueue<TIncoming>();
 
           queue.send({
@@ -45,7 +45,7 @@ export function createWebSocketSubscription<TIncoming = unknown, TOutgoing = TIn
           yield on<{ data: string }>(raw, 'message').forEach((message) => {
             messageQueue.send(JSON.parse(message.data));
           });
-        });
+        }).within(scope);
       }));
 
       yield ensure(() => { wss.close(); });


### PR DESCRIPTION
## Motivation

There is a more complete writeup and discussion for this change in #360 but the long and the short are that `task.spawn()` the function and standalone `spawn()` the operation have different semantics and should be named different things.

## Approach

This renames `task.spawn()` to `task.run()` which is in keeping with the static definition of `run()`. Global `run()` is a function that turns an operation into a task as the child of the root task, there fore `task.run()` is a function that turns an operation into a task as the child of `task`.

`task.spawn()` is deprecated in favor of `task.run()`.