### PR TITLE
Install changesets in workflow

### DIFF
--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -13,6 +13,8 @@ jobs:
     - uses: actions/checkout@v1
     - name: Install Dependencies
       run: yarn
+    - name: Install Changesets
+      run: yarn add @changesets/cli -W
     - name: Create Release Pull Request
       uses: changesets/action@master
       env:


### PR DESCRIPTION
## Motivation
I removed changesets dependency in #420 without realizing that it's required for the changesets' action. Oopsy.

## Approach
Added a run step in the changesets workflow:
```yaml
- name: Install Dependencies
  run: yarn
- name: Install Changesets
  run: yarn add @changesets/cli -W
- name: Create Release Pull Request
  uses: changesets/action@master
```
This is so that people won't rely on the changesets/cli to generate changesets in new PRs but the workflow will still update the version packages PR for pre-existing PRs that are still using changesets.