### PR TITLE
Publish New Versions

### DIFF
--- a/.changes/pre.json
+++ b/.changes/pre.json
@@ -1,4 +1,6 @@
 {
   "tag": "beta",
-  "changes": []
+  "changes": [
+    ".changes/produce.md"
+  ]
 }

--- a/packages/atom/CHANGELOG.md
+++ b/packages/atom/CHANGELOG.md
@@ -1,10 +1,16 @@
 # @effection/atom
 
+## \[2.0.0-beta.5]
+
+- Deprecate Future#resolve in favour of Future#produce.
+  - Bumped due to a bump in @effection/core.
+  - [7b8ce8e](https://github.com/thefrontside/effection/commit/7b8ce8ef1d46ddf10806d51b3f0ed1ef14e8f9cd) Depreacte Future#resolve in favour of Future#produce ([#437](https://github.com/thefrontside/effection/pull/437)) on 2021-07-22
+
 ## 2.0.0-beta.4
 
 ### Patch Changes
 
-- Updated dependencies [e297c86]
+- Updated dependencies \[e297c86]
   - @effection/core@2.0.0-beta.4
   - @effection/channel@2.0.0-beta.4
   - @effection/subscription@2.0.0-beta.4
@@ -13,10 +19,10 @@
 
 ### Patch Changes
 
-- Updated dependencies [3e77f29]
-- Updated dependencies [5d95e6d]
-- Updated dependencies [9700b45]
-- Updated dependencies [9700b45]
+- Updated dependencies \[3e77f29]
+- Updated dependencies \[5d95e6d]
+- Updated dependencies \[9700b45]
+- Updated dependencies \[9700b45]
   - @effection/subscription@2.0.0-beta.3
   - @effection/core@2.0.0-beta.3
   - @effection/channel@2.0.0-beta.3
@@ -25,11 +31,11 @@
 
 ### Patch Changes
 
-- Updated dependencies [19414f0]
-- Updated dependencies [26a86cb]
-- Updated dependencies [9c76cc5]
-- Updated dependencies [f7e3344]
-- Updated dependencies [ac7c1ce]
+- Updated dependencies \[19414f0]
+- Updated dependencies \[26a86cb]
+- Updated dependencies \[9c76cc5]
+- Updated dependencies \[f7e3344]
+- Updated dependencies \[ac7c1ce]
   - @effection/core@2.0.0-beta.2
   - @effection/channel@2.0.0-beta.2
   - @effection/subscription@2.0.0-beta.2
@@ -39,7 +45,7 @@
 ### Patch Changes
 
 - 0c6e263: release 2.0.0-beta
-- Updated dependencies [0c6e263]
+- Updated dependencies \[0c6e263]
   - @effection/channel@2.0.0-beta.1
   - @effection/core@2.0.0-beta.1
   - @effection/subscription@2.0.0-beta.1
@@ -48,10 +54,10 @@
 
 ### Patch Changes
 
-- Updated dependencies [9998088]
-- Updated dependencies [2bce454]
-- Updated dependencies [1981b35]
-- Updated dependencies [88dc59a]
+- Updated dependencies \[9998088]
+- Updated dependencies \[2bce454]
+- Updated dependencies \[1981b35]
+- Updated dependencies \[88dc59a]
   - @effection/core@2.0.0-preview.12
   - @effection/channel@2.0.0-preview.15
   - @effection/subscription@2.0.0-preview.14
@@ -61,10 +67,10 @@
 ### Patch Changes
 
 - b46434a: Use the generic monocle-ts import and not the commonjs import
-- Updated dependencies [88eca21]
-- Updated dependencies [ae8d090]
-- Updated dependencies [8bb4514]
-- Updated dependencies [44c354d]
+- Updated dependencies \[88eca21]
+- Updated dependencies \[ae8d090]
+- Updated dependencies \[8bb4514]
+- Updated dependencies \[44c354d]
   - @effection/core@2.0.0-preview.11
   - @effection/channel@2.0.0-preview.14
   - @effection/subscription@2.0.0-preview.13
@@ -79,10 +85,10 @@
 
 ### Patch Changes
 
-- Updated dependencies [625b521]
-- Updated dependencies [a06c679]
-- Updated dependencies [4d04159]
-- Updated dependencies [625b521]
+- Updated dependencies \[625b521]
+- Updated dependencies \[a06c679]
+- Updated dependencies \[4d04159]
+- Updated dependencies \[625b521]
   - @effection/core@2.0.0-preview.10
   - @effection/channel@2.0.0-preview.13
   - @effection/subscription@2.0.0-preview.12
@@ -91,7 +97,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [92f921e]
+- Updated dependencies \[92f921e]
   - @effection/subscription@2.0.0-preview.11
   - @effection/channel@2.0.0-preview.12
 
@@ -99,14 +105,14 @@
 
 ### Patch Changes
 
-- Updated dependencies [110a2cd]
-- Updated dependencies [e2545b2]
-- Updated dependencies [2b92370]
-- Updated dependencies [00562fd]
-- Updated dependencies [110a2cd]
-- Updated dependencies [110a2cd]
-- Updated dependencies [02446ad]
-- Updated dependencies [da86a9c]
+- Updated dependencies \[110a2cd]
+- Updated dependencies \[e2545b2]
+- Updated dependencies \[2b92370]
+- Updated dependencies \[00562fd]
+- Updated dependencies \[110a2cd]
+- Updated dependencies \[110a2cd]
+- Updated dependencies \[02446ad]
+- Updated dependencies \[da86a9c]
   - @effection/core@2.0.0-preview.9
   - @effection/channel@2.0.0-preview.11
   - @effection/subscription@2.0.0-preview.10
@@ -115,7 +121,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [a13987f]
+- Updated dependencies \[a13987f]
   - @effection/core@2.0.0-preview.8
   - @effection/subscription@2.0.0-preview.9
   - @effection/channel@2.0.0-preview.10
@@ -125,14 +131,14 @@
 ### Patch Changes
 
 - 91ade6c: Add missing dependency on @effection/channel which could cause incorrect module resolution
-- Updated dependencies [91ade6c]
+- Updated dependencies \[91ade6c]
   - @effection/channel@2.0.0-preview.9
 
 ## 2.0.0-preview.7
 
 ### Patch Changes
 
-- Updated dependencies [2bad074]
+- Updated dependencies \[2bad074]
   - @effection/core@2.0.0-preview.7
   - @effection/subscription@2.0.0-preview.8
 
@@ -141,7 +147,7 @@
 ### Patch Changes
 
 - 9a6a6e3: Make atom more reentrant
-- Updated dependencies [3db7270]
+- Updated dependencies \[3db7270]
   - @effection/subscription@2.0.0-preview.7
 
 ## 2.0.0-preview.5
@@ -157,8 +163,8 @@
 ### Patch Changes
 
 - 1222756: Use strict dependency requirements for internal dependencies while in prerelease mode
-- Updated dependencies [0dca571]
-- Updated dependencies [1222756]
+- Updated dependencies \[0dca571]
+- Updated dependencies \[1222756]
   - @effection/subscription@2.0.0-preview.6
   - @effection/core@2.0.0-preview.6
 

--- a/packages/atom/package.json
+++ b/packages/atom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/atom",
-  "version": "2.0.0-beta.4",
+  "version": "2.0.0-beta.5",
   "description": "State atom implementation for effection",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -44,9 +44,9 @@
     "yarn": "1.19.1"
   },
   "dependencies": {
-    "@effection/channel": "2.0.0-beta.4",
-    "@effection/core": "2.0.0-beta.4",
-    "@effection/subscription": "2.0.0-beta.4",
+    "@effection/channel": "2.0.0-beta.5",
+    "@effection/core": "2.1.0-beta.0",
+    "@effection/subscription": "2.0.0-beta.5",
     "assert-ts": "^0.2.2",
     "fp-ts": "^2.8.2",
     "monocle-ts": "^2.3.3"

--- a/packages/channel/CHANGELOG.md
+++ b/packages/channel/CHANGELOG.md
@@ -1,10 +1,16 @@
 # Changelog
 
+## \[2.0.0-beta.5]
+
+- Deprecate Future#resolve in favour of Future#produce.
+  - Bumped due to a bump in @effection/core.
+  - [7b8ce8e](https://github.com/thefrontside/effection/commit/7b8ce8ef1d46ddf10806d51b3f0ed1ef14e8f9cd) Depreacte Future#resolve in favour of Future#produce ([#437](https://github.com/thefrontside/effection/pull/437)) on 2021-07-22
+
 ## 2.0.0-beta.4
 
 ### Patch Changes
 
-- Updated dependencies [e297c86]
+- Updated dependencies \[e297c86]
   - @effection/core@2.0.0-beta.4
   - @effection/events@2.0.0-beta.4
   - @effection/subscription@2.0.0-beta.4
@@ -13,10 +19,10 @@
 
 ### Patch Changes
 
-- Updated dependencies [3e77f29]
-- Updated dependencies [5d95e6d]
-- Updated dependencies [9700b45]
-- Updated dependencies [9700b45]
+- Updated dependencies \[3e77f29]
+- Updated dependencies \[5d95e6d]
+- Updated dependencies \[9700b45]
+- Updated dependencies \[9700b45]
   - @effection/subscription@2.0.0-beta.3
   - @effection/events@2.0.0-beta.3
   - @effection/core@2.0.0-beta.3
@@ -25,11 +31,11 @@
 
 ### Patch Changes
 
-- Updated dependencies [19414f0]
-- Updated dependencies [26a86cb]
-- Updated dependencies [9c76cc5]
-- Updated dependencies [f7e3344]
-- Updated dependencies [ac7c1ce]
+- Updated dependencies \[19414f0]
+- Updated dependencies \[26a86cb]
+- Updated dependencies \[9c76cc5]
+- Updated dependencies \[f7e3344]
+- Updated dependencies \[ac7c1ce]
   - @effection/core@2.0.0-beta.2
   - @effection/events@2.0.0-beta.2
   - @effection/subscription@2.0.0-beta.2
@@ -39,7 +45,7 @@
 ### Patch Changes
 
 - 0c6e263: release 2.0.0-beta
-- Updated dependencies [0c6e263]
+- Updated dependencies \[0c6e263]
   - @effection/core@2.0.0-beta.1
   - @effection/events@2.0.0-beta.1
   - @effection/subscription@2.0.0-beta.1
@@ -48,11 +54,11 @@
 
 ### Patch Changes
 
-- Updated dependencies [9998088]
-- Updated dependencies [d7c0eb1]
-- Updated dependencies [2bce454]
-- Updated dependencies [1981b35]
-- Updated dependencies [88dc59a]
+- Updated dependencies \[9998088]
+- Updated dependencies \[d7c0eb1]
+- Updated dependencies \[2bce454]
+- Updated dependencies \[1981b35]
+- Updated dependencies \[88dc59a]
   - @effection/core@2.0.0-preview.12
   - @effection/events@2.0.0-preview.13
   - @effection/subscription@2.0.0-preview.14
@@ -61,10 +67,10 @@
 
 ### Patch Changes
 
-- Updated dependencies [88eca21]
-- Updated dependencies [ae8d090]
-- Updated dependencies [8bb4514]
-- Updated dependencies [44c354d]
+- Updated dependencies \[88eca21]
+- Updated dependencies \[ae8d090]
+- Updated dependencies \[8bb4514]
+- Updated dependencies \[44c354d]
   - @effection/core@2.0.0-preview.11
   - @effection/events@2.0.0-preview.12
   - @effection/subscription@2.0.0-preview.13
@@ -73,10 +79,10 @@
 
 ### Patch Changes
 
-- Updated dependencies [625b521]
-- Updated dependencies [a06c679]
-- Updated dependencies [4d04159]
-- Updated dependencies [625b521]
+- Updated dependencies \[625b521]
+- Updated dependencies \[a06c679]
+- Updated dependencies \[4d04159]
+- Updated dependencies \[625b521]
   - @effection/core@2.0.0-preview.10
   - @effection/events@2.0.0-preview.11
   - @effection/subscription@2.0.0-preview.12
@@ -85,7 +91,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [92f921e]
+- Updated dependencies \[92f921e]
   - @effection/subscription@2.0.0-preview.11
   - @effection/events@2.0.0-preview.10
 
@@ -93,15 +99,15 @@
 
 ### Patch Changes
 
-- Updated dependencies [110a2cd]
-- Updated dependencies [7216a21]
-- Updated dependencies [e2545b2]
-- Updated dependencies [2b92370]
-- Updated dependencies [00562fd]
-- Updated dependencies [110a2cd]
-- Updated dependencies [110a2cd]
-- Updated dependencies [02446ad]
-- Updated dependencies [da86a9c]
+- Updated dependencies \[110a2cd]
+- Updated dependencies \[7216a21]
+- Updated dependencies \[e2545b2]
+- Updated dependencies \[2b92370]
+- Updated dependencies \[00562fd]
+- Updated dependencies \[110a2cd]
+- Updated dependencies \[110a2cd]
+- Updated dependencies \[02446ad]
+- Updated dependencies \[da86a9c]
   - @effection/core@2.0.0-preview.9
   - @effection/events@2.0.0-preview.9
   - @effection/subscription@2.0.0-preview.10
@@ -110,7 +116,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [a13987f]
+- Updated dependencies \[a13987f]
   - @effection/core@2.0.0-preview.8
   - @effection/subscription@2.0.0-preview.9
   - @effection/events@2.0.0-preview.8
@@ -125,7 +131,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [2bad074]
+- Updated dependencies \[2bad074]
   - @effection/core@2.0.0-preview.7
   - @effection/events@2.0.0-preview.7
   - @effection/subscription@2.0.0-preview.8
@@ -134,7 +140,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [3db7270]
+- Updated dependencies \[3db7270]
   - @effection/subscription@2.0.0-preview.7
   - @effection/events@2.0.0-preview.6
 
@@ -143,8 +149,8 @@
 ### Patch Changes
 
 - 1222756: Use strict dependency requirements for internal dependencies while in prerelease mode
-- Updated dependencies [0dca571]
-- Updated dependencies [1222756]
+- Updated dependencies \[0dca571]
+- Updated dependencies \[1222756]
   - @effection/subscription@2.0.0-preview.6
   - @effection/events@2.0.0-preview.5
   - @effection/core@2.0.0-preview.6
@@ -158,11 +164,11 @@
 
 ### Patch Changes
 
-- Updated dependencies [0b24415]
-- Updated dependencies [22e5230]
-- Updated dependencies [70c358f]
-- Updated dependencies [3983202]
-- Updated dependencies [2c2749d]
+- Updated dependencies \[0b24415]
+- Updated dependencies \[22e5230]
+- Updated dependencies \[70c358f]
+- Updated dependencies \[3983202]
+- Updated dependencies \[2c2749d]
   - @effection/subscription@2.0.0-preview.5
   - @effection/core@2.0.0-preview.5
 
@@ -174,9 +180,9 @@
 
 ### Patch Changes
 
-- Updated dependencies [7b6ba05]
-- Updated dependencies [ab41f6a]
-- Updated dependencies [72f743c]
+- Updated dependencies \[7b6ba05]
+- Updated dependencies \[ab41f6a]
+- Updated dependencies \[72f743c]
   - @effection/events@2.0.0-preview.4
   - @effection/subscription@2.0.0-preview.4
   - @effection/core@2.0.0-preview.4
@@ -191,10 +197,10 @@
 ### Patch Changes
 
 - 3ca4cd4: Use new channel and subscription interfaces internally
-- Updated dependencies [3ca4cd4]
-- Updated dependencies [3ca4cd4]
-- Updated dependencies [bdedf68]
-- Updated dependencies [2bf5ef4]
+- Updated dependencies \[3ca4cd4]
+- Updated dependencies \[3ca4cd4]
+- Updated dependencies \[bdedf68]
+- Updated dependencies \[2bf5ef4]
   - @effection/events@2.0.0-preview.3
   - @effection/subscription@2.0.0-preview.3
   - @effection/core@2.0.0-preview.3
@@ -204,7 +210,7 @@
 ### Patch Changes
 
 - 93ec0d6: Include CHANGELOGS and src with all packages
-- Updated dependencies [93ec0d6]
+- Updated dependencies \[93ec0d6]
   - @effection/core@2.0.0-preview.2
   - @effection/events@2.0.0-preview.2
   - @effection/subscription@2.0.0-preview.2
@@ -214,7 +220,7 @@
 ### Patch Changes
 
 - 80143d5: Fix packaging
-- Updated dependencies [80143d5]
+- Updated dependencies \[80143d5]
   - @effection/core@2.0.0-preview.1
   - @effection/events@2.0.0-preview.1
   - @effection/subscription@2.0.0-preview.1
@@ -227,7 +233,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [undefined]
+- Updated dependencies \[undefined]
   - effection@2.0.0-preview.0
   - @effection/events@2.0.0-preview.0
   - @effection/subscription@2.0.0-preview.0
@@ -240,7 +246,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [b988025]
+- Updated dependencies \[b988025]
   - effection@1.0.0
   - @effection/events@1.0.0
   - @effection/subscription@1.0.0
@@ -249,8 +255,8 @@
 
 ### Patch Changes
 
-- Updated dependencies [f851981]
-- Updated dependencies [d3d3b64]
+- Updated dependencies \[f851981]
+- Updated dependencies \[d3d3b64]
   - effection@0.8.0
   - @effection/subscription@0.12.0
   - @effection/events@0.7.9
@@ -260,7 +266,7 @@
 ### Patch Changes
 
 - 25b68eb: Subscriptions created via `createSubscription` are chainable on both sides of the yield
-- Updated dependencies [25b68eb]
+- Updated dependencies \[25b68eb]
   - @effection/subscription@0.11.0
   - @effection/events@0.7.8
 
@@ -269,7 +275,7 @@
 ### Patch Changes
 
 - 6a41f0b: Bump lodash from 4.17.15 to 4.17.19 in /packages/channel
-- Updated dependencies [5d118ee]
+- Updated dependencies \[5d118ee]
   - @effection/subscription@0.10.0
   - @effection/events@0.7.7
 
@@ -283,7 +289,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [786b20e]
+- Updated dependencies \[786b20e]
   - @effection/subscription@0.9.0
   - @effection/events@0.7.6
 
@@ -292,14 +298,14 @@
 ### Patch Changes
 
 - 2a008aa: use effection as dependency, not peer dependency
-- Updated dependencies [a7f9396]
+- Updated dependencies \[a7f9396]
   - @effection/subscription@0.8.1
 
 ## 0.6.2
 
 ### Patch Changes
 
-- Updated dependencies [8303e92]
+- Updated dependencies \[8303e92]
   - @effection/subscription@0.8.0
   - @effection/events@0.7.5
 
@@ -308,4 +314,4 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## \[Unreleased]

--- a/packages/channel/package.json
+++ b/packages/channel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/channel",
-  "version": "2.0.0-beta.4",
+  "version": "2.0.0-beta.5",
   "description": "MPMC Channel implementation for effection",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -41,8 +41,8 @@
     "yarn": "1.19.1"
   },
   "dependencies": {
-    "@effection/core": "2.0.0-beta.4",
-    "@effection/events": "2.0.0-beta.4",
-    "@effection/subscription": "2.0.0-beta.4"
+    "@effection/core": "2.1.0-beta.0",
+    "@effection/events": "2.0.0-beta.5",
+    "@effection/subscription": "2.0.0-beta.5"
   }
 }

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,10 @@
 # @effection/core
 
+## \[2.1.0-beta.0]
+
+- Deprecate Future#resolve in favour of Future#produce.
+  - [7b8ce8e](https://github.com/thefrontside/effection/commit/7b8ce8ef1d46ddf10806d51b3f0ed1ef14e8f9cd) Depreacte Future#resolve in favour of Future#produce ([#437](https://github.com/thefrontside/effection/pull/437)) on 2021-07-22
+
 ## 2.0.0-beta.4
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/core",
-  "version": "2.0.0-beta.4",
+  "version": "2.1.0-beta.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "license": "MIT",

--- a/packages/effection/CHANGELOG.md
+++ b/packages/effection/CHANGELOG.md
@@ -1,11 +1,17 @@
 # Changelog
 
+## \[2.0.0-beta.5]
+
+- Deprecate Future#resolve in favour of Future#produce.
+  - Bumped due to a bump in @effection/core.
+  - [7b8ce8e](https://github.com/thefrontside/effection/commit/7b8ce8ef1d46ddf10806d51b3f0ed1ef14e8f9cd) Depreacte Future#resolve in favour of Future#produce ([#437](https://github.com/thefrontside/effection/pull/437)) on 2021-07-22
+
 ## 2.0.0-beta.4
 
 ### Patch Changes
 
 - e297c86: rename Task.spawn() -> Task.run()
-- Updated dependencies [e297c86]
+- Updated dependencies \[e297c86]
   - @effection/core@2.0.0-beta.4
   - @effection/channel@2.0.0-beta.4
   - @effection/events@2.0.0-beta.4
@@ -19,11 +25,11 @@
 - 3e77f29: - label events for visual inspection
   - label stream and queue operations
 - 5d95e6d: label the "suspend" operation that is created with a bare `yield` statement;
-- Updated dependencies [248b0a6]
-- Updated dependencies [3e77f29]
-- Updated dependencies [5d95e6d]
-- Updated dependencies [9700b45]
-- Updated dependencies [9700b45]
+- Updated dependencies \[248b0a6]
+- Updated dependencies \[3e77f29]
+- Updated dependencies \[5d95e6d]
+- Updated dependencies \[9700b45]
+- Updated dependencies \[9700b45]
   - @effection/main@2.0.0-beta.3
   - @effection/subscription@2.0.0-beta.3
   - @effection/events@2.0.0-beta.3
@@ -42,11 +48,11 @@
 ### Patch Changes
 
 - f7e3344: Name in interface should be yieldingTo and not subTask
-- Updated dependencies [19414f0]
-- Updated dependencies [26a86cb]
-- Updated dependencies [9c76cc5]
-- Updated dependencies [f7e3344]
-- Updated dependencies [ac7c1ce]
+- Updated dependencies \[19414f0]
+- Updated dependencies \[26a86cb]
+- Updated dependencies \[9c76cc5]
+- Updated dependencies \[f7e3344]
+- Updated dependencies \[ac7c1ce]
   - @effection/core@2.0.0-beta.2
   - @effection/channel@2.0.0-beta.2
   - @effection/events@2.0.0-beta.2
@@ -58,7 +64,7 @@
 ### Patch Changes
 
 - 0c6e263: release 2.0.0-beta
-- Updated dependencies [0c6e263]
+- Updated dependencies \[0c6e263]
   - @effection/channel@2.0.0-beta.1
   - @effection/core@2.0.0-beta.1
   - @effection/events@2.0.0-beta.1
@@ -78,12 +84,12 @@
 
 ### Patch Changes
 
-- Updated dependencies [9998088]
-- Updated dependencies [d7c0eb1]
-- Updated dependencies [2bce454]
-- Updated dependencies [1981b35]
-- Updated dependencies [88dc59a]
-- Updated dependencies [88dc59a]
+- Updated dependencies \[9998088]
+- Updated dependencies \[d7c0eb1]
+- Updated dependencies \[2bce454]
+- Updated dependencies \[1981b35]
+- Updated dependencies \[88dc59a]
+- Updated dependencies \[88dc59a]
   - @effection/core@2.0.0-preview.12
   - @effection/events@2.0.0-preview.13
   - @effection/main@2.0.0-preview.3
@@ -102,10 +108,10 @@
 ### Patch Changes
 
 - ae8d090: Sleeping for zero milliseconds should not suspend indefinitely
-- Updated dependencies [88eca21]
-- Updated dependencies [ae8d090]
-- Updated dependencies [8bb4514]
-- Updated dependencies [44c354d]
+- Updated dependencies \[88eca21]
+- Updated dependencies \[ae8d090]
+- Updated dependencies \[8bb4514]
+- Updated dependencies \[44c354d]
   - @effection/core@2.0.0-preview.11
   - @effection/channel@2.0.0-preview.14
   - @effection/events@2.0.0-preview.12
@@ -122,10 +128,10 @@
 
 ### Patch Changes
 
-- Updated dependencies [625b521]
-- Updated dependencies [a06c679]
-- Updated dependencies [4d04159]
-- Updated dependencies [625b521]
+- Updated dependencies \[625b521]
+- Updated dependencies \[a06c679]
+- Updated dependencies \[4d04159]
+- Updated dependencies \[625b521]
   - @effection/core@2.0.0-preview.10
   - @effection/channel@2.0.0-preview.13
   - @effection/events@2.0.0-preview.11
@@ -139,7 +145,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [92f921e]
+- Updated dependencies \[92f921e]
   - @effection/subscription@2.0.0-preview.11
   - @effection/channel@2.0.0-preview.12
   - @effection/events@2.0.0-preview.10
@@ -159,15 +165,15 @@
 
 ### Patch Changes
 
-- Updated dependencies [110a2cd]
-- Updated dependencies [7216a21]
-- Updated dependencies [e2545b2]
-- Updated dependencies [2b92370]
-- Updated dependencies [00562fd]
-- Updated dependencies [110a2cd]
-- Updated dependencies [110a2cd]
-- Updated dependencies [02446ad]
-- Updated dependencies [da86a9c]
+- Updated dependencies \[110a2cd]
+- Updated dependencies \[7216a21]
+- Updated dependencies \[e2545b2]
+- Updated dependencies \[2b92370]
+- Updated dependencies \[00562fd]
+- Updated dependencies \[110a2cd]
+- Updated dependencies \[110a2cd]
+- Updated dependencies \[02446ad]
+- Updated dependencies \[da86a9c]
   - @effection/core@2.0.0-preview.9
   - @effection/events@2.0.0-preview.9
   - @effection/channel@2.0.0-preview.11
@@ -177,7 +183,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [a13987f]
+- Updated dependencies \[a13987f]
   - @effection/core@2.0.0-preview.8
   - @effection/subscription@2.0.0-preview.9
   - @effection/events@2.0.0-preview.8
@@ -187,7 +193,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [91ade6c]
+- Updated dependencies \[91ade6c]
   - @effection/channel@2.0.0-preview.9
 
 ## 2.0.0-preview.9
@@ -198,7 +204,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [2bad074]
+- Updated dependencies \[2bad074]
   - @effection/core@2.0.0-preview.7
   - @effection/channel@2.0.0-preview.8
   - @effection/events@2.0.0-preview.7
@@ -213,7 +219,7 @@
 ### Patch Changes
 
 - 9a6a6e3: Make atom more reentrant
-- Updated dependencies [3db7270]
+- Updated dependencies \[3db7270]
   - @effection/subscription@2.0.0-preview.7
   - @effection/channel@2.0.0-preview.7
   - @effection/events@2.0.0-preview.6
@@ -227,8 +233,8 @@
 ### Patch Changes
 
 - 1222756: Use strict dependency requirements for internal dependencies while in prerelease mode
-- Updated dependencies [0dca571]
-- Updated dependencies [1222756]
+- Updated dependencies \[0dca571]
+- Updated dependencies \[1222756]
   - @effection/subscription@2.0.0-preview.6
   - @effection/channel@2.0.0-preview.6
   - @effection/events@2.0.0-preview.5
@@ -248,12 +254,12 @@
 
 ### Patch Changes
 
-- Updated dependencies [9cf6053]
-- Updated dependencies [0b24415]
-- Updated dependencies [22e5230]
-- Updated dependencies [70c358f]
-- Updated dependencies [3983202]
-- Updated dependencies [2c2749d]
+- Updated dependencies \[9cf6053]
+- Updated dependencies \[0b24415]
+- Updated dependencies \[22e5230]
+- Updated dependencies \[70c358f]
+- Updated dependencies \[3983202]
+- Updated dependencies \[2c2749d]
   - @effection/channel@2.0.0-preview.5
   - @effection/subscription@2.0.0-preview.5
   - @effection/core@2.0.0-preview.5
@@ -277,10 +283,13 @@
   which accounts for 99.9% of the use cases. For the cases where all the
   arguments are required, use `onEmit()`.
 
-- Updated dependencies [7b6ba05]
-- Updated dependencies [ab41f6a]
-- Updated dependencies [ce76f15]
-- Updated dependencies [72f743c]
+- Updated dependencies \[7b6ba05]
+
+- Updated dependencies \[ab41f6a]
+
+- Updated dependencies \[ce76f15]
+
+- Updated dependencies \[72f743c]
   - @effection/events@2.0.0-preview.4
   - @effection/subscription@2.0.0-preview.4
   - @effection/channel@2.0.0-preview.4
@@ -298,8 +307,8 @@
 ### Patch Changes
 
 - 2bf5ef4: Make iterator controllers reentrant so they can e.g. halt themselves
-- Updated dependencies [bdedf68]
-- Updated dependencies [2bf5ef4]
+- Updated dependencies \[bdedf68]
+- Updated dependencies \[2bf5ef4]
   - @effection/core@2.0.0-preview.3
 
 ## 2.0.0-preview.3
@@ -307,7 +316,7 @@
 ### Patch Changes
 
 - 93ec0d6: Include CHANGELOGS and src with all packages
-- Updated dependencies [93ec0d6]
+- Updated dependencies \[93ec0d6]
   - @effection/core@2.0.0-preview.2
 
 ## 2.0.0-preview.2
@@ -315,7 +324,7 @@
 ### Patch Changes
 
 - 80143d5: Fix packaging
-- Updated dependencies [80143d5]
+- Updated dependencies \[80143d5]
   - @effection/core@2.0.0-preview.1
 
 ## 2.0.0-preview.1
@@ -369,9 +378,9 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## \[Unreleased]
 
-## [0.6.2] - 2020-04-24
+## \[0.6.2] - 2020-04-24
 
 ## Changed
 
@@ -379,7 +388,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   properly as part of the migration to
   `microbundle`. https://github.com/thefrontside/effection.js/pull/107
 
-## [0.6.1] - 2020-04-24
+## \[0.6.1] - 2020-04-24
 
 ### Changed
 
@@ -389,7 +398,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   pika. https://github.com/thefrontside/effection.js/pull/100
 - removed custom publish scripts in order to fix releases 🙏
 
-## [0.6.0] - 2020-04-15
+## \[0.6.0] - 2020-04-15
 
 ### Changed
 
@@ -403,7 +412,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   to any JavaScript object.
   https://github.com/thefrontside/effection.js/pull/89
 
-## [0.5.2] - 2020-03-09
+## \[0.5.2] - 2020-03-09
 
 ### Added
 
@@ -416,7 +425,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Catch errors raised in ensure blocks and print nasty warning
   https://github.com/thefrontside/effection.js/pull/80
 
-## [0.5.1] - 2020-02-24
+## \[0.5.1] - 2020-02-24
 
 ### Changed
 
@@ -425,7 +434,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   from working in those environments. This was addressed with
   https://github.com/thefrontside/effection.js/pull/77
 
-## [0.5.0] - 2020-02-10
+## \[0.5.0] - 2020-02-10
 
 ### Added
 
@@ -440,7 +449,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Introduced a `main` function to enter a brand new context
 
-## [0.4.0] - 2019-11-20
+## \[0.4.0] - 2019-11-20
 
 ### Added
 
@@ -456,7 +465,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   API. E.g. `fork(operation).then()`
   https://github.com/thefrontside/effection.js/pull/38
 
-## [0.3.3] - 2019-11-04
+## \[0.3.3] - 2019-11-04
 
 ### Added
 
@@ -464,7 +473,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   construction of non-trivial async processes like servers.
   https://github.com/thefrontside/effection.js/pull/24
 
-## [0.3.2] - 2019-10-30
+## \[0.3.2] - 2019-10-30
 
 ### Changed
 
@@ -475,7 +484,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   and while not running will cause memory leaks long-term
   https://github.com/thefrontside/effection.js/pull/22
 
-## [0.3.1] - 2019-10-23
+## \[0.3.1] - 2019-10-23
 
 ### Changed
 
@@ -485,7 +494,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - remove some dead files that were not contributing to the API
   https://github.com/thefrontside/effection.js/pull/18
 
-## [0.3.0] - 2019-10-18
+## \[0.3.0] - 2019-10-18
 
 ### Changed
 
@@ -507,7 +516,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   simplifying code greatly.
   https://github.com/thefrontside/effection.js/pull/13
 
-## [0.2.0] - 2019-10-17
+## \[0.2.0] - 2019-10-17
 
 ### Added
 
@@ -516,7 +525,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   up-to-date typing information for its entire public API
   https://github.com/thefrontside/effection.js/pull/8
 
-## [0.1.0] - 2019-10-05
+## \[0.1.0] - 2019-10-05
 
 ### Added
 

--- a/packages/effection/package.json
+++ b/packages/effection/package.json
@@ -1,6 +1,6 @@
 {
   "name": "effection",
-  "version": "2.0.0-beta.4",
+  "version": "2.0.0-beta.5",
   "description": "Effortlessly composable structured concurrency primitive for JavaScript",
   "homepage": "https://github.com/thefrontside/effection",
   "repository": {
@@ -27,11 +27,11 @@
     "prepack": "tsdx build --tsconfig tsconfig.dist.json"
   },
   "dependencies": {
-    "@effection/channel": "2.0.0-beta.4",
-    "@effection/core": "2.0.0-beta.4",
-    "@effection/events": "2.0.0-beta.4",
-    "@effection/main": "2.0.0-beta.4",
-    "@effection/subscription": "2.0.0-beta.4"
+    "@effection/channel": "2.0.0-beta.5",
+    "@effection/core": "2.1.0-beta.0",
+    "@effection/events": "2.0.0-beta.5",
+    "@effection/main": "2.0.0-beta.5",
+    "@effection/subscription": "2.0.0-beta.5"
   },
   "devDependencies": {
     "@types/mocha": "^7.0.2",

--- a/packages/events/CHANGELOG.md
+++ b/packages/events/CHANGELOG.md
@@ -1,10 +1,16 @@
 # Changelog
 
+## \[2.0.0-beta.5]
+
+- Deprecate Future#resolve in favour of Future#produce.
+  - Bumped due to a bump in @effection/core.
+  - [7b8ce8e](https://github.com/thefrontside/effection/commit/7b8ce8ef1d46ddf10806d51b3f0ed1ef14e8f9cd) Depreacte Future#resolve in favour of Future#produce ([#437](https://github.com/thefrontside/effection/pull/437)) on 2021-07-22
+
 ## 2.0.0-beta.4
 
 ### Patch Changes
 
-- Updated dependencies [e297c86]
+- Updated dependencies \[e297c86]
   - @effection/core@2.0.0-beta.4
   - @effection/subscription@2.0.0-beta.4
 
@@ -14,10 +20,10 @@
 
 - 3e77f29: - label events for visual inspection
   - label stream and queue operations
-- Updated dependencies [3e77f29]
-- Updated dependencies [5d95e6d]
-- Updated dependencies [9700b45]
-- Updated dependencies [9700b45]
+- Updated dependencies \[3e77f29]
+- Updated dependencies \[5d95e6d]
+- Updated dependencies \[9700b45]
+- Updated dependencies \[9700b45]
   - @effection/subscription@2.0.0-beta.3
   - @effection/core@2.0.0-beta.3
 
@@ -25,11 +31,11 @@
 
 ### Patch Changes
 
-- Updated dependencies [19414f0]
-- Updated dependencies [26a86cb]
-- Updated dependencies [9c76cc5]
-- Updated dependencies [f7e3344]
-- Updated dependencies [ac7c1ce]
+- Updated dependencies \[19414f0]
+- Updated dependencies \[26a86cb]
+- Updated dependencies \[9c76cc5]
+- Updated dependencies \[f7e3344]
+- Updated dependencies \[ac7c1ce]
   - @effection/core@2.0.0-beta.2
   - @effection/subscription@2.0.0-beta.2
 
@@ -38,7 +44,7 @@
 ### Patch Changes
 
 - 0c6e263: release 2.0.0-beta
-- Updated dependencies [0c6e263]
+- Updated dependencies \[0c6e263]
   - @effection/core@2.0.0-beta.1
   - @effection/subscription@2.0.0-beta.1
 
@@ -50,10 +56,10 @@
 
 ### Patch Changes
 
-- Updated dependencies [9998088]
-- Updated dependencies [2bce454]
-- Updated dependencies [1981b35]
-- Updated dependencies [88dc59a]
+- Updated dependencies \[9998088]
+- Updated dependencies \[2bce454]
+- Updated dependencies \[1981b35]
+- Updated dependencies \[88dc59a]
   - @effection/core@2.0.0-preview.12
   - @effection/subscription@2.0.0-preview.14
 
@@ -61,10 +67,10 @@
 
 ### Patch Changes
 
-- Updated dependencies [88eca21]
-- Updated dependencies [ae8d090]
-- Updated dependencies [8bb4514]
-- Updated dependencies [44c354d]
+- Updated dependencies \[88eca21]
+- Updated dependencies \[ae8d090]
+- Updated dependencies \[8bb4514]
+- Updated dependencies \[44c354d]
   - @effection/core@2.0.0-preview.11
   - @effection/subscription@2.0.0-preview.13
 
@@ -72,10 +78,10 @@
 
 ### Patch Changes
 
-- Updated dependencies [625b521]
-- Updated dependencies [a06c679]
-- Updated dependencies [4d04159]
-- Updated dependencies [625b521]
+- Updated dependencies \[625b521]
+- Updated dependencies \[a06c679]
+- Updated dependencies \[4d04159]
+- Updated dependencies \[625b521]
   - @effection/core@2.0.0-preview.10
   - @effection/subscription@2.0.0-preview.12
 
@@ -83,7 +89,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [92f921e]
+- Updated dependencies \[92f921e]
   - @effection/subscription@2.0.0-preview.11
 
 ## 2.0.0-preview.9
@@ -94,14 +100,14 @@
 
 ### Patch Changes
 
-- Updated dependencies [110a2cd]
-- Updated dependencies [e2545b2]
-- Updated dependencies [2b92370]
-- Updated dependencies [00562fd]
-- Updated dependencies [110a2cd]
-- Updated dependencies [110a2cd]
-- Updated dependencies [02446ad]
-- Updated dependencies [da86a9c]
+- Updated dependencies \[110a2cd]
+- Updated dependencies \[e2545b2]
+- Updated dependencies \[2b92370]
+- Updated dependencies \[00562fd]
+- Updated dependencies \[110a2cd]
+- Updated dependencies \[110a2cd]
+- Updated dependencies \[02446ad]
+- Updated dependencies \[da86a9c]
   - @effection/core@2.0.0-preview.9
   - @effection/subscription@2.0.0-preview.10
 
@@ -111,7 +117,7 @@
 
 - a13987f: make operation resolution an interface. Make operation iterators
   an operation.
-- Updated dependencies [a13987f]
+- Updated dependencies \[a13987f]
   - @effection/core@2.0.0-preview.8
   - @effection/subscription@2.0.0-preview.9
 
@@ -119,7 +125,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [2bad074]
+- Updated dependencies \[2bad074]
   - @effection/core@2.0.0-preview.7
   - @effection/subscription@2.0.0-preview.8
 
@@ -127,7 +133,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [3db7270]
+- Updated dependencies \[3db7270]
   - @effection/subscription@2.0.0-preview.7
 
 ## 2.0.0-preview.5
@@ -135,8 +141,8 @@
 ### Patch Changes
 
 - 1222756: Use strict dependency requirements for internal dependencies while in prerelease mode
-- Updated dependencies [0dca571]
-- Updated dependencies [1222756]
+- Updated dependencies \[0dca571]
+- Updated dependencies \[1222756]
   - @effection/subscription@2.0.0-preview.6
   - @effection/core@2.0.0-preview.6
 
@@ -152,11 +158,15 @@
   which accounts for 99.9% of the use cases. For the cases where all the
   arguments are required, use `onEmit()`.
 
-- Updated dependencies [7b6ba05]
-- Updated dependencies [ab41f6a]
-- Updated dependencies [ce76f15]
-- Updated dependencies [72f743c]
-- Updated dependencies [53661b7]
+- Updated dependencies \[7b6ba05]
+
+- Updated dependencies \[ab41f6a]
+
+- Updated dependencies \[ce76f15]
+
+- Updated dependencies \[72f743c]
+
+- Updated dependencies \[53661b7]
   - effection@2.0.0-preview.5
   - @effection/subscription@2.0.0-preview.4
 
@@ -168,11 +178,11 @@
 
 ### Patch Changes
 
-- Updated dependencies [3ca4cd4]
-- Updated dependencies [3ca4cd4]
-- Updated dependencies [3ca4cd4]
-- Updated dependencies [2bf5ef4]
-- Updated dependencies [3ca4cd4]
+- Updated dependencies \[3ca4cd4]
+- Updated dependencies \[3ca4cd4]
+- Updated dependencies \[3ca4cd4]
+- Updated dependencies \[2bf5ef4]
+- Updated dependencies \[3ca4cd4]
   - effection@2.0.0-preview.4
   - @effection/subscription@2.0.0-preview.3
 
@@ -181,7 +191,7 @@
 ### Patch Changes
 
 - 93ec0d6: Include CHANGELOGS and src with all packages
-- Updated dependencies [93ec0d6]
+- Updated dependencies \[93ec0d6]
   - effection@2.0.0-preview.3
   - @effection/subscription@2.0.0-preview.2
 
@@ -190,7 +200,7 @@
 ### Patch Changes
 
 - 80143d5: Fix packaging
-- Updated dependencies [80143d5]
+- Updated dependencies \[80143d5]
   - effection@2.0.0-preview.2
   - @effection/subscription@2.0.0-preview.1
 
@@ -202,7 +212,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [undefined]
+- Updated dependencies \[undefined]
   - effection@2.0.0-preview.0
   - @effection/subscription@2.0.0-preview.0
 
@@ -214,7 +224,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [b988025]
+- Updated dependencies \[b988025]
   - effection@1.0.0
   - @effection/subscription@1.0.0
 
@@ -222,8 +232,8 @@
 
 ### Patch Changes
 
-- Updated dependencies [f851981]
-- Updated dependencies [d3d3b64]
+- Updated dependencies \[f851981]
+- Updated dependencies \[d3d3b64]
   - effection@0.8.0
   - @effection/subscription@0.12.0
 
@@ -232,28 +242,28 @@
 ### Patch Changes
 
 - 25b68eb: Subscriptions created via `createSubscription` are chainable on both sides of the yield
-- Updated dependencies [25b68eb]
+- Updated dependencies \[25b68eb]
   - @effection/subscription@0.11.0
 
 ## 0.7.7
 
 ### Patch Changes
 
-- Updated dependencies [5d118ee]
+- Updated dependencies \[5d118ee]
   - @effection/subscription@0.10.0
 
 ## 0.7.6
 
 ### Patch Changes
 
-- Updated dependencies [786b20e]
+- Updated dependencies \[786b20e]
   - @effection/subscription@0.9.0
 
 ## 0.7.5
 
 ### Patch Changes
 
-- Updated dependencies [8303e92]
+- Updated dependencies \[8303e92]
   - @effection/subscription@0.8.0
 
 ## 0.7.4
@@ -264,8 +274,8 @@
 - 3688203: Only require EventTarget-like objects for the `on()` method to
   implement the `addEventListener` and `removeEventlistener` functions,
   not `dispatchEvent`
-- Updated dependencies [db11b3f]
-- Updated dependencies [0e8951f]
+- Updated dependencies \[db11b3f]
+- Updated dependencies \[0e8951f]
   - @effection/subscription@0.7.2
   - effection@0.7.0
 
@@ -274,7 +284,7 @@
 ### Patch Changes
 
 - 68c4dab: include typescript sources with package in order for sourcemaps to work.
-- Updated dependencies [68c4dab]
+- Updated dependencies \[68c4dab]
   - effection@0.6.4
   - @effection/subscription@0.7.1
 
@@ -282,8 +292,8 @@
 
 ### Patch Changes
 
-- Updated dependencies [ad0d7e2]
-- Updated dependencies [3336949]
+- Updated dependencies \[ad0d7e2]
+- Updated dependencies \[3336949]
   - @effection/subscription@0.7.0
 
 ## 0.7.1
@@ -318,7 +328,7 @@
 
   https://github.com/thefrontside/effection/pull/120
 
-- Updated dependencies [60ed704]
+- Updated dependencies \[60ed704]
   - effection@0.6.3
 
 All notable changes to this project will be documented in this file.
@@ -326,9 +336,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## \[Unreleased]
 
-## [0.6.1] - 2020-04-29
+## \[0.6.1] - 2020-04-29
 
 ## Changed
 

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/events",
-  "version": "2.0.0-beta.4",
+  "version": "2.0.0-beta.5",
   "description": "Helpers for listening to events with effection",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -27,8 +27,8 @@
     "mocha": "mocha -r ts-node/register"
   },
   "dependencies": {
-    "@effection/core": "2.0.0-beta.4",
-    "@effection/subscription": "2.0.0-beta.4"
+    "@effection/core": "2.1.0-beta.0",
+    "@effection/subscription": "2.0.0-beta.5"
   },
   "devDependencies": {
     "@effection/mocha": "2.0.0-beta.4",

--- a/packages/fetch/CHANGELOG.md
+++ b/packages/fetch/CHANGELOG.md
@@ -1,29 +1,35 @@
 # @effection/fetch
 
+## \[2.0.0-beta.5]
+
+- Deprecate Future#resolve in favour of Future#produce.
+  - Bumped due to a bump in @effection/core.
+  - [7b8ce8e](https://github.com/thefrontside/effection/commit/7b8ce8ef1d46ddf10806d51b3f0ed1ef14e8f9cd) Depreacte Future#resolve in favour of Future#produce ([#437](https://github.com/thefrontside/effection/pull/437)) on 2021-07-22
+
 ## 2.0.0-beta.4
 
 ### Patch Changes
 
-- Updated dependencies [e297c86]
+- Updated dependencies \[e297c86]
   - @effection/core@2.0.0-beta.4
 
 ## 2.0.0-beta.3
 
 ### Patch Changes
 
-- Updated dependencies [5d95e6d]
-- Updated dependencies [9700b45]
+- Updated dependencies \[5d95e6d]
+- Updated dependencies \[9700b45]
   - @effection/core@2.0.0-beta.3
 
 ## 2.0.0-beta.2
 
 ### Patch Changes
 
-- Updated dependencies [19414f0]
-- Updated dependencies [26a86cb]
-- Updated dependencies [9c76cc5]
-- Updated dependencies [f7e3344]
-- Updated dependencies [ac7c1ce]
+- Updated dependencies \[19414f0]
+- Updated dependencies \[26a86cb]
+- Updated dependencies \[9c76cc5]
+- Updated dependencies \[f7e3344]
+- Updated dependencies \[ac7c1ce]
   - @effection/core@2.0.0-beta.2
 
 ## 2.0.0-beta.1
@@ -31,51 +37,51 @@
 ### Patch Changes
 
 - 0c6e263: release 2.0.0-beta
-- Updated dependencies [0c6e263]
+- Updated dependencies \[0c6e263]
   - @effection/core@2.0.0-beta.1
 
 ## 2.0.0-preview.11
 
 ### Patch Changes
 
-- Updated dependencies [9998088]
-- Updated dependencies [2bce454]
-- Updated dependencies [1981b35]
-- Updated dependencies [88dc59a]
+- Updated dependencies \[9998088]
+- Updated dependencies \[2bce454]
+- Updated dependencies \[1981b35]
+- Updated dependencies \[88dc59a]
   - @effection/core@2.0.0-preview.12
 
 ## 2.0.0-preview.10
 
 ### Patch Changes
 
-- Updated dependencies [88eca21]
-- Updated dependencies [ae8d090]
-- Updated dependencies [8bb4514]
-- Updated dependencies [44c354d]
+- Updated dependencies \[88eca21]
+- Updated dependencies \[ae8d090]
+- Updated dependencies \[8bb4514]
+- Updated dependencies \[44c354d]
   - @effection/core@2.0.0-preview.11
 
 ## 2.0.0-preview.9
 
 ### Patch Changes
 
-- Updated dependencies [625b521]
-- Updated dependencies [a06c679]
-- Updated dependencies [4d04159]
-- Updated dependencies [625b521]
+- Updated dependencies \[625b521]
+- Updated dependencies \[a06c679]
+- Updated dependencies \[4d04159]
+- Updated dependencies \[625b521]
   - @effection/core@2.0.0-preview.10
 
 ## 2.0.0-preview.8
 
 ### Patch Changes
 
-- Updated dependencies [110a2cd]
-- Updated dependencies [e2545b2]
-- Updated dependencies [2b92370]
-- Updated dependencies [00562fd]
-- Updated dependencies [110a2cd]
-- Updated dependencies [110a2cd]
-- Updated dependencies [02446ad]
-- Updated dependencies [da86a9c]
+- Updated dependencies \[110a2cd]
+- Updated dependencies \[e2545b2]
+- Updated dependencies \[2b92370]
+- Updated dependencies \[00562fd]
+- Updated dependencies \[110a2cd]
+- Updated dependencies \[110a2cd]
+- Updated dependencies \[02446ad]
+- Updated dependencies \[da86a9c]
   - @effection/core@2.0.0-preview.9
 
 ## 2.0.0-preview.7
@@ -84,14 +90,14 @@
 
 - a13987f: make operation resolution an interface. Make operation iterators
   an operation.
-- Updated dependencies [a13987f]
+- Updated dependencies \[a13987f]
   - @effection/core@2.0.0-preview.8
 
 ## 2.0.0-preview.6
 
 ### Patch Changes
 
-- Updated dependencies [2bad074]
+- Updated dependencies \[2bad074]
   - @effection/core@2.0.0-preview.7
 
 ## 2.0.0-preview.5
@@ -99,7 +105,7 @@
 ### Patch Changes
 
 - 1222756: Use strict dependency requirements for internal dependencies while in prerelease mode
-- Updated dependencies [1222756]
+- Updated dependencies \[1222756]
   - @effection/core@2.0.0-preview.6
 
 ## 2.0.0-preview.4
@@ -113,7 +119,7 @@
 ### Patch Changes
 
 - 93ec0d6: Include CHANGELOGS and src with all packages
-- Updated dependencies [93ec0d6]
+- Updated dependencies \[93ec0d6]
   - @effection/core@2.0.0-preview.2
 
 ## 2.0.0-preview.1
@@ -121,7 +127,7 @@
 ### Patch Changes
 
 - 80143d5: Fix packaging
-- Updated dependencies [80143d5]
+- Updated dependencies \[80143d5]
   - @effection/core@2.0.0-preview.1
 
 ## 2.0.0-preview.0
@@ -132,7 +138,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [undefined]
+- Updated dependencies \[undefined]
   - effection@2.0.0-preview.0
 
 ## 1.0.0
@@ -143,14 +149,14 @@
 
 ### Patch Changes
 
-- Updated dependencies [b988025]
+- Updated dependencies \[b988025]
   - effection@1.0.0
 
 ## 0.1.3
 
 ### Patch Changes
 
-- Updated dependencies [f851981]
+- Updated dependencies \[f851981]
   - effection@0.8.0
 
 ## 0.1.2
@@ -165,7 +171,7 @@
 ### Patch Changes
 
 - db11b3f: convert `effection` dependency into normal, non-peer dependency
-- Updated dependencies [0e8951f]
+- Updated dependencies \[0e8951f]
   - effection@0.7.0
 
 ## 0.1.0
@@ -176,5 +182,5 @@
 
 ### Patch Changes
 
-- Updated dependencies [68c4dab]
+- Updated dependencies \[68c4dab]
   - effection@0.6.4

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/fetch",
-  "version": "2.0.0-beta.4",
+  "version": "2.0.0-beta.5",
   "description": "Fetch operation for Effection",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -37,7 +37,7 @@
     "typescript": "^3.9.5"
   },
   "dependencies": {
-    "@effection/core": "2.0.0-beta.4",
+    "@effection/core": "2.1.0-beta.0",
     "abort-controller": "^3.0.0",
     "cross-fetch": "^3.0.4",
     "node-fetch": "^2.6.1"

--- a/packages/inspect-server/CHANGELOG.md
+++ b/packages/inspect-server/CHANGELOG.md
@@ -1,10 +1,16 @@
 # @effection/inspect-server
 
+## \[2.0.0-beta.6]
+
+- Deprecate Future#resolve in favour of Future#produce.
+  - Bumped due to a bump in @effection/core.
+  - [7b8ce8e](https://github.com/thefrontside/effection/commit/7b8ce8ef1d46ddf10806d51b3f0ed1ef14e8f9cd) Depreacte Future#resolve in favour of Future#produce ([#437](https://github.com/thefrontside/effection/pull/437)) on 2021-07-22
+
 ## 2.0.0-beta.5
 
 ### Patch Changes
 
-- Updated dependencies [e297c86]
+- Updated dependencies \[e297c86]
   - @effection/core@2.0.0-beta.4
   - @effection/atom@2.0.0-beta.4
   - @effection/channel@2.0.0-beta.4
@@ -18,10 +24,10 @@
 
 ### Patch Changes
 
-- Updated dependencies [3e77f29]
-- Updated dependencies [5d95e6d]
-- Updated dependencies [9700b45]
-- Updated dependencies [9700b45]
+- Updated dependencies \[3e77f29]
+- Updated dependencies \[5d95e6d]
+- Updated dependencies \[9700b45]
+- Updated dependencies \[9700b45]
   - @effection/subscription@2.0.0-beta.3
   - @effection/events@2.0.0-beta.3
   - @effection/core@2.0.0-beta.3
@@ -42,11 +48,11 @@
 
 ### Patch Changes
 
-- Updated dependencies [19414f0]
-- Updated dependencies [26a86cb]
-- Updated dependencies [9c76cc5]
-- Updated dependencies [f7e3344]
-- Updated dependencies [ac7c1ce]
+- Updated dependencies \[19414f0]
+- Updated dependencies \[26a86cb]
+- Updated dependencies \[9c76cc5]
+- Updated dependencies \[f7e3344]
+- Updated dependencies \[ac7c1ce]
   - @effection/core@2.0.0-beta.2
   - @effection/atom@2.0.0-beta.2
   - @effection/channel@2.0.0-beta.2

--- a/packages/inspect-server/package.json
+++ b/packages/inspect-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/inspect-server",
-  "version": "2.0.0-beta.5",
+  "version": "2.0.0-beta.6",
   "description": "Inspect server for inspecting effection processes",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -28,14 +28,14 @@
     "examples:basic": "ts-node ./examples/basic.ts"
   },
   "dependencies": {
-    "@effection/atom": "2.0.0-beta.4",
-    "@effection/channel": "2.0.0-beta.4",
-    "@effection/core": "2.0.0-beta.4",
-    "@effection/inspect-ui": "2.0.0-beta.4",
-    "@effection/inspect-utils": "2.0.0-beta.4",
-    "@effection/events": "2.0.0-beta.4",
-    "@effection/subscription": "2.0.0-beta.4",
-    "@effection/websocket-server": "2.0.0-beta.5",
+    "@effection/atom": "2.0.0-beta.5",
+    "@effection/channel": "2.0.0-beta.5",
+    "@effection/core": "2.1.0-beta.0",
+    "@effection/inspect-ui": "2.0.0-beta.5",
+    "@effection/inspect-utils": "2.0.0-beta.5",
+    "@effection/events": "2.0.0-beta.5",
+    "@effection/subscription": "2.0.0-beta.5",
+    "@effection/websocket-server": "2.0.0-beta.6",
     "node-static": "^0.7.11",
     "websocket": "^1.0.34"
   },

--- a/packages/inspect-ui/CHANGELOG.md
+++ b/packages/inspect-ui/CHANGELOG.md
@@ -1,10 +1,16 @@
 # @effection/inspect-ui
 
+## \[2.0.0-beta.5]
+
+- Deprecate Future#resolve in favour of Future#produce.
+  - Bumped due to a bump in @effection/core.
+  - [7b8ce8e](https://github.com/thefrontside/effection/commit/7b8ce8ef1d46ddf10806d51b3f0ed1ef14e8f9cd) Depreacte Future#resolve in favour of Future#produce ([#437](https://github.com/thefrontside/effection/pull/437)) on 2021-07-22
+
 ## 2.0.0-beta.4
 
 ### Patch Changes
 
-- Updated dependencies [e297c86]
+- Updated dependencies \[e297c86]
   - @effection/core@2.0.0-beta.4
   - @effection/events@2.0.0-beta.4
   - @effection/inspect-utils@2.0.0-beta.4
@@ -15,11 +21,11 @@
 
 ### Patch Changes
 
-- Updated dependencies [248b0a6]
-- Updated dependencies [3e77f29]
-- Updated dependencies [5d95e6d]
-- Updated dependencies [9700b45]
-- Updated dependencies [9700b45]
+- Updated dependencies \[248b0a6]
+- Updated dependencies \[3e77f29]
+- Updated dependencies \[5d95e6d]
+- Updated dependencies \[9700b45]
+- Updated dependencies \[9700b45]
   - @effection/main@2.0.0-beta.3
   - @effection/subscription@2.0.0-beta.3
   - @effection/events@2.0.0-beta.3
@@ -30,11 +36,11 @@
 
 ### Patch Changes
 
-- Updated dependencies [19414f0]
-- Updated dependencies [26a86cb]
-- Updated dependencies [9c76cc5]
-- Updated dependencies [f7e3344]
-- Updated dependencies [ac7c1ce]
+- Updated dependencies \[19414f0]
+- Updated dependencies \[26a86cb]
+- Updated dependencies \[9c76cc5]
+- Updated dependencies \[f7e3344]
+- Updated dependencies \[ac7c1ce]
   - @effection/core@2.0.0-beta.2
   - @effection/events@2.0.0-beta.2
   - @effection/inspect-utils@2.0.0-beta.2

--- a/packages/inspect-ui/package.json
+++ b/packages/inspect-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/inspect-ui",
-  "version": "2.0.0-beta.4",
+  "version": "2.0.0-beta.5",
   "description": "Web interface for inspecting effection applications",
   "main": "index.js",
   "types": "index.d.ts",
@@ -30,11 +30,11 @@
     "mocha": "mocha -r ts-node/register --timeout 5000"
   },
   "dependencies": {
-    "@effection/core": "2.0.0-beta.4",
-    "@effection/inspect-utils": "2.0.0-beta.4",
-    "@effection/events": "2.0.0-beta.4",
-    "@effection/main": "2.0.0-beta.4",
-    "@effection/subscription": "2.0.0-beta.4",
+    "@effection/core": "2.1.0-beta.0",
+    "@effection/inspect-utils": "2.0.0-beta.5",
+    "@effection/events": "2.0.0-beta.5",
+    "@effection/main": "2.0.0-beta.5",
+    "@effection/subscription": "2.0.0-beta.5",
     "@types/react": "^17.0.9",
     "@types/react-dom": "^17.0.6",
     "react": "^17.0.2",

--- a/packages/inspect-utils/CHANGELOG.md
+++ b/packages/inspect-utils/CHANGELOG.md
@@ -1,10 +1,16 @@
 # @effection/inspect-utils
 
+## \[2.0.0-beta.5]
+
+- Deprecate Future#resolve in favour of Future#produce.
+  - Bumped due to a bump in @effection/core.
+  - [7b8ce8e](https://github.com/thefrontside/effection/commit/7b8ce8ef1d46ddf10806d51b3f0ed1ef14e8f9cd) Depreacte Future#resolve in favour of Future#produce ([#437](https://github.com/thefrontside/effection/pull/437)) on 2021-07-22
+
 ## 2.0.0-beta.4
 
 ### Patch Changes
 
-- Updated dependencies [e297c86]
+- Updated dependencies \[e297c86]
   - @effection/core@2.0.0-beta.4
   - @effection/atom@2.0.0-beta.4
   - @effection/channel@2.0.0-beta.4
@@ -15,10 +21,10 @@
 
 ### Patch Changes
 
-- Updated dependencies [3e77f29]
-- Updated dependencies [5d95e6d]
-- Updated dependencies [9700b45]
-- Updated dependencies [9700b45]
+- Updated dependencies \[3e77f29]
+- Updated dependencies \[5d95e6d]
+- Updated dependencies \[9700b45]
+- Updated dependencies \[9700b45]
   - @effection/subscription@2.0.0-beta.3
   - @effection/events@2.0.0-beta.3
   - @effection/core@2.0.0-beta.3
@@ -29,11 +35,11 @@
 
 ### Patch Changes
 
-- Updated dependencies [19414f0]
-- Updated dependencies [26a86cb]
-- Updated dependencies [9c76cc5]
-- Updated dependencies [f7e3344]
-- Updated dependencies [ac7c1ce]
+- Updated dependencies \[19414f0]
+- Updated dependencies \[26a86cb]
+- Updated dependencies \[9c76cc5]
+- Updated dependencies \[f7e3344]
+- Updated dependencies \[ac7c1ce]
   - @effection/core@2.0.0-beta.2
   - @effection/atom@2.0.0-beta.2
   - @effection/channel@2.0.0-beta.2

--- a/packages/inspect-utils/package.json
+++ b/packages/inspect-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/inspect-utils",
-  "version": "2.0.0-beta.4",
+  "version": "2.0.0-beta.5",
   "description": "Helper functions and types for inspecting effection applications",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -27,11 +27,11 @@
     "mocha": "mocha -r ts-node/register"
   },
   "dependencies": {
-    "@effection/atom": "2.0.0-beta.4",
-    "@effection/channel": "2.0.0-beta.4",
-    "@effection/core": "2.0.0-beta.4",
-    "@effection/events": "2.0.0-beta.4",
-    "@effection/subscription": "2.0.0-beta.4"
+    "@effection/atom": "2.0.0-beta.5",
+    "@effection/channel": "2.0.0-beta.5",
+    "@effection/core": "2.1.0-beta.0",
+    "@effection/events": "2.0.0-beta.5",
+    "@effection/subscription": "2.0.0-beta.5"
   },
   "devDependencies": {
     "@effection/mocha": "2.0.0-beta.4",

--- a/packages/inspect/CHANGELOG.md
+++ b/packages/inspect/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @effection/inspect
 
+## \[2.0.0-beta.6]
+
+- Deprecate Future#resolve in favour of Future#produce.
+  - Bumped due to a bump in @effection/inspect-server.
+  - [7b8ce8e](https://github.com/thefrontside/effection/commit/7b8ce8ef1d46ddf10806d51b3f0ed1ef14e8f9cd) Depreacte Future#resolve in favour of Future#produce ([#437](https://github.com/thefrontside/effection/pull/437)) on 2021-07-22
+
 ## 2.0.0-beta.5
 
 ### Patch Changes
@@ -16,7 +22,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [41aa4a2]
+- Updated dependencies \[41aa4a2]
   - @effection/inspect-server@2.0.0-beta.3
 
 ## 2.0.0-beta.2

--- a/packages/inspect/package.json
+++ b/packages/inspect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/inspect",
-  "version": "2.0.0-beta.5",
+  "version": "2.0.0-beta.6",
   "description": "Injects an inspector into an Effection application",
   "main": "index.js",
   "homepage": "https://github.com/thefrontside/effection",
@@ -24,7 +24,7 @@
     "docs": "echo noop"
   },
   "dependencies": {
-    "@effection/inspect-server": "2.0.0-beta.5"
+    "@effection/inspect-server": "2.0.0-beta.6"
   },
   "volta": {
     "node": "12.16.0",

--- a/packages/main/CHANGELOG.md
+++ b/packages/main/CHANGELOG.md
@@ -1,10 +1,16 @@
 # @effection/main
 
+## \[2.0.0-beta.5]
+
+- Deprecate Future#resolve in favour of Future#produce.
+  - Bumped due to a bump in @effection/core.
+  - [7b8ce8e](https://github.com/thefrontside/effection/commit/7b8ce8ef1d46ddf10806d51b3f0ed1ef14e8f9cd) Depreacte Future#resolve in favour of Future#produce ([#437](https://github.com/thefrontside/effection/pull/437)) on 2021-07-22
+
 ## 2.0.0-beta.4
 
 ### Patch Changes
 
-- Updated dependencies [e297c86]
+- Updated dependencies \[e297c86]
   - @effection/core@2.0.0-beta.4
 
 ## 2.0.0-beta.3
@@ -12,19 +18,19 @@
 ### Patch Changes
 
 - 248b0a6: label the main entry point for use in the debugger
-- Updated dependencies [5d95e6d]
-- Updated dependencies [9700b45]
+- Updated dependencies \[5d95e6d]
+- Updated dependencies \[9700b45]
   - @effection/core@2.0.0-beta.3
 
 ## 2.0.0-beta.2
 
 ### Patch Changes
 
-- Updated dependencies [19414f0]
-- Updated dependencies [26a86cb]
-- Updated dependencies [9c76cc5]
-- Updated dependencies [f7e3344]
-- Updated dependencies [ac7c1ce]
+- Updated dependencies \[19414f0]
+- Updated dependencies \[26a86cb]
+- Updated dependencies \[9c76cc5]
+- Updated dependencies \[f7e3344]
+- Updated dependencies \[ac7c1ce]
   - @effection/core@2.0.0-beta.2
 
 ## 2.0.0-beta.1
@@ -32,7 +38,7 @@
 ### Patch Changes
 
 - 0c6e263: release 2.0.0-beta
-- Updated dependencies [0c6e263]
+- Updated dependencies \[0c6e263]
   - @effection/core@2.0.0-beta.1
 
 ## 2.0.0-preview.3
@@ -44,18 +50,18 @@
 
 ### Patch Changes
 
-- Updated dependencies [9998088]
-- Updated dependencies [2bce454]
-- Updated dependencies [1981b35]
-- Updated dependencies [88dc59a]
+- Updated dependencies \[9998088]
+- Updated dependencies \[2bce454]
+- Updated dependencies \[1981b35]
+- Updated dependencies \[88dc59a]
   - @effection/core@2.0.0-preview.12
 
 ## 2.0.0-preview.2
 
 ### Patch Changes
 
-- Updated dependencies [88eca21]
-- Updated dependencies [ae8d090]
-- Updated dependencies [8bb4514]
-- Updated dependencies [44c354d]
+- Updated dependencies \[88eca21]
+- Updated dependencies \[ae8d090]
+- Updated dependencies \[8bb4514]
+- Updated dependencies \[44c354d]
   - @effection/core@2.0.0-preview.11

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/main",
-  "version": "2.0.0-beta.4",
+  "version": "2.0.0-beta.5",
   "description": "Main entry point for Effection applications",
   "main": "dist/node.js",
   "browser": "dist/browser.js",
@@ -26,13 +26,13 @@
     "mocha": "mocha -r ts-node/register"
   },
   "dependencies": {
-    "@effection/core": "2.0.0-beta.4",
+    "@effection/core": "2.1.0-beta.0",
     "chalk": "^4.1.1",
     "stacktrace-parser": "^0.1.10"
   },
   "devDependencies": {
     "@effection/mocha": "2.0.0-beta.4",
-    "@effection/process": "2.0.0-beta.4",
+    "@effection/process": "2.0.0-beta.5",
     "@frontside/tsconfig": "^1.2.0",
     "@types/node": "^13.13.5",
     "expect": "^25.4.0",

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## \[2.0.0-beta.5]
+
+- Deprecate Future#resolve in favour of Future#produce.
+  - Bumped due to a bump in @effection/main.
+  - [7b8ce8e](https://github.com/thefrontside/effection/commit/7b8ce8ef1d46ddf10806d51b3f0ed1ef14e8f9cd) Depreacte Future#resolve in favour of Future#produce ([#437](https://github.com/thefrontside/effection/pull/437)) on 2021-07-22
+
 ## 2.0.0-beta.4
 
 ### Patch Changes
@@ -11,7 +17,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [248b0a6]
+- Updated dependencies \[248b0a6]
   - @effection/main@2.0.0-beta.3
   - @effection/process@2.0.0-beta.3
 
@@ -27,7 +33,7 @@
 ### Patch Changes
 
 - 0c6e263: release 2.0.0-beta
-- Updated dependencies [0c6e263]
+- Updated dependencies \[0c6e263]
   - @effection/main@2.0.0-beta.1
   - @effection/process@2.0.0-beta.1
 
@@ -35,11 +41,11 @@
 
 ### Patch Changes
 
-- Updated dependencies [9998088]
-- Updated dependencies [d7c0eb1]
-- Updated dependencies [2bce454]
-- Updated dependencies [1981b35]
-- Updated dependencies [88dc59a]
+- Updated dependencies \[9998088]
+- Updated dependencies \[d7c0eb1]
+- Updated dependencies \[2bce454]
+- Updated dependencies \[1981b35]
+- Updated dependencies \[88dc59a]
   - @effection/core@2.0.0-preview.12
   - @effection/events@2.0.0-preview.13
   - @effection/channel@2.0.0-preview.15
@@ -54,10 +60,10 @@
 ### Patch Changes
 
 - 9cfb809: Upgrade ctrlc-windows to 2.0.0
-- Updated dependencies [88eca21]
-- Updated dependencies [ae8d090]
-- Updated dependencies [8bb4514]
-- Updated dependencies [44c354d]
+- Updated dependencies \[88eca21]
+- Updated dependencies \[ae8d090]
+- Updated dependencies \[8bb4514]
+- Updated dependencies \[44c354d]
   - @effection/core@2.0.0-preview.11
   - @effection/channel@2.0.0-preview.14
   - @effection/events@2.0.0-preview.12
@@ -67,10 +73,10 @@
 
 ### Patch Changes
 
-- Updated dependencies [625b521]
-- Updated dependencies [a06c679]
-- Updated dependencies [4d04159]
-- Updated dependencies [625b521]
+- Updated dependencies \[625b521]
+- Updated dependencies \[a06c679]
+- Updated dependencies \[4d04159]
+- Updated dependencies \[625b521]
   - @effection/core@2.0.0-preview.10
   - @effection/channel@2.0.0-preview.13
   - @effection/events@2.0.0-preview.11
@@ -84,7 +90,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [92f921e]
+- Updated dependencies \[92f921e]
   - @effection/subscription@2.0.0-preview.11
   - @effection/channel@2.0.0-preview.12
   - @effection/events@2.0.0-preview.10
@@ -93,15 +99,15 @@
 
 ### Patch Changes
 
-- Updated dependencies [110a2cd]
-- Updated dependencies [7216a21]
-- Updated dependencies [e2545b2]
-- Updated dependencies [2b92370]
-- Updated dependencies [00562fd]
-- Updated dependencies [110a2cd]
-- Updated dependencies [110a2cd]
-- Updated dependencies [02446ad]
-- Updated dependencies [da86a9c]
+- Updated dependencies \[110a2cd]
+- Updated dependencies \[7216a21]
+- Updated dependencies \[e2545b2]
+- Updated dependencies \[2b92370]
+- Updated dependencies \[00562fd]
+- Updated dependencies \[110a2cd]
+- Updated dependencies \[110a2cd]
+- Updated dependencies \[02446ad]
+- Updated dependencies \[da86a9c]
   - @effection/core@2.0.0-preview.9
   - @effection/events@2.0.0-preview.9
   - @effection/channel@2.0.0-preview.11
@@ -112,7 +118,7 @@
 ### Patch Changes
 
 - dbaed3a: Disable command parsing when exec({ shell: true }). This allows complex commands that involve pipes and redirects to work
-- Updated dependencies [a13987f]
+- Updated dependencies \[a13987f]
   - @effection/core@2.0.0-preview.8
   - @effection/subscription@2.0.0-preview.9
   - @effection/events@2.0.0-preview.8
@@ -122,14 +128,14 @@
 
 ### Patch Changes
 
-- Updated dependencies [91ade6c]
+- Updated dependencies \[91ade6c]
   - @effection/channel@2.0.0-preview.9
 
 ## 2.0.0-preview.9
 
 ### Patch Changes
 
-- Updated dependencies [2bad074]
+- Updated dependencies \[2bad074]
   - @effection/core@2.0.0-preview.7
   - @effection/channel@2.0.0-preview.8
   - @effection/events@2.0.0-preview.7
@@ -139,7 +145,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [3db7270]
+- Updated dependencies \[3db7270]
   - @effection/subscription@2.0.0-preview.7
   - @effection/channel@2.0.0-preview.7
   - @effection/events@2.0.0-preview.6
@@ -149,8 +155,8 @@
 ### Patch Changes
 
 - 1222756: Use strict dependency requirements for internal dependencies while in prerelease mode
-- Updated dependencies [0dca571]
-- Updated dependencies [1222756]
+- Updated dependencies \[0dca571]
+- Updated dependencies \[1222756]
   - @effection/subscription@2.0.0-preview.6
   - @effection/channel@2.0.0-preview.6
   - @effection/events@2.0.0-preview.5
@@ -164,12 +170,12 @@
 
 ### Patch Changes
 
-- Updated dependencies [9cf6053]
-- Updated dependencies [0b24415]
-- Updated dependencies [22e5230]
-- Updated dependencies [70c358f]
-- Updated dependencies [3983202]
-- Updated dependencies [2c2749d]
+- Updated dependencies \[9cf6053]
+- Updated dependencies \[0b24415]
+- Updated dependencies \[22e5230]
+- Updated dependencies \[70c358f]
+- Updated dependencies \[3983202]
+- Updated dependencies \[2c2749d]
   - @effection/channel@2.0.0-preview.5
   - @effection/subscription@2.0.0-preview.5
   - @effection/core@2.0.0-preview.5
@@ -186,13 +192,13 @@
 
 - 4703d0b: Upgrade ctrlc-windows to 1.0.3
 - 3ca4cd4: Use new channel and subscription interfaces internally
-- Updated dependencies [3ca4cd4]
-- Updated dependencies [3ca4cd4]
-- Updated dependencies [3ca4cd4]
-- Updated dependencies [bdedf68]
-- Updated dependencies [2bf5ef4]
-- Updated dependencies [3ca4cd4]
-- Updated dependencies [3ca4cd4]
+- Updated dependencies \[3ca4cd4]
+- Updated dependencies \[3ca4cd4]
+- Updated dependencies \[3ca4cd4]
+- Updated dependencies \[bdedf68]
+- Updated dependencies \[2bf5ef4]
+- Updated dependencies \[3ca4cd4]
+- Updated dependencies \[3ca4cd4]
   - @effection/events@2.0.0-preview.3
   - @effection/subscription@2.0.0-preview.3
   - @effection/channel@2.0.0-preview.3
@@ -203,7 +209,7 @@
 ### Patch Changes
 
 - 93ec0d6: Include CHANGELOGS and src with all packages
-- Updated dependencies [93ec0d6]
+- Updated dependencies \[93ec0d6]
   - @effection/channel@2.0.0-preview.2
   - @effection/core@2.0.0-preview.2
   - @effection/events@2.0.0-preview.2
@@ -214,7 +220,7 @@
 ### Patch Changes
 
 - 80143d5: Fix packaging
-- Updated dependencies [80143d5]
+- Updated dependencies \[80143d5]
   - @effection/channel@2.0.0-preview.1
   - @effection/core@2.0.0-preview.1
   - @effection/events@2.0.0-preview.1
@@ -228,7 +234,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [undefined]
+- Updated dependencies \[undefined]
   - @effection/channel@2.0.0-preview.0
   - effection@2.0.0-preview.0
   - @effection/events@2.0.0-preview.0
@@ -242,7 +248,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [b988025]
+- Updated dependencies \[b988025]
   - @effection/channel@1.0.0
   - effection@1.0.0
   - @effection/events@1.0.0
@@ -253,8 +259,8 @@
 ### Patch Changes
 
 - 9ce3ab7: Bump ctrlc-windows on node to skip building on non-windows
-- Updated dependencies [f851981]
-- Updated dependencies [d3d3b64]
+- Updated dependencies \[f851981]
+- Updated dependencies \[d3d3b64]
   - effection@0.8.0
   - @effection/subscription@0.12.0
   - @effection/channel@0.6.8
@@ -287,7 +293,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [649ec8d]
+- Updated dependencies \[649ec8d]
   - @effection/subscription@0.11.1
 
 ## 0.8.0
@@ -307,9 +313,9 @@
 ### Patch Changes
 
 - db11b3f: convert `effection` dependency into normal, non-peer dependency
-- Updated dependencies [db11b3f]
-- Updated dependencies [3688203]
-- Updated dependencies [0e8951f]
+- Updated dependencies \[db11b3f]
+- Updated dependencies \[3688203]
+- Updated dependencies \[0e8951f]
   - @effection/events@0.7.4
   - effection@0.7.0
 
@@ -318,7 +324,7 @@
 ### Patch Changes
 
 - 68c4dab: include typescript sources with package in order for sourcemaps to work.
-- Updated dependencies [68c4dab]
+- Updated dependencies \[68c4dab]
   - effection@0.6.4
   - @effection/events@0.7.3
 
@@ -338,8 +344,9 @@
 
   https://github.com/thefrontside/effection/pull/120
 
-- Updated dependencies [70ac8e3]
-- Updated dependencies [60ed704]
+- Updated dependencies \[70ac8e3]
+
+- Updated dependencies \[60ed704]
   - @effection/events@0.7.0
   - effection@0.6.3
     All notable changes to this project will be documented in this file.
@@ -347,16 +354,16 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## \[Unreleased]
 
-## [0.6.2] - 2020-05-04
+## \[0.6.2] - 2020-05-04
 
 ### Changed
 
 - cancel main context upon SIGTERM
   https://github.com/thefrontside/effection/pull/116
 
-## [0.6.1] - 2020-04-29
+## \[0.6.1] - 2020-04-29
 
 ### Added
 

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/node",
-  "version": "2.0.0-beta.4",
+  "version": "2.0.0-beta.5",
   "description": "Work in Node.js with Effection",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -32,8 +32,8 @@
     "typescript": "^3.7.0"
   },
   "dependencies": {
-    "@effection/main": "2.0.0-beta.4",
-    "@effection/process": "2.0.0-beta.4"
+    "@effection/main": "2.0.0-beta.5",
+    "@effection/process": "2.0.0-beta.5"
   },
   "volta": {
     "node": "12.16.0",

--- a/packages/process/CHANGELOG.md
+++ b/packages/process/CHANGELOG.md
@@ -1,10 +1,16 @@
 # @effection/process
 
+## \[2.0.0-beta.5]
+
+- Deprecate Future#resolve in favour of Future#produce.
+  - Bumped due to a bump in @effection/core.
+  - [7b8ce8e](https://github.com/thefrontside/effection/commit/7b8ce8ef1d46ddf10806d51b3f0ed1ef14e8f9cd) Depreacte Future#resolve in favour of Future#produce ([#437](https://github.com/thefrontside/effection/pull/437)) on 2021-07-22
+
 ## 2.0.0-beta.4
 
 ### Patch Changes
 
-- Updated dependencies [e297c86]
+- Updated dependencies \[e297c86]
   - @effection/core@2.0.0-beta.4
   - @effection/channel@2.0.0-beta.4
   - @effection/events@2.0.0-beta.4
@@ -14,10 +20,10 @@
 
 ### Patch Changes
 
-- Updated dependencies [3e77f29]
-- Updated dependencies [5d95e6d]
-- Updated dependencies [9700b45]
-- Updated dependencies [9700b45]
+- Updated dependencies \[3e77f29]
+- Updated dependencies \[5d95e6d]
+- Updated dependencies \[9700b45]
+- Updated dependencies \[9700b45]
   - @effection/subscription@2.0.0-beta.3
   - @effection/events@2.0.0-beta.3
   - @effection/core@2.0.0-beta.3
@@ -27,11 +33,11 @@
 
 ### Patch Changes
 
-- Updated dependencies [19414f0]
-- Updated dependencies [26a86cb]
-- Updated dependencies [9c76cc5]
-- Updated dependencies [f7e3344]
-- Updated dependencies [ac7c1ce]
+- Updated dependencies \[19414f0]
+- Updated dependencies \[26a86cb]
+- Updated dependencies \[9c76cc5]
+- Updated dependencies \[f7e3344]
+- Updated dependencies \[ac7c1ce]
   - @effection/core@2.0.0-beta.2
   - @effection/channel@2.0.0-beta.2
   - @effection/events@2.0.0-beta.2
@@ -42,7 +48,7 @@
 ### Patch Changes
 
 - 0c6e263: release 2.0.0-beta
-- Updated dependencies [0c6e263]
+- Updated dependencies \[0c6e263]
   - @effection/channel@2.0.0-beta.1
   - @effection/core@2.0.0-beta.1
   - @effection/events@2.0.0-beta.1

--- a/packages/process/package.json
+++ b/packages/process/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/process",
-  "version": "2.0.0-beta.4",
+  "version": "2.0.0-beta.5",
   "description": "Spawn and manage external processes with Effection",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -40,10 +40,10 @@
     "typescript": "^3.7.0"
   },
   "dependencies": {
-    "@effection/channel": "2.0.0-beta.4",
-    "@effection/core": "2.0.0-beta.4",
-    "@effection/events": "2.0.0-beta.4",
-    "@effection/subscription": "2.0.0-beta.4",
+    "@effection/channel": "2.0.0-beta.5",
+    "@effection/core": "2.1.0-beta.0",
+    "@effection/events": "2.0.0-beta.5",
+    "@effection/subscription": "2.0.0-beta.5",
     "cross-spawn": "^7.0.3",
     "ctrlc-windows": "^2.0.0",
     "shellwords": "^0.1.1"

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,10 +1,16 @@
 # @effection/react
 
+## \[2.0.0-beta.6]
+
+- Deprecate Future#resolve in favour of Future#produce.
+  - Bumped due to a bump in @effection/core.
+  - [7b8ce8e](https://github.com/thefrontside/effection/commit/7b8ce8ef1d46ddf10806d51b3f0ed1ef14e8f9cd) Depreacte Future#resolve in favour of Future#produce ([#437](https://github.com/thefrontside/effection/pull/437)) on 2021-07-22
+
 ## 2.0.0-beta.5
 
 ### Patch Changes
 
-- Updated dependencies [e297c86]
+- Updated dependencies \[e297c86]
   - @effection/core@2.0.0-beta.4
   - @effection/subscription@2.0.0-beta.4
 
@@ -12,10 +18,10 @@
 
 ### Patch Changes
 
-- Updated dependencies [3e77f29]
-- Updated dependencies [5d95e6d]
-- Updated dependencies [9700b45]
-- Updated dependencies [9700b45]
+- Updated dependencies \[3e77f29]
+- Updated dependencies \[5d95e6d]
+- Updated dependencies \[9700b45]
+- Updated dependencies \[9700b45]
   - @effection/subscription@2.0.0-beta.3
   - @effection/core@2.0.0-beta.3
 
@@ -23,11 +29,11 @@
 
 ### Patch Changes
 
-- Updated dependencies [19414f0]
-- Updated dependencies [26a86cb]
-- Updated dependencies [9c76cc5]
-- Updated dependencies [f7e3344]
-- Updated dependencies [ac7c1ce]
+- Updated dependencies \[19414f0]
+- Updated dependencies \[26a86cb]
+- Updated dependencies \[9c76cc5]
+- Updated dependencies \[f7e3344]
+- Updated dependencies \[ac7c1ce]
   - @effection/core@2.0.0-beta.2
   - @effection/subscription@2.0.0-beta.2
 
@@ -42,7 +48,7 @@
 ### Patch Changes
 
 - 0c6e263: release 2.0.0-beta
-- Updated dependencies [0c6e263]
+- Updated dependencies \[0c6e263]
   - @effection/core@2.0.0-beta.1
   - @effection/subscription@2.0.0-beta.1
 
@@ -50,9 +56,9 @@
 
 ### Patch Changes
 
-- Updated dependencies [9998088]
-- Updated dependencies [2bce454]
-- Updated dependencies [1981b35]
-- Updated dependencies [88dc59a]
+- Updated dependencies \[9998088]
+- Updated dependencies \[2bce454]
+- Updated dependencies \[1981b35]
+- Updated dependencies \[88dc59a]
   - @effection/core@2.0.0-preview.12
   - @effection/subscription@2.0.0-preview.14

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/react",
-  "version": "2.0.0-beta.5",
+  "version": "2.0.0-beta.6",
   "description": "Hooks for integrating effection into react applications",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -27,8 +27,8 @@
     "mocha": "mocha -r ts-node/register"
   },
   "dependencies": {
-    "@effection/core": "2.0.0-beta.4",
-    "@effection/subscription": "2.0.0-beta.4",
+    "@effection/core": "2.1.0-beta.0",
+    "@effection/subscription": "2.0.0-beta.5",
     "react": "^17.0.2"
   },
   "devDependencies": {

--- a/packages/subscription/CHANGELOG.md
+++ b/packages/subscription/CHANGELOG.md
@@ -1,10 +1,16 @@
 # @effection/subscription
 
+## \[2.0.0-beta.5]
+
+- Deprecate Future#resolve in favour of Future#produce.
+  - Bumped due to a bump in @effection/core.
+  - [7b8ce8e](https://github.com/thefrontside/effection/commit/7b8ce8ef1d46ddf10806d51b3f0ed1ef14e8f9cd) Depreacte Future#resolve in favour of Future#produce ([#437](https://github.com/thefrontside/effection/pull/437)) on 2021-07-22
+
 ## 2.0.0-beta.4
 
 ### Patch Changes
 
-- Updated dependencies [e297c86]
+- Updated dependencies \[e297c86]
   - @effection/core@2.0.0-beta.4
 
 ## 2.0.0-beta.3
@@ -15,19 +21,19 @@
   - label stream and queue operations
 - 9700b45: stream operations like `forEach` and `expect` no longer create
   intermediate delegation tasks
-- Updated dependencies [5d95e6d]
-- Updated dependencies [9700b45]
+- Updated dependencies \[5d95e6d]
+- Updated dependencies \[9700b45]
   - @effection/core@2.0.0-beta.3
 
 ## 2.0.0-beta.2
 
 ### Patch Changes
 
-- Updated dependencies [19414f0]
-- Updated dependencies [26a86cb]
-- Updated dependencies [9c76cc5]
-- Updated dependencies [f7e3344]
-- Updated dependencies [ac7c1ce]
+- Updated dependencies \[19414f0]
+- Updated dependencies \[26a86cb]
+- Updated dependencies \[9c76cc5]
+- Updated dependencies \[f7e3344]
+- Updated dependencies \[ac7c1ce]
   - @effection/core@2.0.0-beta.2
 
 ## 2.0.0-beta.1
@@ -35,37 +41,37 @@
 ### Patch Changes
 
 - 0c6e263: release 2.0.0-beta
-- Updated dependencies [0c6e263]
+- Updated dependencies \[0c6e263]
   - @effection/core@2.0.0-beta.1
 
 ## 2.0.0-preview.14
 
 ### Patch Changes
 
-- Updated dependencies [9998088]
-- Updated dependencies [2bce454]
-- Updated dependencies [1981b35]
-- Updated dependencies [88dc59a]
+- Updated dependencies \[9998088]
+- Updated dependencies \[2bce454]
+- Updated dependencies \[1981b35]
+- Updated dependencies \[88dc59a]
   - @effection/core@2.0.0-preview.12
 
 ## 2.0.0-preview.13
 
 ### Patch Changes
 
-- Updated dependencies [88eca21]
-- Updated dependencies [ae8d090]
-- Updated dependencies [8bb4514]
-- Updated dependencies [44c354d]
+- Updated dependencies \[88eca21]
+- Updated dependencies \[ae8d090]
+- Updated dependencies \[8bb4514]
+- Updated dependencies \[44c354d]
   - @effection/core@2.0.0-preview.11
 
 ## 2.0.0-preview.12
 
 ### Patch Changes
 
-- Updated dependencies [625b521]
-- Updated dependencies [a06c679]
-- Updated dependencies [4d04159]
-- Updated dependencies [625b521]
+- Updated dependencies \[625b521]
+- Updated dependencies \[a06c679]
+- Updated dependencies \[4d04159]
+- Updated dependencies \[625b521]
   - @effection/core@2.0.0-preview.10
 
 ## 2.0.0-preview.11
@@ -78,14 +84,14 @@
 
 ### Patch Changes
 
-- Updated dependencies [110a2cd]
-- Updated dependencies [e2545b2]
-- Updated dependencies [2b92370]
-- Updated dependencies [00562fd]
-- Updated dependencies [110a2cd]
-- Updated dependencies [110a2cd]
-- Updated dependencies [02446ad]
-- Updated dependencies [da86a9c]
+- Updated dependencies \[110a2cd]
+- Updated dependencies \[e2545b2]
+- Updated dependencies \[2b92370]
+- Updated dependencies \[00562fd]
+- Updated dependencies \[110a2cd]
+- Updated dependencies \[110a2cd]
+- Updated dependencies \[02446ad]
+- Updated dependencies \[da86a9c]
   - @effection/core@2.0.0-preview.9
 
 ## 2.0.0-preview.9
@@ -94,14 +100,14 @@
 
 - a13987f: make operation resolution an interface. Make operation iterators
   an operation.
-- Updated dependencies [a13987f]
+- Updated dependencies \[a13987f]
   - @effection/core@2.0.0-preview.8
 
 ## 2.0.0-preview.8
 
 ### Patch Changes
 
-- Updated dependencies [2bad074]
+- Updated dependencies \[2bad074]
   - @effection/core@2.0.0-preview.7
 
 ## 2.0.0-preview.7
@@ -119,7 +125,7 @@
 ### Patch Changes
 
 - 1222756: Use strict dependency requirements for internal dependencies while in prerelease mode
-- Updated dependencies [1222756]
+- Updated dependencies \[1222756]
   - @effection/core@2.0.0-preview.6
 
 ## 2.0.0-preview.5
@@ -133,7 +139,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [70c358f]
+- Updated dependencies \[70c358f]
   - @effection/core@2.0.0-preview.5
 
 ## 2.0.0-preview.4
@@ -144,7 +150,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [72f743c]
+- Updated dependencies \[72f743c]
   - @effection/core@2.0.0-preview.4
 
 ## 2.0.0-preview.3
@@ -155,8 +161,8 @@
 
 ### Patch Changes
 
-- Updated dependencies [bdedf68]
-- Updated dependencies [2bf5ef4]
+- Updated dependencies \[bdedf68]
+- Updated dependencies \[2bf5ef4]
   - @effection/core@2.0.0-preview.3
 
 ## 2.0.0-preview.2
@@ -164,7 +170,7 @@
 ### Patch Changes
 
 - 93ec0d6: Include CHANGELOGS and src with all packages
-- Updated dependencies [93ec0d6]
+- Updated dependencies \[93ec0d6]
   - @effection/core@2.0.0-preview.2
 
 ## 2.0.0-preview.1
@@ -172,7 +178,7 @@
 ### Patch Changes
 
 - 80143d5: Fix packaging
-- Updated dependencies [80143d5]
+- Updated dependencies \[80143d5]
   - @effection/core@2.0.0-preview.1
 
 ## 2.0.0-preview.0
@@ -183,7 +189,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [undefined]
+- Updated dependencies \[undefined]
   - effection@2.0.0-preview.0
 
 ## 1.0.0
@@ -194,7 +200,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [b988025]
+- Updated dependencies \[b988025]
   - effection@1.0.0
 
 ## 0.12.0
@@ -205,7 +211,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [f851981]
+- Updated dependencies \[f851981]
   - effection@0.8.0
 
 ## 0.11.1
@@ -256,7 +262,7 @@
 ### Patch Changes
 
 - db11b3f: convert `effection` dependency into normal, non-peer dependency
-- Updated dependencies [0e8951f]
+- Updated dependencies \[0e8951f]
   - effection@0.7.0
 
 ## 0.7.1
@@ -264,7 +270,7 @@
 ### Patch Changes
 
 - 68c4dab: include typescript sources with package in order for sourcemaps to work.
-- Updated dependencies [68c4dab]
+- Updated dependencies \[68c4dab]
   - effection@0.6.4
 
 ## 0.7.0
@@ -284,5 +290,5 @@
   Refactor `on()` operation from `@effection/events` to use
   createSubscription()
 
-- Updated dependencies [60ed704]
+- Updated dependencies \[60ed704]
   - effection@0.6.3

--- a/packages/subscription/package.json
+++ b/packages/subscription/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/subscription",
-  "version": "2.0.0-beta.4",
+  "version": "2.0.0-beta.5",
   "description": "Effection Subscriptions",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -26,7 +26,7 @@
     "mocha": "mocha -r ts-node/register"
   },
   "dependencies": {
-    "@effection/core": "2.0.0-beta.4"
+    "@effection/core": "2.1.0-beta.0"
   },
   "devDependencies": {
     "@effection/mocha": "2.0.0-beta.4",

--- a/packages/websocket-client/CHANGELOG.md
+++ b/packages/websocket-client/CHANGELOG.md
@@ -1,10 +1,16 @@
 # @effection/websocket-client
 
+## \[2.0.0-beta.6]
+
+- Deprecate Future#resolve in favour of Future#produce.
+  - Bumped due to a bump in @effection/core.
+  - [7b8ce8e](https://github.com/thefrontside/effection/commit/7b8ce8ef1d46ddf10806d51b3f0ed1ef14e8f9cd) Depreacte Future#resolve in favour of Future#produce ([#437](https://github.com/thefrontside/effection/pull/437)) on 2021-07-22
+
 ## 2.0.0-beta.5
 
 ### Patch Changes
 
-- Updated dependencies [e297c86]
+- Updated dependencies \[e297c86]
   - @effection/core@2.0.0-beta.4
   - @effection/events@2.0.0-beta.4
   - @effection/subscription@2.0.0-beta.4
@@ -13,10 +19,10 @@
 
 ### Patch Changes
 
-- Updated dependencies [3e77f29]
-- Updated dependencies [5d95e6d]
-- Updated dependencies [9700b45]
-- Updated dependencies [9700b45]
+- Updated dependencies \[3e77f29]
+- Updated dependencies \[5d95e6d]
+- Updated dependencies \[9700b45]
+- Updated dependencies \[9700b45]
   - @effection/subscription@2.0.0-beta.3
   - @effection/events@2.0.0-beta.3
   - @effection/core@2.0.0-beta.3
@@ -25,11 +31,11 @@
 
 ### Patch Changes
 
-- Updated dependencies [19414f0]
-- Updated dependencies [26a86cb]
-- Updated dependencies [9c76cc5]
-- Updated dependencies [f7e3344]
-- Updated dependencies [ac7c1ce]
+- Updated dependencies \[19414f0]
+- Updated dependencies \[26a86cb]
+- Updated dependencies \[9c76cc5]
+- Updated dependencies \[f7e3344]
+- Updated dependencies \[ac7c1ce]
   - @effection/core@2.0.0-beta.2
   - @effection/events@2.0.0-beta.2
   - @effection/subscription@2.0.0-beta.2
@@ -45,7 +51,7 @@
 ### Patch Changes
 
 - 0c6e263: release 2.0.0-beta
-- Updated dependencies [0c6e263]
+- Updated dependencies \[0c6e263]
   - @effection/core@2.0.0-beta.1
   - @effection/events@2.0.0-beta.1
   - @effection/subscription@2.0.0-beta.1
@@ -54,11 +60,11 @@
 
 ### Patch Changes
 
-- Updated dependencies [9998088]
-- Updated dependencies [d7c0eb1]
-- Updated dependencies [2bce454]
-- Updated dependencies [1981b35]
-- Updated dependencies [88dc59a]
+- Updated dependencies \[9998088]
+- Updated dependencies \[d7c0eb1]
+- Updated dependencies \[2bce454]
+- Updated dependencies \[1981b35]
+- Updated dependencies \[88dc59a]
   - @effection/core@2.0.0-preview.12
   - @effection/events@2.0.0-preview.13
   - @effection/subscription@2.0.0-preview.14
@@ -67,10 +73,10 @@
 
 ### Patch Changes
 
-- Updated dependencies [88eca21]
-- Updated dependencies [ae8d090]
-- Updated dependencies [8bb4514]
-- Updated dependencies [44c354d]
+- Updated dependencies \[88eca21]
+- Updated dependencies \[ae8d090]
+- Updated dependencies \[8bb4514]
+- Updated dependencies \[44c354d]
   - @effection/core@2.0.0-preview.11
   - @effection/events@2.0.0-preview.12
   - @effection/subscription@2.0.0-preview.13

--- a/packages/websocket-client/package.json
+++ b/packages/websocket-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/websocket-client",
-  "version": "2.0.0-beta.5",
+  "version": "2.0.0-beta.6",
   "description": "A websocket client for Effection in node and browser",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -27,9 +27,9 @@
     "mocha": "mocha -r ts-node/register"
   },
   "dependencies": {
-    "@effection/core": "2.0.0-beta.4",
-    "@effection/events": "2.0.0-beta.4",
-    "@effection/subscription": "2.0.0-beta.4",
+    "@effection/core": "2.1.0-beta.0",
+    "@effection/events": "2.0.0-beta.5",
+    "@effection/subscription": "2.0.0-beta.5",
     "isomorphic-ws": "^4.0.1"
   },
   "devDependencies": {

--- a/packages/websocket-server/CHANGELOG.md
+++ b/packages/websocket-server/CHANGELOG.md
@@ -1,10 +1,16 @@
 # @effection/websocket-server
 
+## \[2.0.0-beta.6]
+
+- Deprecate Future#resolve in favour of Future#produce.
+  - Bumped due to a bump in @effection/core.
+  - [7b8ce8e](https://github.com/thefrontside/effection/commit/7b8ce8ef1d46ddf10806d51b3f0ed1ef14e8f9cd) Depreacte Future#resolve in favour of Future#produce ([#437](https://github.com/thefrontside/effection/pull/437)) on 2021-07-22
+
 ## 2.0.0-beta.5
 
 ### Patch Changes
 
-- Updated dependencies [e297c86]
+- Updated dependencies \[e297c86]
   - @effection/core@2.0.0-beta.4
   - @effection/events@2.0.0-beta.4
   - @effection/subscription@2.0.0-beta.4
@@ -13,10 +19,10 @@
 
 ### Patch Changes
 
-- Updated dependencies [3e77f29]
-- Updated dependencies [5d95e6d]
-- Updated dependencies [9700b45]
-- Updated dependencies [9700b45]
+- Updated dependencies \[3e77f29]
+- Updated dependencies \[5d95e6d]
+- Updated dependencies \[9700b45]
+- Updated dependencies \[9700b45]
   - @effection/subscription@2.0.0-beta.3
   - @effection/events@2.0.0-beta.3
   - @effection/core@2.0.0-beta.3
@@ -29,11 +35,11 @@
 
 ### Patch Changes
 
-- Updated dependencies [19414f0]
-- Updated dependencies [26a86cb]
-- Updated dependencies [9c76cc5]
-- Updated dependencies [f7e3344]
-- Updated dependencies [ac7c1ce]
+- Updated dependencies \[19414f0]
+- Updated dependencies \[26a86cb]
+- Updated dependencies \[9c76cc5]
+- Updated dependencies \[f7e3344]
+- Updated dependencies \[ac7c1ce]
   - @effection/core@2.0.0-beta.2
   - @effection/events@2.0.0-beta.2
   - @effection/subscription@2.0.0-beta.2
@@ -49,7 +55,7 @@
 ### Patch Changes
 
 - 0c6e263: release 2.0.0-beta
-- Updated dependencies [0c6e263]
+- Updated dependencies \[0c6e263]
   - @effection/core@2.0.0-beta.1
   - @effection/events@2.0.0-beta.1
   - @effection/subscription@2.0.0-beta.1
@@ -58,11 +64,11 @@
 
 ### Patch Changes
 
-- Updated dependencies [9998088]
-- Updated dependencies [d7c0eb1]
-- Updated dependencies [2bce454]
-- Updated dependencies [1981b35]
-- Updated dependencies [88dc59a]
+- Updated dependencies \[9998088]
+- Updated dependencies \[d7c0eb1]
+- Updated dependencies \[2bce454]
+- Updated dependencies \[1981b35]
+- Updated dependencies \[88dc59a]
   - @effection/core@2.0.0-preview.12
   - @effection/events@2.0.0-preview.13
   - @effection/subscription@2.0.0-preview.14
@@ -71,10 +77,10 @@
 
 ### Patch Changes
 
-- Updated dependencies [88eca21]
-- Updated dependencies [ae8d090]
-- Updated dependencies [8bb4514]
-- Updated dependencies [44c354d]
+- Updated dependencies \[88eca21]
+- Updated dependencies \[ae8d090]
+- Updated dependencies \[8bb4514]
+- Updated dependencies \[44c354d]
   - @effection/core@2.0.0-preview.11
   - @effection/events@2.0.0-preview.12
   - @effection/subscription@2.0.0-preview.13

--- a/packages/websocket-server/package.json
+++ b/packages/websocket-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/websocket-server",
-  "version": "2.0.0-beta.5",
+  "version": "2.0.0-beta.6",
   "description": "A simple websocket server for Effection",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -27,9 +27,9 @@
     "mocha": "mocha -r ts-node/register"
   },
   "dependencies": {
-    "@effection/core": "2.0.0-beta.4",
-    "@effection/events": "2.0.0-beta.4",
-    "@effection/subscription": "2.0.0-beta.4",
+    "@effection/core": "2.1.0-beta.0",
+    "@effection/events": "2.0.0-beta.5",
+    "@effection/subscription": "2.0.0-beta.5",
     "ws": "^7.4.6"
   },
   "devDependencies": {


### PR DESCRIPTION
# Version Updates

Merging this PR will bump all of the applicable packages based on your change files.




# @effection/channel

## [2.0.0-beta.5]
- Deprecate Future#resolve in favour of Future#produce.
  - Bumped due to a bump in @effection/core.
  - [7b8ce8e](https://github.com/thefrontside/effection/commit/7b8ce8ef1d46ddf10806d51b3f0ed1ef14e8f9cd) Depreacte Future#resolve in favour of Future#produce ([#437](https://github.com/thefrontside/effection/pull/437)) on 2021-07-22



# @effection/atom

## [2.0.0-beta.5]
- Deprecate Future#resolve in favour of Future#produce.
  - Bumped due to a bump in @effection/core.
  - [7b8ce8e](https://github.com/thefrontside/effection/commit/7b8ce8ef1d46ddf10806d51b3f0ed1ef14e8f9cd) Depreacte Future#resolve in favour of Future#produce ([#437](https://github.com/thefrontside/effection/pull/437)) on 2021-07-22



# @effection/core

## [2.1.0-beta.0]
- Deprecate Future#resolve in favour of Future#produce.
  - [7b8ce8e](https://github.com/thefrontside/effection/commit/7b8ce8ef1d46ddf10806d51b3f0ed1ef14e8f9cd) Depreacte Future#resolve in favour of Future#produce ([#437](https://github.com/thefrontside/effection/pull/437)) on 2021-07-22



# effection

## [2.0.0-beta.5]
- Deprecate Future#resolve in favour of Future#produce.
  - Bumped due to a bump in @effection/core.
  - [7b8ce8e](https://github.com/thefrontside/effection/commit/7b8ce8ef1d46ddf10806d51b3f0ed1ef14e8f9cd) Depreacte Future#resolve in favour of Future#produce ([#437](https://github.com/thefrontside/effection/pull/437)) on 2021-07-22



# @effection/events

## [2.0.0-beta.5]
- Deprecate Future#resolve in favour of Future#produce.
  - Bumped due to a bump in @effection/core.
  - [7b8ce8e](https://github.com/thefrontside/effection/commit/7b8ce8ef1d46ddf10806d51b3f0ed1ef14e8f9cd) Depreacte Future#resolve in favour of Future#produce ([#437](https://github.com/thefrontside/effection/pull/437)) on 2021-07-22



# @effection/fetch

## [2.0.0-beta.5]
- Deprecate Future#resolve in favour of Future#produce.
  - Bumped due to a bump in @effection/core.
  - [7b8ce8e](https://github.com/thefrontside/effection/commit/7b8ce8ef1d46ddf10806d51b3f0ed1ef14e8f9cd) Depreacte Future#resolve in favour of Future#produce ([#437](https://github.com/thefrontside/effection/pull/437)) on 2021-07-22



# @effection/inspect

## [2.0.0-beta.6]
- Deprecate Future#resolve in favour of Future#produce.
  - Bumped due to a bump in @effection/inspect-server.
  - [7b8ce8e](https://github.com/thefrontside/effection/commit/7b8ce8ef1d46ddf10806d51b3f0ed1ef14e8f9cd) Depreacte Future#resolve in favour of Future#produce ([#437](https://github.com/thefrontside/effection/pull/437)) on 2021-07-22



# @effection/inspect-server

## [2.0.0-beta.6]
- Deprecate Future#resolve in favour of Future#produce.
  - Bumped due to a bump in @effection/core.
  - [7b8ce8e](https://github.com/thefrontside/effection/commit/7b8ce8ef1d46ddf10806d51b3f0ed1ef14e8f9cd) Depreacte Future#resolve in favour of Future#produce ([#437](https://github.com/thefrontside/effection/pull/437)) on 2021-07-22



# @effection/inspect-ui

## [2.0.0-beta.5]
- Deprecate Future#resolve in favour of Future#produce.
  - Bumped due to a bump in @effection/core.
  - [7b8ce8e](https://github.com/thefrontside/effection/commit/7b8ce8ef1d46ddf10806d51b3f0ed1ef14e8f9cd) Depreacte Future#resolve in favour of Future#produce ([#437](https://github.com/thefrontside/effection/pull/437)) on 2021-07-22



# @effection/inspect-utils

## [2.0.0-beta.5]
- Deprecate Future#resolve in favour of Future#produce.
  - Bumped due to a bump in @effection/core.
  - [7b8ce8e](https://github.com/thefrontside/effection/commit/7b8ce8ef1d46ddf10806d51b3f0ed1ef14e8f9cd) Depreacte Future#resolve in favour of Future#produce ([#437](https://github.com/thefrontside/effection/pull/437)) on 2021-07-22



# @effection/main

## [2.0.0-beta.5]
- Deprecate Future#resolve in favour of Future#produce.
  - Bumped due to a bump in @effection/core.
  - [7b8ce8e](https://github.com/thefrontside/effection/commit/7b8ce8ef1d46ddf10806d51b3f0ed1ef14e8f9cd) Depreacte Future#resolve in favour of Future#produce ([#437](https://github.com/thefrontside/effection/pull/437)) on 2021-07-22



# @effection/node

## [2.0.0-beta.5]
- Deprecate Future#resolve in favour of Future#produce.
  - Bumped due to a bump in @effection/main.
  - [7b8ce8e](https://github.com/thefrontside/effection/commit/7b8ce8ef1d46ddf10806d51b3f0ed1ef14e8f9cd) Depreacte Future#resolve in favour of Future#produce ([#437](https://github.com/thefrontside/effection/pull/437)) on 2021-07-22



# @effection/process

## [2.0.0-beta.5]
- Deprecate Future#resolve in favour of Future#produce.
  - Bumped due to a bump in @effection/core.
  - [7b8ce8e](https://github.com/thefrontside/effection/commit/7b8ce8ef1d46ddf10806d51b3f0ed1ef14e8f9cd) Depreacte Future#resolve in favour of Future#produce ([#437](https://github.com/thefrontside/effection/pull/437)) on 2021-07-22



# @effection/react

## [2.0.0-beta.6]
- Deprecate Future#resolve in favour of Future#produce.
  - Bumped due to a bump in @effection/core.
  - [7b8ce8e](https://github.com/thefrontside/effection/commit/7b8ce8ef1d46ddf10806d51b3f0ed1ef14e8f9cd) Depreacte Future#resolve in favour of Future#produce ([#437](https://github.com/thefrontside/effection/pull/437)) on 2021-07-22



# @effection/subscription

## [2.0.0-beta.5]
- Deprecate Future#resolve in favour of Future#produce.
  - Bumped due to a bump in @effection/core.
  - [7b8ce8e](https://github.com/thefrontside/effection/commit/7b8ce8ef1d46ddf10806d51b3f0ed1ef14e8f9cd) Depreacte Future#resolve in favour of Future#produce ([#437](https://github.com/thefrontside/effection/pull/437)) on 2021-07-22



# @effection/websocket-client

## [2.0.0-beta.6]
- Deprecate Future#resolve in favour of Future#produce.
  - Bumped due to a bump in @effection/core.
  - [7b8ce8e](https://github.com/thefrontside/effection/commit/7b8ce8ef1d46ddf10806d51b3f0ed1ef14e8f9cd) Depreacte Future#resolve in favour of Future#produce ([#437](https://github.com/thefrontside/effection/pull/437)) on 2021-07-22



# @effection/websocket-server

## [2.0.0-beta.6]
- Deprecate Future#resolve in favour of Future#produce.
  - Bumped due to a bump in @effection/core.
  - [7b8ce8e](https://github.com/thefrontside/effection/commit/7b8ce8ef1d46ddf10806d51b3f0ed1ef14e8f9cd) Depreacte Future#resolve in favour of Future#produce ([#437](https://github.com/thefrontside/effection/pull/437)) on 2021-07-22