### PR TITLE
Add sideEffects field to package.json

### DIFF
--- a/.changes/side-effects.md
+++ b/.changes/side-effects.md
@@ -1,0 +1,22 @@
+---
+"@effection/atom": patch
+"@effection/channel": patch
+"@effection/core": patch
+"effection": patch
+"@effection/events": patch
+"@effection/fetch": patch
+"@effection/inspect": patch
+"@effection/inspect-server": patch
+"@effection/inspect-utils": patch
+"@effection/inspect-ui": patch
+"@effection/main": patch
+"@effection/mocha": patch
+"@effection/node": patch
+"@effection/process": patch
+"@effection/react": patch
+"@effection/subscription": patch
+"@effection/websocket-client": patch
+"@effection/websocket-server": patch
+---
+
+Add sideEffects field to package.json

--- a/.eslintignore
+++ b/.eslintignore
@@ -5,4 +5,5 @@
 /benchmarks
 /README
 /**/*.d.ts
+/**/**/*.test.ts
 /tests/typescript/*.ts

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,9 @@
 {
-  "extends": "@frontside/eslint-config"
+  "extends": "@frontside/eslint-config",
+  "plugins": [
+    "tree-shaking"
+  ],
+  "rules": {
+    "tree-shaking/no-side-effects-in-initialization": 1
+}
 }

--- a/packages/atom/package.json
+++ b/packages/atom/package.json
@@ -4,6 +4,7 @@
   "description": "State atom implementation for effection",
   "main": "dist-cjs/index.js",
   "types": "dist-esm/index.d.ts",
+  "sideEffects": false,
   "typeDocEntry": "src/index.ts",
   "homepage": "https://github.com/thefrontside/effection",
   "repository": {

--- a/packages/channel/package.json
+++ b/packages/channel/package.json
@@ -6,6 +6,7 @@
   "module": "dist-esm/index.js",
   "types": "dist-esm/index.d.ts",
   "typeDocEntry": "src/index.ts",
+  "sideEffects": false,
   "homepage": "https://github.com/thefrontside/effection",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.0-beta.7",
   "main": "dist-cjs/index.js",
   "module": "dist-esm/index.js",
+  "sideEffects": false,
   "types": "dist-esm/index.d.ts",
   "typeDocEntry": "src/index.ts",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,6 +31,7 @@
     "@types/mocha": "^7.0.2",
     "@types/node": "^16.3.2",
     "eslint": "^7.30.0",
+    "eslint-plugin-tree-shaking": "^1.9.2",
     "expect": "^25.3.0",
     "mocha": "^8.3.1",
     "rimraf": "^3.0.2",

--- a/packages/core/test/setup.ts
+++ b/packages/core/test/setup.ts
@@ -1,4 +1,5 @@
 import { Effection, Operation, sleep } from '../src/index';
+// eslint-disable-next-line tree-shaking/no-side-effects-in-initialization
 import { beforeEach } from 'mocha';
 
 beforeEach(async () => {

--- a/packages/effection/package.json
+++ b/packages/effection/package.json
@@ -8,6 +8,7 @@
     "url": "https://github.com/thefrontside/effection.git",
     "directory": "packages/effection"
   },
+  "sideEffects": false,
   "author": "Charles Lowell <cowboyd@frontside.com>",
   "license": "MIT",
   "private": false,

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -6,6 +6,7 @@
   "module": "dist-esm/index.js",
   "types": "dist-esm/index.d.ts",
   "typeDocEntry": "src/index.ts",
+  "sideEffects": false,
   "homepage": "https://github.com/thefrontside/effection",
   "repository": {
     "type": "git",

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -5,6 +5,7 @@
   "main": "dist-cjs/index.js",
   "module": "dist-esm/index.js",
   "types": "dist-esm/index.d.ts",
+  "sideEffects": false,
   "homepage": "https://github.com/thefrontside/effection",
   "repository": {
     "type": "git",

--- a/packages/inspect-server/package.json
+++ b/packages/inspect-server/package.json
@@ -5,6 +5,7 @@
   "main": "dist-cjs/index.js",
   "types": "dist-esm/index.d.ts",
   "module": "dist-esm/index.js",
+  "sideEffects": false,
   "homepage": "https://github.com/thefrontside/effection",
   "repository": {
     "type": "git",

--- a/packages/inspect-ui/package.json
+++ b/packages/inspect-ui/package.json
@@ -6,6 +6,9 @@
   "types": "index.d.ts",
   "browser": "dist/index.html",
   "module": "dist/inspect-ui.esm.js",
+  "sideEffects": [
+    "*.css"
+  ],
   "homepage": "https://github.com/thefrontside/effection",
   "repository": {
     "type": "git",

--- a/packages/inspect-ui/package.json
+++ b/packages/inspect-ui/package.json
@@ -7,7 +7,8 @@
   "browser": "dist/index.html",
   "module": "dist/inspect-ui.esm.js",
   "sideEffects": [
-    "*.css"
+    "*.css",
+    "./index.js"
   ],
   "homepage": "https://github.com/thefrontside/effection",
   "repository": {

--- a/packages/inspect-utils/package.json
+++ b/packages/inspect-utils/package.json
@@ -6,6 +6,7 @@
   "types": "dist-esm/index.d.ts",
   "module": "dist-inspect-utils.esm.js",
   "homepage": "https://github.com/thefrontside/effection",
+  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "https://github.com/thefrontside/effection.git",

--- a/packages/inspect/package.json
+++ b/packages/inspect/package.json
@@ -4,6 +4,7 @@
   "description": "Injects an inspector into an Effection application",
   "main": "index.cjs.js",
   "module": "index.esm.js",
+  "sideEffects": false,
   "homepage": "https://github.com/thefrontside/effection",
   "repository": {
     "type": "git",

--- a/packages/inspect/package.json
+++ b/packages/inspect/package.json
@@ -4,7 +4,6 @@
   "description": "Injects an inspector into an Effection application",
   "main": "index.cjs.js",
   "module": "index.esm.js",
-  "sideEffects": false,
   "homepage": "https://github.com/thefrontside/effection",
   "repository": {
     "type": "git",

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -6,6 +6,7 @@
   "module": "dist-esm/node.js",
   "browser": "dist-cjs/browser.js",
   "typeDocEntry": "src/node.ts",
+  "sideEffects": false,
   "homepage": "https://github.com/thefrontside/effection",
   "repository": {
     "type": "git",

--- a/packages/mocha/package.json
+++ b/packages/mocha/package.json
@@ -6,7 +6,6 @@
   "module": "dist-esm/index.js",
   "types": "dist-esm/index.d.ts",
   "typeDocEntry": "src/index.ts",
-  "sideEffects": false,
   "homepage": "https://github.com/thefrontside/effection",
   "repository": {
     "type": "git",

--- a/packages/mocha/package.json
+++ b/packages/mocha/package.json
@@ -6,6 +6,7 @@
   "module": "dist-esm/index.js",
   "types": "dist-esm/index.d.ts",
   "typeDocEntry": "src/index.ts",
+  "sideEffects": false,
   "homepage": "https://github.com/thefrontside/effection",
   "repository": {
     "type": "git",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -6,6 +6,7 @@
   "module": "dist-esm/index.js",
   "types": "dist-esm/index.d.ts",
   "typeDocEntry": "src/index.ts",
+  "sideEffects": false,
   "homepage": "https://github.com/thefrontside/effection",
   "repository": {
     "type": "git",

--- a/packages/process/package.json
+++ b/packages/process/package.json
@@ -6,6 +6,7 @@
   "module": "dist-esm/index.js",
   "types": "dist-esm/index.d.ts",
   "typeDocEntry": "src/index.ts",
+  "sideEffects": false,
   "homepage": "https://github.com/thefrontside/effection",
   "repository": {
     "type": "git",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -6,6 +6,7 @@
   "module": "dist-esm/index.js",
   "types": "dist-esm/index.d.ts",
   "typeDocEntry": "src/index.ts",
+  "sideEffects": false,
   "homepage": "https://github.com/thefrontside/effection",
   "repository": {
     "type": "git",

--- a/packages/subscription/package.json
+++ b/packages/subscription/package.json
@@ -6,6 +6,7 @@
   "module": "dist-esm/index.js",
   "types": "dist-esm/index.d.ts",
   "typeDocEntry": "src/index.ts",
+  "sideEffects": false,
   "homepage": "https://github.com/thefrontside/effection",
   "repository": {
     "type": "git",

--- a/packages/websocket-client/package.json
+++ b/packages/websocket-client/package.json
@@ -7,6 +7,7 @@
   "types": "dist-esm/index.d.ts",
   "typeDocEntry": "src/index.ts",
   "homepage": "https://github.com/thefrontside/effection",
+  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "https://github.com/thefrontside/effection.git",

--- a/packages/websocket-server/package.json
+++ b/packages/websocket-server/package.json
@@ -6,6 +6,7 @@
   "module": "dist-esm/index.js",
   "types": "dist-esm/index.d.ts",
   "typeDocEntry": "src/index.ts",
+  "sideEffects": false,
   "homepage": "https://github.com/thefrontside/effection",
   "repository": {
     "type": "git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4356,6 +4356,11 @@ eslint-plugin-react@^7.24.0:
     resolve "^2.0.0-next.3"
     string.prototype.matchall "^4.0.5"
 
+eslint-plugin-tree-shaking@^1.9.2:
+  version "1.9.2"
+  resolved "https://registry.npmjs.org/eslint-plugin-tree-shaking/-/eslint-plugin-tree-shaking-1.9.2.tgz#f3055ba6baf596336fe55c7a2ef5fc6d89b22cbc"
+  integrity sha512-3nF/ea5aeH1Qby7WPrbLGm/5oYH8Oh+8GQiNrqT6L/AS7chciKo+8tvghGAYogqAHkHLYhgCrJkjgomPY7kthg==
+
 eslint-rule-composer@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz#79320c927b0c5c0d3d3d2b76c8b4a488f25bbaf9"


### PR DESCRIPTION
## Motivation

add "sideEffects" field to all package.json so that bundlers like webpack are able to tree shake

## Approach

I have added this to all packages apart from `@effection/inspect-ui`.

```json
"sideEffects: false
```

We would need to mark anything that has side-effects like any top level calls like below

```ts
import { registerThing } from 'thing-registry';
const store = registerThing( THING_KEY, { /* ... */ } );
```
