### PR TITLE
Volta step in version publish workflow

### DIFF
--- a/.github/workflows/covector-version-or-publish.yml
+++ b/.github/workflows/covector-version-or-publish.yml
@@ -25,6 +25,7 @@ jobs:
         run: |
           git config --global user.name "${{ github.event.pusher.name }}"
           git config --global user.email "${{ github.event.pusher.email }}"
+      - uses: volta-cli/action@v1
       - run: yarn install --immutable
       - run: yarn prepack
       - name: covector version or publish (publish when no change files present)


### PR DESCRIPTION
## Motivation

Adding volta step in our workflows so that it will use the `node` and `npm` versions specified in `package.json`.

## Approach

- `Preview` workflow already has it. `Status` and `synchronize-npm-tags` do not need it.
- Added it to `version-or-publish` workflow.
