### PR TITLE
chore: update repository and homepage fields

### DIFF
--- a/packages/atom/package.json
+++ b/packages/atom/package.json
@@ -4,7 +4,12 @@
   "description": "State atom implementation for effection",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
-  "repository": "https://github.com/thefrontside/bigtest.git",
+  "homepage": "https://github.com/thefrontside/effection",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/thefrontside/effection.git",
+    "directory": "packages/atom"
+  },
   "author": "Frontside Engineering <engineering@frontside.io>",
   "license": "MIT",
   "files": [

--- a/packages/channel/package.json
+++ b/packages/channel/package.json
@@ -4,7 +4,12 @@
   "description": "MPMC Channel implementation for effection",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
-  "repository": "https://github.com/thefrontside/bigtest.git",
+  "homepage": "https://github.com/thefrontside/effection",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/thefrontside/effection.git",
+    "directory": "packages/channel"
+  },
   "author": "Frontside Engineering <engineering@frontside.io>",
   "license": "MIT",
   "files": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,6 +4,12 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "license": "MIT",
+  "homepage": "https://github.com/thefrontside/effection",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/thefrontside/effection.git",
+    "directory": "packages/core"
+  },
   "scripts": {
     "lint": "eslint '{src,bin,test}/**/*.ts'",
     "test": "mocha -r ts-node/register 'test/**/*.test.ts'",

--- a/packages/effection/package.json
+++ b/packages/effection/package.json
@@ -2,7 +2,12 @@
   "name": "effection",
   "version": "2.0.0-beta.3",
   "description": "Effortlessly composable structured concurrency primitive for JavaScript",
-  "repository": "http://github.com/thefrontside/effection",
+  "homepage": "https://github.com/thefrontside/effection",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/thefrontside/effection.git",
+    "directory": "packages/effection"
+  },
   "author": "Charles Lowell <cowboyd@frontside.com>",
   "license": "MIT",
   "private": false,

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -5,7 +5,12 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "module": "dist/events.esm.js",
-  "repository": "https://github.com/thefrontside/bigtest.git",
+  "homepage": "https://github.com/thefrontside/effection",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/thefrontside/effection.git",
+    "directory": "packages/events"
+  },
   "author": "Frontside Engineering <engineering@frontside.com>",
   "license": "MIT",
   "files": [

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -4,7 +4,12 @@
   "description": "Fetch operation for Effection",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
-  "repository": "https://github.com/thefrontside/effection.git",
+  "homepage": "https://github.com/thefrontside/effection",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/thefrontside/effection.git",
+    "directory": "packages/fetch"
+  },
   "author": "Frontside Engineering <engineering@frontside.com>",
   "license": "MIT",
   "files": [

--- a/packages/inspect-server/package.json
+++ b/packages/inspect-server/package.json
@@ -5,7 +5,12 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "module": "dist/inspect-server.esm.js",
-  "repository": "https://github.com/thefrontside/bigtest.git",
+  "homepage": "https://github.com/thefrontside/effection",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/thefrontside/effection.git",
+    "directory": "packages/inspect-server"
+  },
   "author": "Frontside Engineering <engineering@frontside.com>",
   "license": "MIT",
   "files": [

--- a/packages/inspect-ui/package.json
+++ b/packages/inspect-ui/package.json
@@ -6,7 +6,12 @@
   "types": "index.d.ts",
   "browser": "dist/index.html",
   "module": "dist/inspect-ui.esm.js",
-  "repository": "https://github.com/thefrontside/bigtest.git",
+  "homepage": "https://github.com/thefrontside/effection",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/thefrontside/effection.git",
+    "directory": "packages/inspect-ui"
+  },
   "author": "Frontside Engineering <engineering@frontside.com>",
   "license": "MIT",
   "files": [

--- a/packages/inspect-utils/package.json
+++ b/packages/inspect-utils/package.json
@@ -5,7 +5,12 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "module": "dist/inspect-utils.esm.js",
-  "repository": "https://github.com/thefrontside/bigtest.git",
+  "homepage": "https://github.com/thefrontside/effection",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/thefrontside/effection.git",
+    "directory": "packages/inspect-utils"
+  },
   "author": "Frontside Engineering <engineering@frontside.com>",
   "license": "MIT",
   "files": [

--- a/packages/inspect/package.json
+++ b/packages/inspect/package.json
@@ -3,7 +3,12 @@
   "version": "2.0.0-beta.4",
   "description": "Injects an inspector into an Effection application",
   "main": "index.js",
-  "repository": "https://github.com/thefrontside/bigtest.git",
+  "homepage": "https://github.com/thefrontside/effection",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/thefrontside/effection.git",
+    "directory": "packages/inspect"
+  },
   "author": "Frontside Engineering <engineering@frontside.com>",
   "license": "MIT",
   "files": [

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -4,7 +4,12 @@
   "description": "Main entry point for Effection applications",
   "main": "dist/node.js",
   "browser": "dist/browser.js",
-  "repository": "https://github.com/thefrontside/bigtest.git",
+  "homepage": "https://github.com/thefrontside/effection",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/thefrontside/effection.git",
+    "directory": "packages/main"
+  },
   "author": "Frontside Engineering <engineering@frontside.com>",
   "license": "MIT",
   "files": [

--- a/packages/mocha/package.json
+++ b/packages/mocha/package.json
@@ -4,7 +4,12 @@
   "description": "Effection Subscriptions",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "repository": "https://github.com/thefrontside/effection.git",
+  "homepage": "https://github.com/thefrontside/effection",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/thefrontside/effection.git",
+    "directory": "packages/mocha"
+  },
   "author": "Frontside Engineering <engineering@frontside.com>",
   "license": "MIT",
   "files": [

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -4,7 +4,12 @@
   "description": "Work in Node.js with Effection",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "repository": "https://github.com/thefrontside/bigtest.git",
+  "homepage": "https://github.com/thefrontside/effection",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/thefrontside/effection.git",
+    "directory": "packages/node"
+  },
   "author": "Frontside Engineering <engineering@frontside.com>",
   "license": "MIT",
   "files": [

--- a/packages/process/package.json
+++ b/packages/process/package.json
@@ -4,7 +4,12 @@
   "description": "Spawn and manage external processes with Effection",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "repository": "https://github.com/thefrontside/bigtest.git",
+  "homepage": "https://github.com/thefrontside/effection",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/thefrontside/effection.git",
+    "directory": "packages/process"
+  },
   "author": "Frontside Engineering <engineering@frontside.com>",
   "license": "MIT",
   "files": [

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -5,7 +5,12 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "module": "dist/react.esm.js",
-  "repository": "https://github.com/thefrontside/effection.git",
+  "homepage": "https://github.com/thefrontside/effection",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/thefrontside/effection.git",
+    "directory": "packages/react"
+  },
   "author": "Frontside Engineering <engineering@frontside.com>",
   "license": "MIT",
   "files": [

--- a/packages/subscription/package.json
+++ b/packages/subscription/package.json
@@ -4,7 +4,12 @@
   "description": "Effection Subscriptions",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "repository": "https://github.com/thefrontside/effection.git",
+  "homepage": "https://github.com/thefrontside/effection",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/thefrontside/effection.git",
+    "directory": "packages/subscription"
+  },
   "author": "Frontside Engineering <engineering@frontside.com>",
   "license": "MIT",
   "files": [

--- a/packages/websocket-client/package.json
+++ b/packages/websocket-client/package.json
@@ -5,7 +5,12 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "module": "dist/websocket-client.esm.js",
-  "repository": "https://github.com/thefrontside/bigtest.git",
+  "homepage": "https://github.com/thefrontside/effection",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/thefrontside/effection.git",
+    "directory": "packages/websocket-client"
+  },
   "author": "Frontside Engineering <engineering@frontside.com>",
   "license": "MIT",
   "files": [

--- a/packages/websocket-server/package.json
+++ b/packages/websocket-server/package.json
@@ -5,7 +5,12 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "module": "dist/websocket-server.esm.js",
-  "repository": "https://github.com/thefrontside/bigtest.git",
+  "homepage": "https://github.com/thefrontside/effection",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/thefrontside/effection.git",
+    "directory": "packages/websocket-server"
+  },
   "author": "Frontside Engineering <engineering@frontside.com>",
   "license": "MIT",
   "files": [


### PR DESCRIPTION
## Motivation

The packages had an outdated repository field that pointed to BigTest. This meant the homepage link on npmjs.com was incorrect. I went through and filled out the homepage and repository for every package. 

Note that I did not add a changeset. It wasn't a big enough change to warrant a new package release. The values will simply be included the next time a package is published.