### PR TITLE
Add spawn operation directly to Task.

### DIFF
--- a/.changes/task-spawn-operation.md
+++ b/.changes/task-spawn-operation.md
@@ -1,0 +1,5 @@
+---
+"effection": patch
+"@effection/core": patch
+---
+add `Task#spawn` operation to spawn new task with a specific scope

--- a/packages/core/src/operations/spawn.ts
+++ b/packages/core/src/operations/spawn.ts
@@ -2,7 +2,7 @@ import { Operation, Resource } from '../operation';
 import type { Task, TaskOptions } from '../task';
 
 interface Spawn<T> extends Resource<Task<T>> {
-  within(scope: Task): Resource<Task<T>>;
+  within(scope: Task): Operation<Task<T>>;
 }
 
 export function spawn<T>(operation?: Operation<T>, options?: TaskOptions): Spawn<T> {
@@ -11,9 +11,7 @@ export function spawn<T>(operation?: Operation<T>, options?: TaskOptions): Spawn
   }
 
   function within(scope: Task) {
-    return {
-      init: () => init(scope)
-    };
+    return scope.spawn(operation, options);
   }
 
   return { init, within, name: 'spawn' };

--- a/packages/core/src/task.ts
+++ b/packages/core/src/task.ts
@@ -43,8 +43,7 @@ export interface Task<TOut = unknown> extends Promise<TOut>, FutureLike<TOut> {
   catchHalt(): Promise<TOut | undefined>;
   setLabels(labels: Labels): void;
   run<R>(operation?: Operation<R>, options?: TaskOptions): Task<R>;
-  /** @deprecated Use run() instead */
-  spawn<R>(operation?: Operation<R>, options?: TaskOptions): Task<R>;
+  spawn<R>(operation?: Operation<R>, options?: TaskOptions): Operation<Task<R>>;
   halt(): Promise<void>;
   start(): void;
   toJSON(): TaskTree;
@@ -117,8 +116,12 @@ export function createTask<TOut = unknown>(operation: Operation<TOut>, options: 
     },
 
     spawn(operation?, options = {}) {
-      console.warn(`DEPRECATED: task.spawn() is deprecated and will be changed or removed prior to the release of effection 2.0\nuse task.run() instead`);
-      return task.run(operation, options);
+      return {
+        name: 'spawn',
+        *init() {
+          return task.run(operation, options);
+        }
+      }
     },
 
     start() {

--- a/packages/core/src/task.ts
+++ b/packages/core/src/task.ts
@@ -121,7 +121,7 @@ export function createTask<TOut = unknown>(operation: Operation<TOut>, options: 
         *init() {
           return task.run(operation, options);
         }
-      }
+      };
     },
 
     start() {

--- a/packages/core/test/operations/spawn.test.ts
+++ b/packages/core/test/operations/spawn.test.ts
@@ -22,10 +22,10 @@ describe('spawn', () => {
     let { future, produce } = createFuture<string>();
     run(function*(scope) {
       yield function*() {
-        yield spawn(function*() {
+        yield scope.spawn(function*() {
           yield sleep(5);
           produce({ state: 'completed', value: 'foo' });
-        }).within(scope);
+        });
       };
       yield;
     });

--- a/packages/fetch/test/echo-server.ts
+++ b/packages/fetch/test/echo-server.ts
@@ -54,14 +54,14 @@ export class EchoServer {
         throw e;
       }
 
-      yield spawn(throwOnErrorEvent(http)).within(scope);
-      yield spawn(function*() {
+      yield scope.spawn(throwOnErrorEvent(http));
+      yield scope.spawn(function*() {
         try {
           yield;
         } finally {
           http.close();
         }
-      }).within(scope);
+      });
     }
   }
 }

--- a/packages/inspect-server/test/server.test.ts
+++ b/packages/inspect-server/test/server.test.ts
@@ -11,8 +11,7 @@ type Message = { value: string };
 describe("createInspectServer()", () => {
   it('sreams inspect trees', function*() {
     let task = yield spawn(undefined, { labels: { name: 'foo' } });
-    let child = yield spawn(undefined, { labels: { name: 'bar' } })
-      .within(task);
+    let child = yield task.spawn(undefined, { labels: { name: 'bar' } });
     let server: InspectServer = yield createInspectServer({ task });
 
     let client: WebSocketClient<Message> = yield createWebSocketClient<Message>(`ws://localhost:${server.port}`);

--- a/packages/inspect-utils/src/inspect.ts
+++ b/packages/inspect-utils/src/inspect.ts
@@ -36,7 +36,7 @@ export function inspect(rootTask: Task): Resource<Slice<InspectTree>> {
     }
 
     yield spawn(on<Task>(task, 'link').forEach(child => {
-      return spawn(linkChild(child)).within(scope) as Operation<void>;
+      return scope.spawn(linkChild(child)) as Operation<void>;
     }));
 
     yield spawn(on<StateTransition>(task, 'state').forEach((transition) => {

--- a/packages/inspect-utils/test/debug.test.ts
+++ b/packages/inspect-utils/test/debug.test.ts
@@ -12,12 +12,11 @@ describe("inspect()", () => {
 
     let tree: Slice<InspectTree> = yield inspect(task);
 
-    let child = yield spawn(function*() {
+    let child = yield task.spawn(function*() {
       yield spawn()
       yield spawn(function*() { /* no op */});
       yield sleep();
-    }, { labels: { name: 'root' } })
-      .within(task);
+    }, { labels: { name: 'root' } });
 
     yield sleep(10);
 

--- a/packages/mocha/test/mocha.test.ts
+++ b/packages/mocha/test/mocha.test.ts
@@ -42,7 +42,7 @@ describe('@effection/mocha', () => {
 
   describe('cleaning up tasks', () => {
     it('sets up task', function*(task) {
-      captured = yield spawn().within(task);
+      captured = yield task.spawn();
     });
 
     it('and cleans it up', function*() {
@@ -62,7 +62,7 @@ describe('@effection/mocha', () => {
 
   describe('spawning in world', () => {
     beforeEach(function*(world) {
-      captured = yield spawn().within(world);
+      captured = yield world.spawn();
     });
 
     it('does not halt the spawned task before it block', function*() {
@@ -72,7 +72,7 @@ describe('@effection/mocha', () => {
 
   describe('spawning in scope', () => {
     beforeEach(function*(_world, scope) {
-      captured = yield spawn().within(scope);
+      captured = yield scope.spawn();
     });
 
     it('halts the spawned task before it block', function*() {

--- a/packages/process/src/exec/posix.ts
+++ b/packages/process/src/exec/posix.ts
@@ -65,7 +65,7 @@ export const createPosixProcess: CreateOSProcess = (command, options) => {
         });
 
         yield task.spawn(on<Buffer>(childProcess.stdout, 'data').map((c) => c.toString()).forEach(stdoutChannel.send));
-        yield task.spawn(on<Buffer>(childProcess.stderr, 'data').map((c) => c.toString()).forEach(stderrChannel.send))
+        yield task.spawn(on<Buffer>(childProcess.stderr, 'data').map((c) => c.toString()).forEach(stderrChannel.send));
 
         try {
           let value = yield onceEmit(childProcess, 'exit');

--- a/packages/process/src/exec/posix.ts
+++ b/packages/process/src/exec/posix.ts
@@ -59,13 +59,13 @@ export const createPosixProcess: CreateOSProcess = (command, options) => {
       };
 
       yield spawn(function*(task) {
-        yield spawn(function*() {
+        yield task.spawn(function*() {
           let value: Error = yield once(childProcess, 'error');
           produce({ state: 'completed', value: { type: 'error', value } });
-        }).within(task);
+        });
 
-        yield spawn(on<Buffer>(childProcess.stdout, 'data').map((c) => c.toString()).forEach(stdoutChannel.send)).within(task);
-        yield spawn(on<Buffer>(childProcess.stderr, 'data').map((c) => c.toString()).forEach(stderrChannel.send)).within(task);
+        yield task.spawn(on<Buffer>(childProcess.stdout, 'data').map((c) => c.toString()).forEach(stdoutChannel.send));
+        yield task.spawn(on<Buffer>(childProcess.stderr, 'data').map((c) => c.toString()).forEach(stderrChannel.send))
 
         try {
           let value = yield onceEmit(childProcess, 'exit');

--- a/packages/process/src/exec/win32.ts
+++ b/packages/process/src/exec/win32.ts
@@ -66,13 +66,13 @@ export const createWin32Process: CreateOSProcess = (command, options) => {
       };
 
       yield spawn(function*(task) {
-        yield spawn(function*() {
+        yield task.spawn(function*() {
           let value: Error = yield once(childProcess, 'error');
           produce({ state: 'completed', value: { type: 'error', value } });
-        }).within(task);
+        });
 
-        yield spawn(on<Buffer>(childProcess.stdout, 'data').map((c) => c.toString()).forEach(stdoutChannel.send)).within(task);
-        yield spawn(on<Buffer>(childProcess.stderr, 'data').map((c) => c.toString()).forEach(stderrChannel.send)).within(task);
+        yield task.spawn(on<Buffer>(childProcess.stdout, 'data').map((c) => c.toString()).forEach(stdoutChannel.send));
+        yield task.spawn(on<Buffer>(childProcess.stderr, 'data').map((c) => c.toString()).forEach(stderrChannel.send));
 
         try {
           let value = yield onceEmit(childProcess, "exit");

--- a/packages/websocket-server/src/index.ts
+++ b/packages/websocket-server/src/index.ts
@@ -32,7 +32,7 @@ export function createWebSocketSubscription<TIncoming = unknown, TOutgoing = TIn
       let queue = createQueue<WebSocketConnection<TIncoming, TOutgoing>>();
 
       yield spawn(on<WebSocket>(wss, 'connection').forEach(function* (raw) {
-        yield spawn(function*() {
+        yield scope.spawn(function*() {
           let messageQueue = createQueue<TIncoming>();
 
           queue.send({
@@ -45,7 +45,7 @@ export function createWebSocketSubscription<TIncoming = unknown, TOutgoing = TIn
           yield on<{ data: string }>(raw, 'message').forEach((message) => {
             messageQueue.send(JSON.parse(message.data));
           });
-        }).within(scope);
+        });
       }));
 
       yield ensure(() => { wss.close() });

--- a/website/docs/guides/testing.md
+++ b/website/docs/guides/testing.md
@@ -56,10 +56,10 @@ task that covers the whole test as "world".
 ``` javascript
 describe('some effection code', () => {
   beforeEach(function*(world, task) {
-    world.spawn(); // still running in the `it` block
-    task.spawn(); // only runs until the end of `beforeEach`
+    world.run(); // still running in the `it` block
+    task.run(); // only runs until the end of `beforeEach`
     yield spawn(); // spawned in `world`, still running in the `it` block
-    yield spawn().within(task); // only runs until the end of `beforeEach`
+    yield task.spawn();
   });
 
   it('does something', function*() {


### PR DESCRIPTION
## Motivation

resolves #360

## Approach

This adds a `spawn()` operation to the `Task` api which, unsuprisingly, spawns a child in the context of a particular task. Note that this is an _operation_, and not a synchronous function. Calling the `spawn()` method will not actually do anything until the operation is evaluated.

Now, it is very easy and safe to spawn operations within the context of a specific task without having to use the `within()` syntax (which we might deprecate in the future).

### Before

```js
yield spawn(function*() {
  //do stuff
}).within(scope);
```

### After

```js
yield scope.spawn(function*() {
  // do stuff
});
