### PR TITLE
Expand and collapse tasks in the inspector

### DIFF
--- a/.changes/inspector-collapse-task.md
+++ b/.changes/inspector-collapse-task.md
@@ -1,0 +1,5 @@
+---
+"@effection/inspect-ui": "patch"
+---
+
+Expand and collapse tasks in inspector

--- a/packages/inspect-ui/app/task-tree.tsx
+++ b/packages/inspect-ui/app/task-tree.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { InspectTree } from '@effection/inspect-utils';
 
 const ICONS = {
@@ -17,16 +17,24 @@ type TreeProps = {
 }
 
 export function TaskTree({ tree }: TreeProps): JSX.Element {
+  let [isOpen, setOpen] = useState<boolean>(true);
   let name = tree.labels.name || 'task';
   let children = Object.values(tree.children);
   let labels = Object.entries(tree.labels).filter(([key]) => key !== 'name');
   return (
     <div className={`task ${tree.state}`}>
       <div className={`task--state ${tree.state}`}>
-        {ICONS[tree.state]}
+        <button title={(isOpen ? 'Collapse' : 'Expand') + ' ' + name} onClick={() => setOpen(!isOpen)}>
+          {isOpen ? '-' : '+'}
+        </button>
       </div>
       <div className="task--title">
-        <div className="task--title--name">{name} </div>
+        <div className="task--title--icon">
+          {ICONS[tree.state]}&nbsp;
+        </div>
+        <div className="task--title--name">
+          {name}
+        </div>
         {
           labels.map(([key, value]) => {
             return (
@@ -41,26 +49,30 @@ export function TaskTree({ tree }: TreeProps): JSX.Element {
         <div className="task--title--id">[{tree.id}] </div>
       </div>
 
-      {tree.yieldingTo ? <>
-        <div className="task--yielding-to">
-          <TaskTree tree={tree.yieldingTo}/>
+      {isOpen ? <>
+        <div className="task--details">
+          {tree.yieldingTo ? <>
+            <div className="task--yielding-to">
+              <TaskTree tree={tree.yieldingTo}/>
+            </div>
+          </> : null}
+
+          {children.length ? <>
+            <h6 className="task--section-header">Children</h6>
+
+            <ol className="task--list">
+              {
+                children.map((child) => {
+                  return (
+                    <li className="task--list--element" key={child.id}>
+                      <TaskTree tree={child}/>
+                    </li>
+                  );
+                })
+              }
+            </ol>
+          </> : null}
         </div>
-      </> : null}
-
-      {children.length ? <>
-        <h6 className="task--section-header">Children</h6>
-
-        <ol className="task--list">
-          {
-            children.map((child) => {
-              return (
-                <li className="task--list--element" key={child.id}>
-                  <TaskTree tree={child}/>
-                </li>
-              );
-            })
-          }
-        </ol>
       </> : null}
     </div>
   );

--- a/packages/inspect-ui/app/task-tree.tsx
+++ b/packages/inspect-ui/app/task-tree.tsx
@@ -24,9 +24,11 @@ export function TaskTree({ tree }: TreeProps): JSX.Element {
   return (
     <div className={`task ${tree.state}`}>
       <div className={`task--state ${tree.state}`}>
-        <button title={(isOpen ? 'Collapse' : 'Expand') + ' ' + name} onClick={() => setOpen(!isOpen)}>
-          {isOpen ? '-' : '+'}
-        </button>
+        {tree.yieldingTo || children.length ? <>
+          <button title={(isOpen ? 'Collapse' : 'Expand') + ' ' + name} onClick={() => setOpen(!isOpen)}>
+            {isOpen ? '-' : '+'}
+          </button>
+        </> : null}
       </div>
       <div className="task--title">
         <div className="task--title--icon">

--- a/packages/inspect-ui/test/task-tree.test.tsx
+++ b/packages/inspect-ui/test/task-tree.test.tsx
@@ -1,6 +1,7 @@
 import './setup';
 import expect from 'expect';
 import { describe, it } from '@effection/mocha';
+import { Button } from '@bigtest/interactor';
 import { Task, YieldingToTask, ChildTask, Label } from './interactors';
 
 import React from 'react';
@@ -10,40 +11,41 @@ import { InspectTree } from '@effection/inspect-utils';
 
 import { TaskTree } from '../app/task-tree';
 
-describe("TaskTree", () => {
-  it("Renders a basic task", function*() {
-    let tree: InspectTree = {
-      id: 123,
-      labels: { name: 'Some task', frobs: 'quox' },
+let tree: InspectTree = {
+  id: 123,
+  labels: { name: 'Some task', frobs: 'quox' },
+  type: 'generator function',
+  state: 'running',
+  children: {
+    777: {
+      id: 777,
+      labels: { name: 'First child' },
       type: 'generator function',
       state: 'running',
-      children: {
-        777: {
-          id: 777,
-          labels: { name: 'First child' },
-          type: 'generator function',
-          state: 'running',
-          yieldingTo: undefined,
-          children: {},
-        },
-        999: {
-          id: 999,
-          labels: { name: 'Second child' },
-          type: 'generator function',
-          state: 'running',
-          yieldingTo: undefined,
-          children: {},
-        }
-      },
-      yieldingTo: {
-        id: 556,
-        labels: { name: 'Yielding to this' },
-        type: 'async function',
-        state: 'running',
-        yieldingTo: undefined,
-        children: {},
-      }
+      yieldingTo: undefined,
+      children: {},
+    },
+    999: {
+      id: 999,
+      labels: { name: 'Second child' },
+      type: 'generator function',
+      state: 'running',
+      yieldingTo: undefined,
+      children: {},
     }
+  },
+  yieldingTo: {
+    id: 556,
+    labels: { name: 'Yielding to this' },
+    type: 'async function',
+    state: 'running',
+    yieldingTo: undefined,
+    children: {},
+  }
+}
+
+describe("TaskTree", () => {
+  it("Renders a basic task", function*() {
     ReactDOM.render(<TaskTree tree={tree}/>, document.querySelector('#test'));
 
     yield Task('Some task').has({ taskId: '[123]', type: 'generator function' });
@@ -51,5 +53,15 @@ describe("TaskTree", () => {
     yield Task('Some task').find(YieldingToTask('Yielding to this')).has({ taskId: '[556]' });
     yield Task('Some task').find(ChildTask('First child')).has({ taskId: '[777]' });
     yield Task('Some task').find(ChildTask('Second child')).has({ taskId: '[999]' });
+  });
+
+  it("can collapse a task", function*() {
+    ReactDOM.render(<TaskTree tree={tree}/>, document.querySelector('#test'));
+
+    yield Task('Some task').find(ChildTask('Second child')).exists();
+    yield Task('Some task').find(Button({ title: 'Collapse Some task' })).click();
+    yield Task('Some task').find(ChildTask('Second child')).absent();
+    yield Task('Some task').find(Button({ title: 'Expand Some task' })).click();
+    yield Task('Some task').find(ChildTask('Second child')).exists();
   });
 });


### PR DESCRIPTION
There can be a lot of information in the inspector, it is useful to be able to expand and collapse individual tasks, to minimize noise.

<img width="1006" alt="Screenshot 2021-08-10 at 11 37 59" src="https://user-images.githubusercontent.com/134/128844733-2679c193-e26a-4893-82b6-c45e0c64a48a.png">
<img width="1006" alt="Screenshot 2021-08-10 at 11 38 03" src="https://user-images.githubusercontent.com/134/128844752-121472cd-819e-4e12-b1a0-1155520ab0ab.png">
