### PR TITLE
Run yarn install with immutable flag

### DIFF
--- a/.github/workflows/covector-version-or-publish.yml
+++ b/.github/workflows/covector-version-or-publish.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           git config --global user.name "${{ github.event.pusher.name }}"
           git config --global user.email "${{ github.event.pusher.email }}"
-      - run: yarn install
+      - run: yarn install --immutable
       - name: covector version or publish (publish when no change files present)
         uses: jbolda/covector/packages/action@covector-v0.7
         id: covector


### PR DESCRIPTION
Prepack in CI is failing because it's fetching a newer version of parcel so instead of `yarn install`, we should be running `yarn install --immutable` which is the newer flag of `--frozen-lockfile`.