### PR TITLE
Add second yarn install step for covector workflow

### DIFF
--- a/.github/workflows/covector-version-or-publish.yml
+++ b/.github/workflows/covector-version-or-publish.yml
@@ -35,6 +35,7 @@ jobs:
         with:
           token: ${{ secrets.FRONTSIDEJACK_GITHUB_TOKEN }}
           command: 'version-or-publish'
+      - run: yarn install # this is to update the lockfile with the new versions of dependencies as a result of covector
       - name: Create Pull Request With Versions Bumped
         id: cpr
         uses: peter-evans/create-pull-request@v3


### PR DESCRIPTION
## Motivation

To resolve #457 

## Approach

Added a second `yarn install` step to run right after `covector version`. This is similar to the [setup](https://github.com/thefrontside/simulacrum/blob/v0/.github/workflows/covector-version-or-publish.yml#L41-L45) we have for `simulacrum`.