### PR TITLE
Don't use deprecated `task.spawn`.

### DIFF
--- a/packages/events/src/on.ts
+++ b/packages/events/src/on.ts
@@ -15,7 +15,7 @@ import { EventSource, addListener, removeListener } from './event-source';
  * log every click in a web page:
  *
  * ```javascript
- * task.spawn(on(document, 'click').forEach(event => {
+ * yield spawn(on(document, 'click').forEach(event => {
  *   console.log(`click at (${event.pageX}, ${event.pageY})`);
  * }));
  * ```
@@ -26,7 +26,7 @@ import { EventSource, addListener, removeListener } from './event-source';
  *
  * ```javascript
  * let buffer = '';
- * task.spawn(on(process.stdin, 'data').forEach(data => {
+ * yield spawn(on(process.stdin, 'data').forEach(data => {
  *   buffer += data;
  * }));
  */
@@ -58,7 +58,7 @@ export function on<T = unknown>(source: EventSource, name: string): Stream<T, vo
  * ```javascript
  * let emitter = new EventEmitter();
  *
- * task.spawn(onEmit(emitter, 'multiplication').forEach(([left, right]) => {
+ * yield spawn(onEmit(emitter, 'multiplication').forEach(([left, right]) => {
  *   console.log(`${left} times ${right} = ${left * right}!`);
  * }));
  *

--- a/packages/inspect-server/examples/basic.ts
+++ b/packages/inspect-server/examples/basic.ts
@@ -6,13 +6,13 @@ import { runInspectServer } from '../src/index';
 runInspectServer({ port: 47000 });
 
 main(function *myProgram(task) {
-  task.spawn(undefined, { labels: { name: 'someServer', frobs: 123, quantile: 'upper' } });
-  task.spawn(undefined, { labels: { name: 'anotherTask' } });
-  task.spawn(function* willComplete() {
+  task.run(undefined, { labels: { name: 'someServer', frobs: 123, quantile: 'upper' } });
+  task.run(undefined, { labels: { name: 'anotherTask' } });
+  task.run(function* willComplete() {
     yield sleep(10000);
     return 123;
   });
-  task.spawn(function* willBlowUp() {
+  task.run(function* willBlowUp() {
     yield sleep(10000);
     throw new Error('boom!');
   }, { ignoreError: true });


### PR DESCRIPTION
While we have removed usage os `task.spawn` in favour of all `task.run` in all code paths, there were a few instances in doc comments and examples left. This fixes those issues.