### PR TITLE
fix: @effection/core to ship dist/esm and dist/cjs

### DIFF
--- a/.changes/core-esm-cjs-dist.md
+++ b/.changes/core-esm-cjs-dist.md
@@ -1,0 +1,5 @@
+---
+"@effection/core": patch
+---
+
+The `dist` directory didn't contain the `esm` and `cjs` directory. We copy the `package.json` for reference into the dist, and this broke the `files` resolution.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,6 +23,8 @@
   "files": [
     "CHANGELOG.md",
     "dist/**/*",
+    "cjs/**/*",
+    "esm/**/*",
     "src/**/*"
   ],
   "devDependencies": {


### PR DESCRIPTION
## Motivation

`@effection/core@2.0.0-beta.6` did not ship with the `dist/esm` and `dist/cjs` folders. It appears that copying the `package.json` into the `dist` directory breaks the `files` resolution.

## Approach

It seems that the `dist/package.json` creates a new root. If we add `esm/**/*` and `cjs/**/*` it appears to resolve the subdirs correctly.
