### PR TITLE
Fix typo for version-or-publish workflow

### DIFF
--- a/.github/workflows/covector-version-or-publish.yml
+++ b/.github/workflows/covector-version-or-publish.yml
@@ -52,7 +52,7 @@ jobs:
   deploy-typedocs:
     runs-on: ubuntu-latest
     needs: version-or-publish
-    if: ${{ needs.version-or-publich.outputs.successfulPublish == 'true' }}
+    if: ${{ needs.version-or-publish.outputs.successfulPublish == 'true' }}
     steps:
       - name: Trigger Netlify Build
         run: curl -X POST -d {} ${{ secrets.DEPLOY_API_DOCS_V2 }}


### PR DESCRIPTION
The typedocs job in our version-or-publish workflow [didn't run](https://github.com/thefrontside/effection/runs/3182342823) when we merged the last version-packages pr because of a typo I made in #396.