### PR TITLE
fix: @effection/core to ship dist-esm and dist-cjs

### DIFF
--- a/.changes/core-esm-cjs-dist.md
+++ b/.changes/core-esm-cjs-dist.md
@@ -2,4 +2,4 @@
 "@effection/core": patch
 ---
 
-The `dist` directory didn't contain the `esm` and `cjs` directory. We copy the `package.json` for reference into the dist, and this broke the `files` resolution.
+The `dist` directory didn't contain the `esm` and `cjs` directory. We copy the `package.json` for reference into the dist, and this broke the `files` resolution. Switch to using `dist-cjs` and `dist-esm` which allows us to avoid copying `package.json`.

--- a/.changes/core-esm-cjs-dist.md
+++ b/.changes/core-esm-cjs-dist.md
@@ -1,5 +1,22 @@
 ---
+"@effection/atom": patch
+"@effection/channel": patch
 "@effection/core": patch
+"effection": patch
+"@effection/events": patch
+"@effection/fetch": patch
+"@effection/inspect": patch
+"@effection/inspect-server": patch
+"@effection/inspect-utils": patch
+"@effection/inspect-ui": patch
+"@effection/main": patch
+"@effection/mocha": patch
+"@effection/node": patch
+"@effection/process": patch
+"@effection/react": patch
+"@effection/subscription": patch
+"@effection/websocket-client": patch
+"@effection/websocket-server": patch
 ---
 
 The `dist` directory didn't contain the `esm` and `cjs` directory. We copy the `package.json` for reference into the dist, and this broke the `files` resolution. Switch to using `dist-cjs` and `dist-esm` which allows us to avoid copying `package.json`.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-            - "packages/*/dist"
+            - "packages/*/dist*"
   test:
     executor: <<parameters.executor>>
     parameters:

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ packages/*/docs
 .esm-cache
 .node-version
 .parcel-cache
-dist/
+dist*/
 pkg/
 .nyc_output/
 coverage

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ packages/*/docs
 .node-version
 .parcel-cache
 dist*/
+*.tgz
 pkg/
 .nyc_output/
 coverage

--- a/packages/atom/package.json
+++ b/packages/atom/package.json
@@ -16,8 +16,7 @@
   "files": [
     "README.md",
     "CHANGELOG.md",
-    "dist-esm/**/*",
-    "dist-cjs/**/*",
+    "dist-*/**/*",
     "src/**/*"
   ],
   "scripts": {

--- a/packages/atom/package.json
+++ b/packages/atom/package.json
@@ -2,21 +2,22 @@
   "name": "@effection/atom",
   "version": "2.0.0-beta.7",
   "description": "State atom implementation for effection",
-  "main": "dist/cjs/index.js",
-  "types": "dist/esm/index.d.ts",
+  "main": "dist-cjs/index.js",
+  "types": "dist-esm/index.d.ts",
+  "typeDocEntry": "src/index.ts",
   "homepage": "https://github.com/thefrontside/effection",
   "repository": {
     "type": "git",
     "url": "https://github.com/thefrontside/effection.git",
     "directory": "packages/atom"
   },
-  "typeDocEntry": "src/index.ts",
   "author": "Frontside Engineering <engineering@frontside.io>",
   "license": "MIT",
   "files": [
     "README.md",
     "CHANGELOG.md",
-    "dist/**/*",
+    "dist-esm/**/*",
+    "dist-cjs/**/*",
     "src/**/*"
   ],
   "scripts": {

--- a/packages/atom/tsconfig.cjs.json
+++ b/packages/atom/tsconfig.cjs.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig",
   "compilerOptions": {
     "rootDir": "./src",
-    "outDir": "./dist/cjs",
+    "outDir": "./dist-cjs",
     "noEmit": false
   },
   "references": [

--- a/packages/atom/tsconfig.esm.json
+++ b/packages/atom/tsconfig.esm.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.cjs.json",
   "compilerOptions": {
-    "outDir": "./dist/esm",
+    "outDir": "./dist-esm",
     "module": "ESNext"
   },
   "references": [

--- a/packages/channel/package.json
+++ b/packages/channel/package.json
@@ -2,22 +2,23 @@
   "name": "@effection/channel",
   "version": "2.0.0-beta.7",
   "description": "MPMC Channel implementation for effection",
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
-  "types": "dist/esm/index.d.ts",
+  "main": "dist-cjs/index.js",
+  "module": "dist-esm/index.js",
+  "types": "dist-esm/index.d.ts",
+  "typeDocEntry": "src/index.ts",
   "homepage": "https://github.com/thefrontside/effection",
   "repository": {
     "type": "git",
     "url": "https://github.com/thefrontside/effection.git",
     "directory": "packages/channel"
   },
-  "typeDocEntry": "src/index.ts",
   "author": "Frontside Engineering <engineering@frontside.io>",
   "license": "MIT",
   "files": [
     "README.md",
     "CHANGELOG.md",
-    "dist/**/*",
+    "dist-esm/**/*",
+    "dist-cjs/**/*",
     "src/**/*"
   ],
   "scripts": {

--- a/packages/channel/package.json
+++ b/packages/channel/package.json
@@ -17,8 +17,7 @@
   "files": [
     "README.md",
     "CHANGELOG.md",
-    "dist-esm/**/*",
-    "dist-cjs/**/*",
+    "dist-*/**/*",
     "src/**/*"
   ],
   "scripts": {

--- a/packages/channel/tsconfig.cjs.json
+++ b/packages/channel/tsconfig.cjs.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig",
   "compilerOptions": {
     "rootDir": "./src",
-    "outDir": "./dist/cjs",
+    "outDir": "./dist-cjs",
     "noEmit": false
   },
   "references": [

--- a/packages/channel/tsconfig.esm.json
+++ b/packages/channel/tsconfig.esm.json
@@ -1,9 +1,9 @@
 {
   "extends": "./tsconfig.cjs.json",
   "compilerOptions": {
-    "outDir": "./dist/esm",
+    "outDir": "./dist-esm",
     "module": "ESNext"
-  },  
+  },
   "references": [
     { "path": "../core/tsconfig.esm.json" },
     { "path": "../events/tsconfig.esm.json" },

--- a/packages/core/.gitignore
+++ b/packages/core/.gitignore
@@ -1,2 +1,2 @@
 node_modules
-dist
+dist*

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@effection/core",
   "version": "2.0.0-beta.6",
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
-  "types": "dist/esm/index.d.ts",
+  "main": "dist-cjs/index.js",
+  "module": "dist-esm/index.js",
+  "types": "dist-esm/index.d.ts",
   "typeDocEntry": "src/index.ts",
   "license": "MIT",
   "homepage": "https://github.com/thefrontside/effection",
@@ -18,20 +18,18 @@
     "test": "mocha -r ts-node/register 'test/**/*.test.ts'",
     "mocha": "mocha -r ts-node/register",
     "build": "yarn prepack",
-    "prepack": "copy-cli \"./package.json\" \"./dist/\" && tsc --build tsconfig.esm.json && tsc --build tsconfig.cjs.json"
+    "prepack": "tsc --build tsconfig.esm.json && tsc --build tsconfig.cjs.json"
   },
   "files": [
     "CHANGELOG.md",
-    "dist/**/*",
-    "cjs/**/*",
-    "esm/**/*",
+    "dist-cjs/**/*",
+    "dist-esm/**/*",
     "src/**/*"
   ],
   "devDependencies": {
     "@frontside/tsconfig": "^1.2.0",
     "@types/mocha": "^7.0.2",
     "@types/node": "^16.3.2",
-    "copy": "^0.3.2",
     "eslint": "^7.30.0",
     "expect": "^25.3.0",
     "mocha": "^8.3.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,8 +22,7 @@
   },
   "files": [
     "CHANGELOG.md",
-    "dist-cjs/**/*",
-    "dist-esm/**/*",
+    "dist-*/**/*",
     "src/**/*"
   ],
   "devDependencies": {

--- a/packages/core/tsconfig.cjs.json
+++ b/packages/core/tsconfig.cjs.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig",
   "compilerOptions": {
     "rootDir": "./src",
-    "outDir": "./dist/cjs",
+    "outDir": "./dist-cjs",
     "noEmit": false
   },
   "exclude": ["./test/*"]

--- a/packages/core/tsconfig.esm.json
+++ b/packages/core/tsconfig.esm.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.cjs.json",
   "compilerOptions": {
-    "outDir": "./dist/esm",
+    "outDir": "./dist-esm",
     "module": "ESNext"
   },
   "exclude": ["./test/*"]

--- a/packages/effection/package.json
+++ b/packages/effection/package.json
@@ -11,13 +11,14 @@
   "author": "Charles Lowell <cowboyd@frontside.com>",
   "license": "MIT",
   "private": false,
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
-  "types": "dist/esm/index.d.ts",
+  "main": "dist-cjs/index.js",
+  "module": "dist-esm/index.js",
+  "types": "dist-esm/index.d.ts",
   "typeDocEntry": "src/index.ts",
   "files": [
     "CHANGELOG.md",
-    "dist/**/*",
+    "dist-esm/**/*",
+    "dist-cjs/**/*",
     "src/**/*"
   ],
   "scripts": {

--- a/packages/effection/package.json
+++ b/packages/effection/package.json
@@ -17,8 +17,7 @@
   "typeDocEntry": "src/index.ts",
   "files": [
     "CHANGELOG.md",
-    "dist-esm/**/*",
-    "dist-cjs/**/*",
+    "dist-*/**/*",
     "src/**/*"
   ],
   "scripts": {

--- a/packages/effection/tsconfig.cjs.json
+++ b/packages/effection/tsconfig.cjs.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig",
   "compilerOptions": {
     "rootDir": "./src",
-    "outDir": "./dist/cjs",
+    "outDir": "./dist-cjs",
     "noEmit": false
   },
   "references": [

--- a/packages/effection/tsconfig.esm.json
+++ b/packages/effection/tsconfig.esm.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.cjs.json",
   "compilerOptions": {
-    "outDir": "./dist/esm",
+    "outDir": "./dist-esm",
     "module": "ESNext"
   },
   "references": [

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -2,9 +2,9 @@
   "name": "@effection/events",
   "version": "2.0.0-beta.7",
   "description": "Helpers for listening to events with effection",
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
-  "types": "dist/esm/index.d.ts",
+  "main": "dist-cjs/index.js",
+  "module": "dist-esm/index.js",
+  "types": "dist-esm/index.d.ts",
   "typeDocEntry": "src/index.ts",
   "homepage": "https://github.com/thefrontside/effection",
   "repository": {
@@ -17,7 +17,8 @@
   "files": [
     "README.md",
     "CHANGELOG.md",
-    "dist/**/*",
+    "dist-esm/**/*",
+    "dist-cjs/**/*",
     "src/**/*"
   ],
   "scripts": {

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -17,8 +17,7 @@
   "files": [
     "README.md",
     "CHANGELOG.md",
-    "dist-esm/**/*",
-    "dist-cjs/**/*",
+    "dist-*/**/*",
     "src/**/*"
   ],
   "scripts": {

--- a/packages/events/tsconfig.cjs.json
+++ b/packages/events/tsconfig.cjs.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig",
   "compilerOptions": {
     "rootDir": "./src",
-    "outDir": "./dist/cjs",
+    "outDir": "./dist-cjs",
     "noEmit": false
   },
   "references": [

--- a/packages/events/tsconfig.esm.json
+++ b/packages/events/tsconfig.esm.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.cjs.json",
   "compilerOptions": {
-    "outDir": "./dist/esm",
+    "outDir": "./dist-esm",
     "module": "ESNext"
   },
   "references": [

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -2,9 +2,9 @@
   "name": "@effection/fetch",
   "version": "2.0.0-beta.7",
   "description": "Fetch operation for Effection",
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
-  "types": "dist/esm/index.d.ts",
+  "main": "dist-cjs/index.js",
+  "module": "dist-esm/index.js",
+  "types": "dist-esm/index.d.ts",
   "homepage": "https://github.com/thefrontside/effection",
   "repository": {
     "type": "git",
@@ -17,7 +17,8 @@
   "files": [
     "README.md",
     "CHANGELOG.md",
-    "dist/**/*",
+    "dist-esm/**/*",
+    "dist-cjs/**/*",
     "src/**/*"
   ],
   "scripts": {

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -17,8 +17,7 @@
   "files": [
     "README.md",
     "CHANGELOG.md",
-    "dist-esm/**/*",
-    "dist-cjs/**/*",
+    "dist-*/**/*",
     "src/**/*"
   ],
   "scripts": {

--- a/packages/fetch/tsconfig.cjs.json
+++ b/packages/fetch/tsconfig.cjs.json
@@ -2,13 +2,9 @@
   "extends": "./tsconfig",
   "compilerOptions": {
     "rootDir": "./src",
-    "outDir": "./dist/cjs",
+    "outDir": "./dist-cjs",
     "noEmit": false
   },
-  "references": [
-    { "path": "../core/tsconfig.cjs.json" },
-  ],
-  "exclude": [
-    "./test/*"
-  ]
+  "references": [{ "path": "../core/tsconfig.cjs.json" }],
+  "exclude": ["./test/*"]
 }

--- a/packages/fetch/tsconfig.esm.json
+++ b/packages/fetch/tsconfig.esm.json
@@ -1,11 +1,9 @@
 {
   "extends": "./tsconfig.cjs.json",
   "compilerOptions": {
-    "outDir": "./dist/esm",
+    "outDir": "./dist-esm",
     "module": "ESNext"
   },
-  "references": [
-    { "path": "../core/tsconfig.esm.json" },
-  ],
+  "references": [{ "path": "../core/tsconfig.esm.json" }],
   "exclude": ["./test/*"]
 }

--- a/packages/inspect-server/package.json
+++ b/packages/inspect-server/package.json
@@ -16,8 +16,7 @@
   "files": [
     "README.md",
     "CHANGELOG.md",
-    "dist-esm/**/*",
-    "dist-cjs/**/*",
+    "dist-*/**/*",
     "src/**/*"
   ],
   "scripts": {

--- a/packages/inspect-server/package.json
+++ b/packages/inspect-server/package.json
@@ -2,9 +2,9 @@
   "name": "@effection/inspect-server",
   "version": "2.0.0-beta.8",
   "description": "Inspect server for inspecting effection processes",
-  "main": "dist/cjs/index.js",
-  "types": "dist/esm/index.d.ts",
-  "module": "dist/esm/index.js",
+  "main": "dist-cjs/index.js",
+  "types": "dist-esm/index.d.ts",
+  "module": "dist-esm/index.js",
   "homepage": "https://github.com/thefrontside/effection",
   "repository": {
     "type": "git",
@@ -16,7 +16,8 @@
   "files": [
     "README.md",
     "CHANGELOG.md",
-    "dist/**/*",
+    "dist-esm/**/*",
+    "dist-cjs/**/*",
     "src/**/*"
   ],
   "scripts": {

--- a/packages/inspect-server/tsconfig.cjs.json
+++ b/packages/inspect-server/tsconfig.cjs.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig",
   "compilerOptions": {
     "rootDir": "./src",
-    "outDir": "./dist/cjs",
+    "outDir": "./dist-cjs",
     "noEmit": false
   },
   "references": [

--- a/packages/inspect-server/tsconfig.esm.json
+++ b/packages/inspect-server/tsconfig.esm.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.cjs.json",
   "compilerOptions": {
-    "outDir": "./dist/esm",
+    "outDir": "./dist-esm",
     "module": "ESNext"
   },
   "references": [

--- a/packages/inspect-utils/package.json
+++ b/packages/inspect-utils/package.json
@@ -2,9 +2,9 @@
   "name": "@effection/inspect-utils",
   "version": "2.0.0-beta.7",
   "description": "Helper functions and types for inspecting effection applications",
-  "main": "dist/cjs/index.js",
-  "types": "dist/esm/index.d.ts",
-  "module": "dist/inspect-utils.esm.js",
+  "main": "dist-cjs/index.js",
+  "types": "dist-esm/index.d.ts",
+  "module": "dist-inspect-utils.esm.js",
   "homepage": "https://github.com/thefrontside/effection",
   "repository": {
     "type": "git",

--- a/packages/inspect-utils/tsconfig.cjs.json
+++ b/packages/inspect-utils/tsconfig.cjs.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig",
   "compilerOptions": {
     "rootDir": "./src",
-    "outDir": "./dist/cjs",
+    "outDir": "./dist-cjs",
     "module": "commonjs"
   },
   "references": [

--- a/packages/inspect-utils/tsconfig.esm.json
+++ b/packages/inspect-utils/tsconfig.esm.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.cjs.json",
   "compilerOptions": {
-    "outDir": "./dist/esm",
+    "outDir": "./dist-esm",
     "module": "ESNext"
   },
   "references": [

--- a/packages/inspect/package.json
+++ b/packages/inspect/package.json
@@ -14,9 +14,7 @@
   "license": "MIT",
   "files": [
     "README.md",
-    "CHANGELOG.md",
-    "dist/**/*",
-    "src/**/*"
+    "CHANGELOG.md"
   ],
   "scripts": {
     "lint": "echo noop",

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -2,22 +2,23 @@
   "name": "@effection/main",
   "version": "2.0.0-beta.7",
   "description": "Main entry point for Effection applications",
-  "main": "dist/cjs/node.js",
-  "module": "dist/esm/node.js",
-  "browser": "dist/cjs/browser.js",
+  "main": "dist-cjs/node.js",
+  "module": "dist-esm/node.js",
+  "browser": "dist-cjs/browser.js",
+  "typeDocEntry": "src/node.ts",
   "homepage": "https://github.com/thefrontside/effection",
   "repository": {
     "type": "git",
     "url": "https://github.com/thefrontside/effection.git",
     "directory": "packages/main"
   },
-  "typeDocEntry": "src/node.ts",
   "author": "Frontside Engineering <engineering@frontside.com>",
   "license": "MIT",
   "files": [
     "README.md",
     "CHANGELOG.md",
-    "dist/**/*",
+    "dist-esm/**/*",
+    "dist-cjs/**/*",
     "src/**/*"
   ],
   "scripts": {

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -17,8 +17,7 @@
   "files": [
     "README.md",
     "CHANGELOG.md",
-    "dist-esm/**/*",
-    "dist-cjs/**/*",
+    "dist-*/**/*",
     "src/**/*"
   ],
   "scripts": {

--- a/packages/main/tsconfig.cjs.json
+++ b/packages/main/tsconfig.cjs.json
@@ -2,12 +2,12 @@
   "extends": "./tsconfig",
   "compilerOptions": {
     "rootDir": "./src",
-    "outDir": "./dist/cjs",
+    "outDir": "./dist-cjs",
     "noEmit": false
   },
   "references": [
     { "path": "../process/tsconfig.cjs.json" },
-    { "path": "../core/tsconfig.cjs.json" },
+    { "path": "../core/tsconfig.cjs.json" }
   ],
   "exclude": ["./test/*"]
 }

--- a/packages/main/tsconfig.esm.json
+++ b/packages/main/tsconfig.esm.json
@@ -1,12 +1,12 @@
 {
   "extends": "./tsconfig.cjs.json",
   "compilerOptions": {
-    "outDir": "./dist/esm",
+    "outDir": "./dist-esm",
     "module": "ESNext"
   },
   "references": [
     { "path": "../process/tsconfig.esm.json" },
-    { "path": "../core/tsconfig.esm.json" },
+    { "path": "../core/tsconfig.esm.json" }
   ],
   "exclude": ["./test/*"]
 }

--- a/packages/mocha/package.json
+++ b/packages/mocha/package.json
@@ -2,22 +2,23 @@
   "name": "@effection/mocha",
   "version": "2.0.0-beta.6",
   "description": "Effection Subscriptions",
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
-  "types": "dist/esm/index.d.ts",
+  "main": "dist-cjs/index.js",
+  "module": "dist-esm/index.js",
+  "types": "dist-esm/index.d.ts",
+  "typeDocEntry": "src/index.ts",
   "homepage": "https://github.com/thefrontside/effection",
   "repository": {
     "type": "git",
     "url": "https://github.com/thefrontside/effection.git",
     "directory": "packages/mocha"
   },
-  "typeDocEntry": "src/index.ts",
   "author": "Frontside Engineering <engineering@frontside.com>",
   "license": "MIT",
   "files": [
     "README.md",
     "CHANGELOG.md",
-    "dist/**/*",
+    "dist-esm/**/*",
+    "dist-cjs/**/*",
     "src/**/*"
   ],
   "scripts": {

--- a/packages/mocha/package.json
+++ b/packages/mocha/package.json
@@ -17,8 +17,7 @@
   "files": [
     "README.md",
     "CHANGELOG.md",
-    "dist-esm/**/*",
-    "dist-cjs/**/*",
+    "dist-*/**/*",
     "src/**/*"
   ],
   "scripts": {

--- a/packages/mocha/tsconfig.cjs.json
+++ b/packages/mocha/tsconfig.cjs.json
@@ -2,11 +2,9 @@
   "extends": "./tsconfig",
   "compilerOptions": {
     "rootDir": "./src",
-    "outDir": "./dist/cjs",
+    "outDir": "./dist-cjs",
     "noEmit": false
   },
-  "references": [
-    { "path": "../core/tsconfig.cjs.json" },
-  ],
+  "references": [{ "path": "../core/tsconfig.cjs.json" }],
   "exclude": ["./test/*"]
 }

--- a/packages/mocha/tsconfig.esm.json
+++ b/packages/mocha/tsconfig.esm.json
@@ -1,11 +1,9 @@
 {
   "extends": "./tsconfig.cjs.json",
   "compilerOptions": {
-    "outDir": "./dist/esm",
+    "outDir": "./dist-esm",
     "module": "ESNext"
   },
-  "references": [
-    { "path": "../core/tsconfig.esm.json" }
-  ],
+  "references": [{ "path": "../core/tsconfig.esm.json" }],
   "exclude": ["./test/*"]
 }

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -2,22 +2,23 @@
   "name": "@effection/node",
   "version": "2.0.0-beta.7",
   "description": "Work in Node.js with Effection",
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
-  "types": "dist/esm/index.d.ts",
+  "main": "dist-cjs/index.js",
+  "module": "dist-esm/index.js",
+  "types": "dist-esm/index.d.ts",
+  "typeDocEntry": "src/index.ts",
   "homepage": "https://github.com/thefrontside/effection",
   "repository": {
     "type": "git",
     "url": "https://github.com/thefrontside/effection.git",
     "directory": "packages/node"
   },
-  "typeDocEntry": "src/index.ts",
   "author": "Frontside Engineering <engineering@frontside.com>",
   "license": "MIT",
   "files": [
     "README.md",
     "CHANGELOG.md",
-    "dist/**/*",
+    "dist-esm/**/*",
+    "dist-cjs/**/*",
     "src/**/*"
   ],
   "scripts": {

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -17,8 +17,7 @@
   "files": [
     "README.md",
     "CHANGELOG.md",
-    "dist-esm/**/*",
-    "dist-cjs/**/*",
+    "dist-*/**/*",
     "src/**/*"
   ],
   "scripts": {

--- a/packages/node/tsconfig.cjs.json
+++ b/packages/node/tsconfig.cjs.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig",
   "compilerOptions": {
     "rootDir": "./src",
-    "outDir": "./dist/cjs",
+    "outDir": "./dist-cjs",
     "noEmit": false
   },
   "references": [

--- a/packages/node/tsconfig.esm.json
+++ b/packages/node/tsconfig.esm.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.cjs.json",
   "compilerOptions": {
-    "outDir": "./dist/esm",
+    "outDir": "./dist-esm",
     "module": "ESNext"
   },
   "references": [

--- a/packages/process/package.json
+++ b/packages/process/package.json
@@ -2,22 +2,23 @@
   "name": "@effection/process",
   "version": "2.0.0-beta.7",
   "description": "Spawn and manage external processes with Effection",
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
-  "types": "dist/esm/index.d.ts",
+  "main": "dist-cjs/index.js",
+  "module": "dist-esm/index.js",
+  "types": "dist-esm/index.d.ts",
+  "typeDocEntry": "src/index.ts",
   "homepage": "https://github.com/thefrontside/effection",
   "repository": {
     "type": "git",
     "url": "https://github.com/thefrontside/effection.git",
     "directory": "packages/process"
   },
-  "typeDocEntry": "src/index.ts",
   "author": "Frontside Engineering <engineering@frontside.com>",
   "license": "MIT",
   "files": [
     "README.md",
     "CHANGELOG.md",
-    "dist/**/*",
+    "dist-esm/**/*",
+    "dist-cjs/**/*",
     "src/**/*"
   ],
   "scripts": {

--- a/packages/process/package.json
+++ b/packages/process/package.json
@@ -17,8 +17,7 @@
   "files": [
     "README.md",
     "CHANGELOG.md",
-    "dist-esm/**/*",
-    "dist-cjs/**/*",
+    "dist-*/**/*",
     "src/**/*"
   ],
   "scripts": {

--- a/packages/process/tsconfig.cjs.json
+++ b/packages/process/tsconfig.cjs.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig",
   "compilerOptions": {
     "rootDir": "./src",
-    "outDir": "./dist/cjs",
+    "outDir": "./dist-cjs",
     "noEmit": false
   },
   "references": [

--- a/packages/process/tsconfig.esm.json
+++ b/packages/process/tsconfig.esm.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.cjs.json",
   "compilerOptions": {
-    "outDir": "./dist/esm",
+    "outDir": "./dist-esm",
     "module": "ESNext"
   },
   "references": [

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -2,22 +2,23 @@
   "name": "@effection/react",
   "version": "2.0.0-beta.8",
   "description": "Hooks for integrating effection into react applications",
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
-  "types": "dist/esm/index.d.ts",
+  "main": "dist-cjs/index.js",
+  "module": "dist-esm/index.js",
+  "types": "dist-esm/index.d.ts",
+  "typeDocEntry": "src/index.ts",
   "homepage": "https://github.com/thefrontside/effection",
   "repository": {
     "type": "git",
     "url": "https://github.com/thefrontside/effection.git",
     "directory": "packages/react"
   },
-  "typeDocEntry": "src/index.ts",
   "author": "Frontside Engineering <engineering@frontside.com>",
   "license": "MIT",
   "files": [
     "README.md",
     "CHANGELOG.md",
-    "dist/**/*",
+    "dist-esm/**/*",
+    "dist-cjs/**/*",
     "src/**/*"
   ],
   "scripts": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -17,8 +17,7 @@
   "files": [
     "README.md",
     "CHANGELOG.md",
-    "dist-esm/**/*",
-    "dist-cjs/**/*",
+    "dist-*/**/*",
     "src/**/*"
   ],
   "scripts": {

--- a/packages/react/tsconfig.cjs.json
+++ b/packages/react/tsconfig.cjs.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig",
   "compilerOptions": {
     "rootDir": "./src",
-    "outDir": "./dist/cjs",
+    "outDir": "./dist-cjs",
     "noEmit": false
   },
   "references": [

--- a/packages/react/tsconfig.esm.json
+++ b/packages/react/tsconfig.esm.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.cjs.json",
   "compilerOptions": {
-    "outDir": "./dist/esm",
+    "outDir": "./dist-esm",
     "module": "ESNext"
   },
   "references": [

--- a/packages/subscription/package.json
+++ b/packages/subscription/package.json
@@ -2,22 +2,23 @@
   "name": "@effection/subscription",
   "version": "2.0.0-beta.7",
   "description": "Effection Subscriptions",
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
-  "types": "dist/esm/index.d.ts",
+  "main": "dist-cjs/index.js",
+  "module": "dist-esm/index.js",
+  "types": "dist-esm/index.d.ts",
+  "typeDocEntry": "src/index.ts",
   "homepage": "https://github.com/thefrontside/effection",
   "repository": {
     "type": "git",
     "url": "https://github.com/thefrontside/effection.git",
     "directory": "packages/subscription"
   },
-  "typeDocEntry": "src/index.ts",
   "author": "Frontside Engineering <engineering@frontside.com>",
   "license": "MIT",
   "files": [
     "README.md",
     "CHANGELOG.md",
-    "dist/**/*",
+    "dist-esm/**/*",
+    "dist-cjs/**/*",
     "src/**/*"
   ],
   "scripts": {

--- a/packages/subscription/package.json
+++ b/packages/subscription/package.json
@@ -17,8 +17,7 @@
   "files": [
     "README.md",
     "CHANGELOG.md",
-    "dist-esm/**/*",
-    "dist-cjs/**/*",
+    "dist-*/**/*",
     "src/**/*"
   ],
   "scripts": {

--- a/packages/subscription/tsconfig.cjs.json
+++ b/packages/subscription/tsconfig.cjs.json
@@ -2,11 +2,9 @@
   "extends": "./tsconfig",
   "compilerOptions": {
     "rootDir": "./src",
-    "outDir": "./dist/cjs",
+    "outDir": "./dist-cjs",
     "noEmit": false
   },
-  "references": [
-    { "path": "../core/tsconfig.cjs.json" },
-  ],
+  "references": [{ "path": "../core/tsconfig.cjs.json" }],
   "exclude": ["./test/*"]
 }

--- a/packages/subscription/tsconfig.esm.json
+++ b/packages/subscription/tsconfig.esm.json
@@ -1,11 +1,9 @@
 {
   "extends": "./tsconfig.cjs.json",
   "compilerOptions": {
-    "outDir": "./dist/esm",
+    "outDir": "./dist-esm",
     "module": "ESNext"
   },
-  "references": [
-    { "path": "../core/tsconfig.esm.json" },
-  ],
+  "references": [{ "path": "../core/tsconfig.esm.json" }],
   "exclude": ["./test/*"]
 }

--- a/packages/websocket-client/package.json
+++ b/packages/websocket-client/package.json
@@ -2,9 +2,9 @@
   "name": "@effection/websocket-client",
   "version": "2.0.0-beta.8",
   "description": "A websocket client for Effection in node and browser",
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
-  "types": "dist/esm/index.d.ts",
+  "main": "dist-cjs/index.js",
+  "module": "dist-esm/index.js",
+  "types": "dist-esm/index.d.ts",
   "typeDocEntry": "src/index.ts",
   "homepage": "https://github.com/thefrontside/effection",
   "repository": {
@@ -17,7 +17,8 @@
   "files": [
     "README.md",
     "CHANGELOG.md",
-    "dist/**/*",
+    "dist-esm/**/*",
+    "dist-cjs/**/*",
     "src/**/*"
   ],
   "scripts": {

--- a/packages/websocket-client/package.json
+++ b/packages/websocket-client/package.json
@@ -17,8 +17,7 @@
   "files": [
     "README.md",
     "CHANGELOG.md",
-    "dist-esm/**/*",
-    "dist-cjs/**/*",
+    "dist-*/**/*",
     "src/**/*"
   ],
   "scripts": {

--- a/packages/websocket-client/tsconfig.cjs.json
+++ b/packages/websocket-client/tsconfig.cjs.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig",
   "compilerOptions": {
     "rootDir": "./src",
-    "outDir": "./dist/cjs",
+    "outDir": "./dist-cjs",
     "noEmit": false
   },
   "references": [

--- a/packages/websocket-client/tsconfig.esm.json
+++ b/packages/websocket-client/tsconfig.esm.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.cjs.json",
   "compilerOptions": {
-    "outDir": "./dist/esm",
+    "outDir": "./dist-esm",
     "module": "ESNext"
   },
   "references": [

--- a/packages/websocket-server/package.json
+++ b/packages/websocket-server/package.json
@@ -2,9 +2,9 @@
   "name": "@effection/websocket-server",
   "version": "2.0.0-beta.8",
   "description": "A simple websocket server for Effection",
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
-  "types": "dist/esm/index.d.ts",
+  "main": "dist-cjs/index.js",
+  "module": "dist-esm/index.js",
+  "types": "dist-esm/index.d.ts",
   "typeDocEntry": "src/index.ts",
   "homepage": "https://github.com/thefrontside/effection",
   "repository": {
@@ -17,7 +17,8 @@
   "files": [
     "README.md",
     "CHANGELOG.md",
-    "dist/**/*",
+    "dist-esm/**/*",
+    "dist-cjs/**/*",
     "src/**/*"
   ],
   "scripts": {

--- a/packages/websocket-server/package.json
+++ b/packages/websocket-server/package.json
@@ -17,8 +17,7 @@
   "files": [
     "README.md",
     "CHANGELOG.md",
-    "dist-esm/**/*",
-    "dist-cjs/**/*",
+    "dist-*/**/*",
     "src/**/*"
   ],
   "scripts": {

--- a/packages/websocket-server/tsconfig.cjs.json
+++ b/packages/websocket-server/tsconfig.cjs.json
@@ -2,13 +2,13 @@
   "extends": "./tsconfig",
   "compilerOptions": {
     "rootDir": "./src",
-    "outDir": "./dist/cjs",
+    "outDir": "./dist-cjs",
     "noEmit": false
   },
   "references": [
     { "path": "../core/tsconfig.cjs.json" },
     { "path": "../events/tsconfig.cjs.json" },
-    { "path": "../subscription/tsconfig.cjs.json" },
+    { "path": "../subscription/tsconfig.cjs.json" }
   ],
   "exclude": ["./test/*"]
 }

--- a/packages/websocket-server/tsconfig.esm.json
+++ b/packages/websocket-server/tsconfig.esm.json
@@ -1,13 +1,13 @@
 {
   "extends": "./tsconfig.cjs.json",
   "compilerOptions": {
-    "outDir": "./dist/esm",
+    "outDir": "./dist-esm",
     "module": "ESNext"
   },
   "references": [
     { "path": "../core/tsconfig.esm.json" },
     { "path": "../events/tsconfig.esm.json" },
-    { "path": "../subscription/tsconfig.esm.json" },
+    { "path": "../subscription/tsconfig.esm.json" }
   ],
   "exclude": ["./test/*"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2546,13 +2546,6 @@ ansi-escapes@^4.2.1:
   dependencies:
     type-fest "^0.11.0"
 
-ansi-green@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.npmjs.org/ansi-green/-/ansi-green-0.1.1.tgz#8a5d9a979e458d57c40e33580b37390b8e10d0f7"
-  integrity sha1-il2al55FjVfEDjNYCzc5C44Q0Pc=
-  dependencies:
-    ansi-wrap "0.1.0"
-
 ansi-html@^0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/ansi-html/-/ansi-html-0.0.7.tgz#813584021962a9e9e6fd039f940d12f56ca7859e"
@@ -2591,11 +2584,6 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
   dependencies:
     color-convert "^2.0.1"
-
-ansi-wrap@0.1.0:
-  version "0.1.0"
-  resolved "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz#a82250ddb0015e9a27ca82e82ea603bbfa45efaf"
-  integrity sha1-qCJQ3bABXponyoLoLqYDu/pF768=
 
 anymatch@~3.1.1:
   version "3.1.1"
@@ -2748,16 +2736,6 @@ astring@^1.6.2:
   resolved "https://registry.yarnpkg.com/astring/-/astring-1.7.4.tgz#06aa7f72ad30097210dee1ae8f7d9615cd3b57d4"
   integrity sha512-WiVqDJV0AayUUH65FfUrbnBO4KD10854cyU49lK30+2n/lEkJDRqBKj/2fYGhZSD3uIt1H1VfW/pQtO07kR2Xg==
 
-async-array-reduce@^0.2.0:
-  version "0.2.1"
-  resolved "https://registry.npmjs.org/async-array-reduce/-/async-array-reduce-0.2.1.tgz#c8be010a2b5cd00dea96c81116034693dfdd82d1"
-  integrity sha1-yL4BCitc0A3qlsgRFgNGk9/dgtE=
-
-async-each@^1.0.0:
-  version "1.0.3"
-  resolved "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz#b727dbf87d7651602f06f4d4ac387f47d91b0cbf"
-  integrity sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==
-
 async-limiter@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
@@ -2900,11 +2878,6 @@ block-stream@*:
   integrity sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=
   dependencies:
     inherits "~2.0.0"
-
-bluebird@^3.4.1:
-  version "3.7.2"
-  resolved "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
-  integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
 
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.11.9:
   version "4.12.0"
@@ -3350,12 +3323,7 @@ cliui@^7.0.2:
     strip-ansi "^6.0.0"
     wrap-ansi "^7.0.0"
 
-clone-stats@^0.0.1:
-  version "0.0.1"
-  resolved "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz#b88f94a82cf38b8791d58046ea4029ad88ca99d1"
-  integrity sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=
-
-clone@^1.0.0, clone@^1.0.2:
+clone@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha1-2jCcwmPfFZlMaIypAheco8fNfH4=
@@ -3561,26 +3529,6 @@ copy-descriptor@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
-
-copy@^0.3.2:
-  version "0.3.2"
-  resolved "https://registry.npmjs.org/copy/-/copy-0.3.2.tgz#870b871d02a599b3c6ef27bc5b3d4c4102261909"
-  integrity sha512-drDFuUZctIuvSuvL9dOF/v5GxrwB1Q8eMIRlYONC0lSMEq+L2xabXP3jme8cQFdDO8cgP8JsuYhQg7JtTwezmg==
-  dependencies:
-    async-each "^1.0.0"
-    bluebird "^3.4.1"
-    extend-shallow "^2.0.1"
-    file-contents "^0.3.1"
-    glob-parent "^2.0.0"
-    graceful-fs "^4.1.4"
-    has-glob "^0.1.1"
-    is-absolute "^0.2.5"
-    lazy-cache "^2.0.1"
-    log-ok "^0.1.1"
-    matched "^0.4.1"
-    mkdirp "^0.5.1"
-    resolve-dir "^0.1.0"
-    to-file "^0.2.0"
 
 core-js-compat@^3.14.0, core-js-compat@^3.15.0:
   version "3.15.2"
@@ -4661,13 +4609,6 @@ expand-brackets@^2.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-expand-tilde@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz#0b81eba897e5a3d31d1c3d102f8f01441e559449"
-  integrity sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=
-  dependencies:
-    os-homedir "^1.0.1"
-
 expect@26.0.1:
   version "26.0.1"
   resolved "https://registry.yarnpkg.com/expect/-/expect-26.0.1.tgz#18697b9611a7e2725e20ba3ceadda49bc9865421"
@@ -4699,7 +4640,7 @@ ext@^1.1.2:
   dependencies:
     type "^2.0.0"
 
-extend-shallow@^2.0.0, extend-shallow@^2.0.1:
+extend-shallow@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-2.0.1.tgz#51af7d614ad9a9f610ea1bafbb989d6b1c56890f"
   integrity sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=
@@ -4828,62 +4769,12 @@ figures@^3.0.0:
   dependencies:
     escape-string-regexp "^1.0.5"
 
-file-contents@^0.2.4:
-  version "0.2.4"
-  resolved "https://registry.npmjs.org/file-contents/-/file-contents-0.2.4.tgz#0506f7b8eff62afa45ae45da4df9e9d47df453cb"
-  integrity sha1-BQb3uO/2KvpFrkXaTfnp1H30U8s=
-  dependencies:
-    extend-shallow "^2.0.0"
-    file-stat "^0.1.0"
-    graceful-fs "^4.1.2"
-    is-buffer "^1.1.0"
-    is-utf8 "^0.2.0"
-    lazy-cache "^0.2.3"
-    through2 "^2.0.0"
-
-file-contents@^0.3.1:
-  version "0.3.2"
-  resolved "https://registry.npmjs.org/file-contents/-/file-contents-0.3.2.tgz#a0939fed1b8cda1580266fc6b753a232fb46de53"
-  integrity sha1-oJOf7RuM2hWAJm/Gt1OiMvtG3lM=
-  dependencies:
-    define-property "^0.2.5"
-    extend-shallow "^2.0.1"
-    file-stat "^0.2.3"
-    fs-exists-sync "^0.1.0"
-    graceful-fs "^4.1.4"
-    is-buffer "^1.1.3"
-    isobject "^2.1.0"
-    lazy-cache "^2.0.1"
-    strip-bom-buffer "^0.1.1"
-    strip-bom-string "^0.1.2"
-    through2 "^2.0.1"
-    vinyl "^1.1.1"
-
 file-entry-cache@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-6.0.1.tgz#211b2dd9659cb0394b073e7323ac3c933d522027"
   integrity sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==
   dependencies:
     flat-cache "^3.0.4"
-
-file-stat@^0.1.0:
-  version "0.1.3"
-  resolved "https://registry.npmjs.org/file-stat/-/file-stat-0.1.3.tgz#d0f1961d7d10732928120a6e6955471c2a5b5411"
-  integrity sha1-0PGWHX0QcykoEgpuaVVHHCpbVBE=
-  dependencies:
-    graceful-fs "^4.1.2"
-    lazy-cache "^0.2.3"
-    through2 "^2.0.0"
-
-file-stat@^0.2.3:
-  version "0.2.3"
-  resolved "https://registry.npmjs.org/file-stat/-/file-stat-0.2.3.tgz#469a7e927d6930079624cdb38109405456cb06a9"
-  integrity sha1-Rpp+kn1pMAeWJM2zgQlAVFbLBqk=
-  dependencies:
-    fs-exists-sync "^0.1.0"
-    graceful-fs "^4.1.4"
-    lazy-cache "^2.0.1"
-    through2 "^2.0.1"
 
 filesize@^6.1.0:
   version "6.3.0"
@@ -5028,11 +4919,6 @@ fs-constants@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
   integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
-
-fs-exists-sync@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz#982d6893af918e72d08dec9e8673ff2b5a8d6add"
-  integrity sha1-mC1ok6+RjnLQjeyehnP/K1qNat0=
 
 fs-extra@^4.0.3:
   version "4.0.3"
@@ -5186,13 +5072,6 @@ git-config@0.0.7:
   dependencies:
     iniparser "~1.0.5"
 
-glob-parent@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz#81383d72db054fcccf5336daa902f182f6edbb28"
-  integrity sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=
-  dependencies:
-    is-glob "^2.0.0"
-
 glob-parent@^5.1.0, glob-parent@~5.1.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.1.tgz#b6c1ef417c4e5663ea498f1c45afac6916bbc229"
@@ -5219,7 +5098,7 @@ glob@7.1.6, glob@^7.0.0, glob@^7.1.1, glob@^7.1.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.5, glob@^7.1.4, glob@^7.1.7:
+glob@^7.1.4, glob@^7.1.7:
   version "7.1.7"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.7.tgz#3b193e9233f01d42d0b3f78294bbeeb418f94a90"
   integrity sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==
@@ -5230,24 +5109,6 @@ glob@^7.0.5, glob@^7.1.4, glob@^7.1.7:
     minimatch "^3.0.4"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
-
-global-modules@^0.2.3:
-  version "0.2.3"
-  resolved "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz#ea5a3bed42c6d6ce995a4f8a1269b5dae223828d"
-  integrity sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=
-  dependencies:
-    global-prefix "^0.1.4"
-    is-windows "^0.2.0"
-
-global-prefix@^0.1.4:
-  version "0.1.5"
-  resolved "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz#8d3bc6b8da3ca8112a160d8d496ff0462bfef78f"
-  integrity sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=
-  dependencies:
-    homedir-polyfill "^1.0.0"
-    ini "^1.3.4"
-    is-windows "^0.2.0"
-    which "^1.2.12"
 
 globals@^11.1.0:
   version "11.12.0"
@@ -5304,7 +5165,7 @@ globby@^11.0.3:
     merge2 "^1.3.0"
     slash "^3.0.0"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.4, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4:
+graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4:
   version "4.2.6"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.6.tgz#ff040b2b0853b23c3d31027523706f1885d76bee"
   integrity sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==
@@ -5365,13 +5226,6 @@ has-flag@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
-
-has-glob@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.npmjs.org/has-glob/-/has-glob-0.1.1.tgz#a261c4c2a6c667e0c77b700a7f297c39ef3aa589"
-  integrity sha1-omHEwqbGZ+DHe3AKfyl8Oe86pYk=
-  dependencies:
-    is-glob "^2.0.1"
 
 has-symbols@^1.0.1:
   version "1.0.1"
@@ -5474,13 +5328,6 @@ hmac-drbg@^1.0.1:
     hash.js "^1.0.3"
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
-
-homedir-polyfill@^1.0.0:
-  version "1.0.3"
-  resolved "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz#743298cef4e5af3e194161fbadcc2151d3a058e8"
-  integrity sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==
-  dependencies:
-    parse-passwd "^1.0.0"
 
 hosted-git-info@^2.1.4, hosted-git-info@^2.7.1:
   version "2.8.9"
@@ -5669,11 +5516,6 @@ inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.0, 
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
-ini@^1.3.4:
-  version "1.3.8"
-  resolved "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
-  integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
-
 iniparser@~1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/iniparser/-/iniparser-1.0.5.tgz#836d6befe6dfbfcee0bccf1cf9f2acc7027f783d"
@@ -5721,14 +5563,6 @@ is-absolute-url@^3.0.1:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/is-absolute-url/-/is-absolute-url-3.0.3.tgz#96c6a22b6a23929b11ea0afb1836c36ad4a5d698"
   integrity sha512-opmNIX7uFnS96NtPmhWQgQx6/NYFgsUXYMllcfzwWKUMwfo8kku1TvE6hkNcH+Q1ts5cMVrsY7j0bxXQDciu9Q==
-
-is-absolute@^0.2.5:
-  version "0.2.6"
-  resolved "https://registry.npmjs.org/is-absolute/-/is-absolute-0.2.6.tgz#20de69f3db942ef2d87b9c2da36f172235b1b5eb"
-  integrity sha1-IN5p89uULvLYe5wto28XIjWxtes=
-  dependencies:
-    is-relative "^0.2.1"
-    is-windows "^0.2.0"
 
 is-accessor-descriptor@^0.1.6:
   version "0.1.6"
@@ -5793,7 +5627,7 @@ is-boolean-object@^1.1.0:
   dependencies:
     call-bind "^1.0.2"
 
-is-buffer@^1.1.0, is-buffer@^1.1.3, is-buffer@^1.1.5:
+is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
@@ -5898,11 +5732,6 @@ is-extendable@^1.0.1:
   dependencies:
     is-plain-object "^2.0.4"
 
-is-extglob@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz#ac468177c4943405a092fc8f29760c6ffc6206c0"
-  integrity sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=
-
 is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
@@ -5929,13 +5758,6 @@ is-generator-function@^1.0.7:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/is-generator-function/-/is-generator-function-1.0.9.tgz#e5f82c2323673e7fcad3d12858c83c4039f6399c"
   integrity sha512-ZJ34p1uvIfptHCN7sFTjGibB9/oBg17sHqzDLfuwhvmN/qLVvIQXRQ8licZQ35WJ8KuEQt/etnnzQFI9C9Ue/A==
-
-is-glob@^2.0.0, is-glob@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz#d096f926a3ded5600f3fdfd91198cb0888c2d863"
-  integrity sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=
-  dependencies:
-    is-extglob "^1.0.0"
 
 is-glob@^4.0.0, is-glob@^4.0.1, is-glob@~4.0.1:
   version "4.0.1"
@@ -6029,13 +5851,6 @@ is-regex@^1.1.3:
     call-bind "^1.0.2"
     has-symbols "^1.0.2"
 
-is-relative@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz#d27f4c7d516d175fb610db84bbeef23c3bc97aa5"
-  integrity sha1-0n9MfVFtF1+2ENuEu+7yPDvJeqU=
-  dependencies:
-    is-unc-path "^0.1.1"
-
 is-resolvable@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.1.0.tgz#fb18f87ce1feb925169c9a407c19318a3206ed88"
@@ -6086,13 +5901,6 @@ is-typedarray@^1.0.0, is-typedarray@~1.0.0:
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
 
-is-unc-path@^0.1.1:
-  version "0.1.2"
-  resolved "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.2.tgz#6ab053a72573c10250ff416a3814c35178af39b9"
-  integrity sha1-arBTpyVzwQJQ/0FqOBTDUXivObk=
-  dependencies:
-    unc-path-regex "^0.1.0"
-
 is-unicode-supported@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz#3f26c76a809593b52bfa2ecb5710ed2779b522a7"
@@ -6102,21 +5910,6 @@ is-url@^1.2.2:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/is-url/-/is-url-1.2.4.tgz#04a4df46d28c4cff3d73d01ff06abeb318a1aa52"
   integrity sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==
-
-is-utf8@^0.2.0:
-  version "0.2.1"
-  resolved "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
-  integrity sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=
-
-is-valid-glob@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz#d4b55c69f51886f9b65c70d6c2622d37e29f48fe"
-  integrity sha1-1LVcafUYhvm2XHDWwmItN+KfSP4=
-
-is-windows@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz#de1aa6d63ea29dd248737b69f1ff8b8002d2108c"
-  integrity sha1-3hqm1j6indJIc3tp8f+LgALSEIw=
 
 is-windows@^1.0.2:
   version "1.0.2"
@@ -6140,7 +5933,7 @@ isexe@^2.0.0:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
 
-isobject@^2.0.0, isobject@^2.1.0:
+isobject@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-2.1.0.tgz#f065561096a3f1da2ef46272f815c840d87e0c89"
   integrity sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=
@@ -6461,18 +6254,6 @@ klaw-sync@^6.0.0:
   dependencies:
     graceful-fs "^4.1.11"
 
-lazy-cache@^0.2.3:
-  version "0.2.7"
-  resolved "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz#7feddf2dcb6edb77d11ef1d117ab5ffdf0ab1b65"
-  integrity sha1-f+3fLctu23fRHvHRF6tf/fCrG2U=
-
-lazy-cache@^2.0.1:
-  version "2.0.2"
-  resolved "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz#b9190a4f913354694840859f8a8f7084d8822264"
-  integrity sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=
-  dependencies:
-    set-getter "^0.1.0"
-
 levn@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.4.1.tgz#ae4562c007473b932a6200d403268dd2fffc6ade"
@@ -6566,14 +6347,6 @@ lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
-
-log-ok@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.npmjs.org/log-ok/-/log-ok-0.1.1.tgz#bea3dd36acd0b8a7240d78736b5b97c65444a334"
-  integrity sha1-vqPdNqzQuKckDXhza1uXxlREozQ=
-  dependencies:
-    ansi-green "^0.1.1"
-    success-symbol "^0.1.0"
 
 log-symbols@4.0.0:
   version "4.0.0"
@@ -6674,21 +6447,6 @@ marked@^2.1.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/marked/-/marked-2.1.3.tgz#bd017cef6431724fd4b27e0657f5ceb14bff3753"
   integrity sha512-/Q+7MGzaETqifOMWYEA7HVMaZb4XbcRfaOzcSsHZEith83KGlvaSG33u0SKu89Mj5h+T8V2hM+8O45Qc5XTgwA==
-
-matched@^0.4.1:
-  version "0.4.4"
-  resolved "https://registry.npmjs.org/matched/-/matched-0.4.4.tgz#56d7b7eb18033f0cf9bc52eb2090fac7dc1e89fa"
-  integrity sha1-Vte36xgDPwz5vFLrIJD6x9weifo=
-  dependencies:
-    arr-union "^3.1.0"
-    async-array-reduce "^0.2.0"
-    extend-shallow "^2.0.1"
-    fs-exists-sync "^0.1.0"
-    glob "^7.0.5"
-    has-glob "^0.1.1"
-    is-valid-glob "^0.3.0"
-    lazy-cache "^2.0.1"
-    resolve-dir "^0.1.0"
 
 md5.js@^1.3.4:
   version "1.3.5"
@@ -7361,7 +7119,7 @@ os-browserify@^0.3.0:
   resolved "https://registry.yarnpkg.com/os-browserify/-/os-browserify-0.3.0.tgz#854373c7f5c2315914fc9bfc6bd8238fdda1ec27"
   integrity sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=
 
-os-homedir@^1.0.0, os-homedir@^1.0.1:
+os-homedir@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
   integrity sha1-/7xJiDNuDoM94MFox+8VISGqf7M=
@@ -7482,11 +7240,6 @@ parse-json@^4.0.0:
   dependencies:
     error-ex "^1.3.1"
     json-parse-better-errors "^1.0.1"
-
-parse-passwd@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz#6d5b934a456993b23d37f40a382d6f1666a8e5c6"
-  integrity sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=
 
 parse5@5.1.0:
   version "5.1.0"
@@ -8252,7 +8005,7 @@ react@^17.0.2:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
 
-"readable-stream@1 || 2", readable-stream@^2.0.6, readable-stream@^2.2.2, readable-stream@~2.3.6:
+"readable-stream@1 || 2", readable-stream@^2.0.6, readable-stream@^2.2.2:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
   integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
@@ -8399,11 +8152,6 @@ repeat-string@^1.0.0, repeat-string@^1.6.1:
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
   integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=
 
-replace-ext@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz#29bbd92078a739f0bcce2b4ee41e837953522924"
-  integrity sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=
-
 request-promise-core@1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/request-promise-core/-/request-promise-core-1.1.4.tgz#3eedd4223208d419867b78ce815167d10593a22f"
@@ -8475,14 +8223,6 @@ requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
-
-resolve-dir@^0.1.0:
-  version "0.1.1"
-  resolved "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz#b219259a5602fac5c5c496ad894a6e8cc430261e"
-  integrity sha1-shklmlYC+sXFxJatiUpujMQwJh4=
-  dependencies:
-    expand-tilde "^1.2.2"
-    global-modules "^0.2.3"
 
 resolve-from@^3.0.0:
   version "3.0.0"
@@ -8694,13 +8434,6 @@ set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
-
-set-getter@^0.1.0:
-  version "0.1.1"
-  resolved "https://registry.npmjs.org/set-getter/-/set-getter-0.1.1.tgz#a3110e1b461d31a9cfc8c5c9ee2e9737ad447102"
-  integrity sha512-9sVWOy+gthr+0G9DzqqLaYNA7+5OKkSmcqjL9cBpDEaZrr3ShQlyX2cZ/O/ozE41oxn/Tt0LGEM/w4Rub3A3gw==
-  dependencies:
-    to-object-path "^0.3.0"
 
 set-value@^2.0.0, set-value@^2.0.1:
   version "2.0.1"
@@ -9120,19 +8853,6 @@ strip-ansi@^6.0.0:
   dependencies:
     ansi-regex "^5.0.0"
 
-strip-bom-buffer@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.npmjs.org/strip-bom-buffer/-/strip-bom-buffer-0.1.1.tgz#ca3ddc4919c13f9fddf30b1dff100a9835248b4d"
-  integrity sha1-yj3cSRnBP5/d8wsd/xAKmDUki00=
-  dependencies:
-    is-buffer "^1.1.0"
-    is-utf8 "^0.2.0"
-
-strip-bom-string@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-0.1.2.tgz#9c6e720a313ba9836589518405ccfb88a5f41b9c"
-  integrity sha1-nG5yCjE7qYNliVGEBcz7iKX0G5w=
-
 strip-final-newline@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
@@ -9156,11 +8876,6 @@ stylehacks@^4.0.0:
     browserslist "^4.0.0"
     postcss "^7.0.0"
     postcss-selector-parser "^3.0.0"
-
-success-symbol@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.npmjs.org/success-symbol/-/success-symbol-0.1.0.tgz#24022e486f3bf1cdca094283b769c472d3b72897"
-  integrity sha1-JAIuSG878c3KCUKDt2nEctO3KJc=
 
 supports-color@8.1.1:
   version "8.1.1"
@@ -9299,14 +9014,6 @@ text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
-through2@^2.0.0, through2@^2.0.1:
-  version "2.0.5"
-  resolved "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz#01c1e39eb31d07cb7d03a96a70823260b23132cd"
-  integrity sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==
-  dependencies:
-    readable-stream "~2.3.6"
-    xtend "~4.0.1"
-
 through@^2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
@@ -9342,20 +9049,6 @@ to-fast-properties@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
   integrity sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=
-
-to-file@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.npmjs.org/to-file/-/to-file-0.2.0.tgz#236c6c088065e570defbd15cf4b4e565be46ea93"
-  integrity sha1-I2xsCIBl5XDe+9Fc9LTlZb5G6pM=
-  dependencies:
-    define-property "^0.2.5"
-    extend-shallow "^2.0.1"
-    file-contents "^0.2.4"
-    glob-parent "^2.0.0"
-    is-valid-glob "^0.3.0"
-    isobject "^2.1.0"
-    lazy-cache "^2.0.1"
-    vinyl "^1.1.1"
 
 to-object-path@^0.3.0:
   version "0.3.0"
@@ -9637,11 +9330,6 @@ unbox-primitive@^1.0.1:
     has-symbols "^1.0.2"
     which-boxed-primitive "^1.0.2"
 
-unc-path-regex@^0.1.0:
-  version "0.1.2"
-  resolved "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz#e73dd3d7b0d7c5ed86fbac6b0ae7d8c6a69d50fa"
-  integrity sha1-5z3T17DXxe2G+6xrCufYxqadUPo=
-
 uncss@^0.17.3:
   version "0.17.3"
   resolved "https://registry.yarnpkg.com/uncss/-/uncss-0.17.3.tgz#50fc1eb4ed573ffff763458d801cd86e4d69ea11"
@@ -9887,15 +9575,6 @@ vfile@^4.0.0:
     unist-util-stringify-position "^2.0.0"
     vfile-message "^2.0.0"
 
-vinyl@^1.1.1:
-  version "1.2.0"
-  resolved "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz#5c88036cf565e5df05558bfc911f8656df218884"
-  integrity sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=
-  dependencies:
-    clone "^1.0.0"
-    clone-stats "^0.0.1"
-    replace-ext "0.0.1"
-
 vm-browserify@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
@@ -10003,7 +9682,7 @@ which@2.0.2, which@^2.0.1:
   dependencies:
     isexe "^2.0.0"
 
-which@^1.2.12, which@^1.2.9:
+which@^1.2.9:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
@@ -10090,7 +9769,7 @@ xmlchars@^2.1.1:
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
-xtend@^4.0.2, xtend@~4.0.1:
+xtend@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==


### PR DESCRIPTION
## Motivation

This supersedes #464. Copying the `package.json` is causing deeper issues.

## Approach

We instead use `dist-esm` and `dist-cjs` and this keeps the same folder depth to the root as with `src`.
