### PR TITLE
Add jack as author to PR action

### DIFF
--- a/.github/workflows/covector-version-or-publish.yml
+++ b/.github/workflows/covector-version-or-publish.yml
@@ -45,3 +45,4 @@ jobs:
           branch: "release"
           body: ${{ steps.covector.outputs.change }}
           token: ${{ secrets.FRONTSIDEJACK_GITHUB_TOKEN }}
+          author: frontsidejack frontsidejack@users.noreply.github.com


### PR DESCRIPTION
## Motivation
I noticed the commits that are being pushed to apply covector changes in the `package version` prs are authored by the person that triggered the workflow. According to [this](https://github.com/peter-evans/create-pull-request/blob/main/README.md#action-inputs) README, it seems we can add a `author` property to the action to specify who we want pushing those commits.

## Approach
Added:
```
- uses: peter-evans/create-pull-request@v3
  with:
    author: frontsidejack frontsidejack@users.noreply.github.com
```