### PR TITLE
Introduce task scope

### DIFF
--- a/.changes/shared-event-loop.md
+++ b/.changes/shared-event-loop.md
@@ -1,0 +1,5 @@
+---
+"@effection/core": "minor"
+---
+
+Share internal run loop among task, task future and task controller. Prevents race conditions which cause internal errors.

--- a/.changes/task-scope.md
+++ b/.changes/task-scope.md
@@ -1,0 +1,5 @@
+---
+"@effection/core": "minor"
+---
+
+Introduce task scope as an alternative to resources for being able to access the outer scope of an operation

--- a/.changes/task-to-string.md
+++ b/.changes/task-to-string.md
@@ -1,0 +1,5 @@
+---
+"@effection/core": "minor"
+---
+
+Add `toString()` method to task for nicely formatted rendering of task structure

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,7 +37,9 @@
     "ts-node": "^10.1.0",
     "typescript": "^4.3.5"
   },
-  "dependencies": {},
+  "dependencies": {
+    "chalk": "^4.1.2"
+  },
   "volta": {
     "extends": "../../package.json"
   }

--- a/packages/core/src/controller/controller.ts
+++ b/packages/core/src/controller/controller.ts
@@ -1,4 +1,5 @@
 import type { Task } from '../task';
+import type { RunLoop } from '../run-loop';
 import type { Operation } from '../operation';
 import { isResource, isResolution, isFuture, isPromise, isGenerator } from '../predicates';
 import { createFunctionController } from './function-controller';
@@ -19,17 +20,18 @@ export interface Controller<TOut> {
 }
 
 export type Options = {
+  runLoop: RunLoop;
   resourceScope?: Task;
   onYieldingToChange?: (task: Task | undefined) => void;
 }
 
-export function createController<T>(task: Task<T>, operation: Operation<T>, options: Options = {}): Controller<T> {
+export function createController<T>(task: Task<T>, operation: Operation<T>, options: Options): Controller<T> {
   if (typeof(operation) === 'function') {
     return createFunctionController(task, operation, () => createController(task, operation(task), options));
   } else if(!operation) {
     return createSuspendController();
   } else if (isResource(operation)) {
-    return createResourceController(task, operation);
+    return createResourceController(task, operation, options);
   } else if (isFuture<T>(operation)) {
     return createFutureController(task, operation);
   } else if (isResolution<T>(operation)) {

--- a/packages/core/src/controller/controller.ts
+++ b/packages/core/src/controller/controller.ts
@@ -14,6 +14,7 @@ import { Future } from '../future';
 export interface Controller<TOut> {
   type: string;
   operation: Operation<TOut>;
+  resourceTask?: Task;
   start(): void;
   halt(): void;
   future: Future<TOut>;

--- a/packages/core/src/controller/controller.ts
+++ b/packages/core/src/controller/controller.ts
@@ -31,7 +31,7 @@ export function createController<T>(task: Task<T>, operation: Operation<T>, opti
   } else if(!operation) {
     return createSuspendController();
   } else if (isResource(operation)) {
-    return createResourceController(task, operation, options);
+    return createResourceController(task, operation);
   } else if (isFuture<T>(operation)) {
     return createFutureController(task, operation);
   } else if (isResolution<T>(operation)) {

--- a/packages/core/src/controller/controller.ts
+++ b/packages/core/src/controller/controller.ts
@@ -21,7 +21,6 @@ export interface Controller<TOut> {
 
 export type Options = {
   runLoop: RunLoop;
-  resourceScope?: Task;
   onYieldingToChange?: (task: Task | undefined) => void;
 }
 

--- a/packages/core/src/controller/function-controller.ts
+++ b/packages/core/src/controller/function-controller.ts
@@ -1,17 +1,9 @@
 import { Task } from '../task';
 import { Controller } from './controller';
-import { createFuture, Future } from '../future';
-import { Operation, OperationFunction } from '../operation';
+import { createFuture } from '../future';
+import { OperationFunction } from '../operation';
 
-interface FunctionController<TOut> {
-  readonly type: string;
-  readonly operation: Operation<TOut>;
-  future: Future<TOut>;
-  start: () => void;
-  halt: () => void;
-}
-
-export function createFunctionController<TOut>(task: Task<TOut>, fn: OperationFunction<TOut>, createController: () => Controller<TOut>): FunctionController<TOut> {
+export function createFunctionController<TOut>(task: Task<TOut>, fn: OperationFunction<TOut>, createController: () => Controller<TOut>): Controller<TOut> {
   let delegate: Controller<TOut>;
   let { produce, future } = createFuture<TOut>();
 
@@ -47,6 +39,9 @@ export function createFunctionController<TOut>(task: Task<TOut>, fn: OperationFu
     },
     get operation() {
       return delegate?.operation;
+    },
+    get resourceTask() {
+      return delegate?.resourceTask;
     },
     future,
     start,

--- a/packages/core/src/controller/iterator-controller.ts
+++ b/packages/core/src/controller/iterator-controller.ts
@@ -45,7 +45,7 @@ export function createIteratorController<TOut>(task: Task<TOut>, iterator: Opera
           produce({ state: 'completed', value: next.value });
         }
       } else {
-        yieldingTo = createTask(next.value, { resourceScope: options.resourceScope || task, ignoreError: true });
+        yieldingTo = createTask(next.value, { scope: options.resourceTask || task, ignoreError: true });
         yieldingTo.consume(trap);
         yieldingTo.start();
         options.onYieldingToChange && options.onYieldingToChange(yieldingTo);

--- a/packages/core/src/controller/iterator-controller.ts
+++ b/packages/core/src/controller/iterator-controller.ts
@@ -3,7 +3,6 @@ import { OperationIterator } from '../operation';
 import { createTask, Task } from '../task';
 import { Operation } from '../operation';
 import { createFuture, Value } from '../future';
-import { createRunLoop } from '../run-loop';
 
 const claimed = Symbol.for('effection/v2/iterator-controller/claimed');
 
@@ -13,12 +12,11 @@ interface Claimable {
   [claimed]?: boolean;
 }
 
-export function createIteratorController<TOut>(task: Task<TOut>, iterator: OperationIterator<TOut> & Claimable, options: Options = {}): Controller<TOut> {
+export function createIteratorController<TOut>(task: Task<TOut>, iterator: OperationIterator<TOut> & Claimable, options: Options): Controller<TOut> {
   let didHalt = false;
   let yieldingTo: Task | undefined;
 
   let { produce, future } = createFuture<TOut>();
-  let runLoop = createRunLoop();
 
   function start() {
     if (iterator[claimed]) {
@@ -32,7 +30,7 @@ export function createIteratorController<TOut>(task: Task<TOut>, iterator: Opera
   }
 
   function resume(iter: NextFn) {
-    runLoop.run(() => {
+    options.runLoop.run(() => {
       let next;
       try {
         next = iter();

--- a/packages/core/src/controller/iterator-controller.ts
+++ b/packages/core/src/controller/iterator-controller.ts
@@ -45,7 +45,7 @@ export function createIteratorController<TOut>(task: Task<TOut>, iterator: Opera
           produce({ state: 'completed', value: next.value });
         }
       } else {
-        yieldingTo = createTask(next.value, { scope: options.resourceTask || task, ignoreError: true });
+        yieldingTo = createTask(next.value, { scope: task.options.yieldScope || task, ignoreError: true });
         yieldingTo.consume(trap);
         yieldingTo.start();
         options.onYieldingToChange && options.onYieldingToChange(yieldingTo);

--- a/packages/core/src/controller/resource-controller.ts
+++ b/packages/core/src/controller/resource-controller.ts
@@ -1,4 +1,3 @@
-import { createIteratorController } from './iterator-controller';
 import { Controller } from './controller';
 import { Resource } from '../operation';
 import { Task } from '../task';

--- a/packages/core/src/controller/resource-controller.ts
+++ b/packages/core/src/controller/resource-controller.ts
@@ -1,10 +1,10 @@
-import { Controller } from './controller';
+import { Controller, Options } from './controller';
 import { createIteratorController } from './iterator-controller';
 import { Resource } from '../operation';
 import { Task } from '../task';
 import { createFuture } from '../future';
 
-export function createResourceController<TOut>(task: Task<TOut>, resource: Resource<TOut>): Controller<TOut> {
+export function createResourceController<TOut>(task: Task<TOut>, resource: Resource<TOut>, options: Options): Controller<TOut> {
   let delegate: Controller<TOut>;
   let { resourceScope } = task.options;
   let { produce, future } = createFuture<TOut>();
@@ -20,7 +20,7 @@ export function createResourceController<TOut>(task: Task<TOut>, resource: Resou
       produce({ state: 'errored', error });
       return;
     }
-    delegate = createIteratorController(task, init, { resourceScope });
+    delegate = createIteratorController(task, init, { resourceScope, runLoop: options.runLoop });
     delegate.future.consume((value) => {
       produce(value);
     });

--- a/packages/core/src/controller/resource-controller.ts
+++ b/packages/core/src/controller/resource-controller.ts
@@ -6,21 +6,23 @@ import { createFuture } from '../future';
 
 export function createResourceController<TOut>(task: Task<TOut>, resource: Resource<TOut>, options: Options): Controller<TOut> {
   let delegate: Controller<TOut>;
-  let { resourceScope } = task.options;
+  let { scope } = task.options;
   let { produce, future } = createFuture<TOut>();
 
   function start() {
-    if(!resourceScope) {
+    if(!scope) {
       throw new Error('cannot spawn resource in task which has no resource scope');
     }
     let init;
     try {
-      init = resource.init(resourceScope, task);
+      init = resource.init(scope, task);
     } catch(error) {
       produce({ state: 'errored', error });
       return;
     }
-    delegate = createIteratorController(task, init, { resourceScope, runLoop: options.runLoop });
+    let name = resource.name || resource.labels?.name || 'resource';
+    let resourceTask = scope.run(undefined, { labels: { name, type: 'resource' } });
+    delegate = createIteratorController(task, init, { resourceTask, runLoop: options.runLoop });
     delegate.future.consume((value) => {
       produce(value);
     });

--- a/packages/core/src/controller/resource-controller.ts
+++ b/packages/core/src/controller/resource-controller.ts
@@ -1,12 +1,12 @@
-import { Controller, Options } from './controller';
 import { createIteratorController } from './iterator-controller';
+import { Controller } from './controller';
 import { Resource } from '../operation';
 import { Task } from '../task';
 import { createFuture } from '../future';
 
-export function createResourceController<TOut>(task: Task<TOut>, resource: Resource<TOut>, options: Options): Controller<TOut> {
-  let delegate: Controller<TOut>;
+export function createResourceController<TOut>(task: Task<TOut>, resource: Resource<TOut>): Controller<TOut> {
   let resourceTask: Task;
+  let initTask: Task<TOut>;
   let { scope } = task.options;
   let { produce, future } = createFuture<TOut>();
 
@@ -18,28 +18,21 @@ export function createResourceController<TOut>(task: Task<TOut>, resource: Resou
     let name = resource.name || resource.labels?.name || 'resource';
     let labels = resource.labels || {};
 
-    resourceTask = scope.run(undefined, { labels: { ...labels, name, type: 'resource' } });
+    resourceTask = scope.run(undefined, { type: 'resource', labels: { ...labels, name } });
 
-    let iterator;
-    try {
-      iterator = resource.init(resourceTask, task);
-    } catch(error) {
-      produce({ state: 'errored', error });
-      return;
-    }
-    delegate = createIteratorController(task, iterator, { resourceTask, runLoop: options.runLoop });
-    delegate.future.consume((value) => {
-      produce(value);
+    initTask = resourceTask.run((task) => resource.init(resourceTask, task), {
+      yieldScope: resourceTask,
+      labels: { name: 'init' }
     });
-    delegate.start();
+    initTask.consume(produce);
   }
 
   function halt() {
-    delegate.halt();
+    initTask?.halt();
   }
 
   return {
-    type: 'resource',
+    type: 'resource constructor',
     start,
     halt,
     future,

--- a/packages/core/src/controller/resource-controller.ts
+++ b/packages/core/src/controller/resource-controller.ts
@@ -16,8 +16,9 @@ export function createResourceController<TOut>(task: Task<TOut>, resource: Resou
     }
 
     let name = resource.name || resource.labels?.name || 'resource';
+    let labels = resource.labels || {};
 
-    resourceTask = scope.run(undefined, { labels: { name, type: 'resource' } });
+    resourceTask = scope.run(undefined, { labels: { ...labels, name, type: 'resource' } });
 
     let iterator;
     try {

--- a/packages/core/src/future.ts
+++ b/packages/core/src/future.ts
@@ -3,10 +3,6 @@ import { createRunLoop, RunLoop } from './run-loop';
 
 export type State = 'pending' | 'errored' | 'completed' | 'halted';
 
-export type Options = {
-  runLoop?: RunLoop;
-}
-
 export type Value<T> =
   | { state: 'errored'; error: Error }
   | { state: 'completed'; value: T }
@@ -31,8 +27,12 @@ export interface NewFuture<T> {
   resolve(value: Value<T>): void;
 }
 
-export function createFuture<T>(options: Options = {}): NewFuture<T> {
-  let runLoop = options.runLoop || createRunLoop('future');
+
+export function createFuture<T>(): NewFuture<T> {
+  return createFutureOnRunLoop(createRunLoop('future'));
+}
+
+export function createFutureOnRunLoop<T>(runLoop: RunLoop): NewFuture<T> {
   let consumers: Consumer<T>[] = [];
   let result: Value<T>;
 

--- a/packages/core/src/future.ts
+++ b/packages/core/src/future.ts
@@ -1,7 +1,11 @@
 import { HaltError } from './halt-error';
-import { createRunLoop } from './run-loop';
+import { createRunLoop, RunLoop } from './run-loop';
 
 export type State = 'pending' | 'errored' | 'completed' | 'halted';
+
+export type Options = {
+  runLoop?: RunLoop;
+}
 
 export type Value<T> =
   | { state: 'errored'; error: Error }
@@ -27,8 +31,8 @@ export interface NewFuture<T> {
   resolve(value: Value<T>): void;
 }
 
-export function createFuture<T>(): NewFuture<T> {
-  let runLoop = createRunLoop();
+export function createFuture<T>(options: Options = {}): NewFuture<T> {
+  let runLoop = options.runLoop || createRunLoop('future');
   let consumers: Consumer<T>[] = [];
   let result: Value<T>;
 

--- a/packages/core/src/operations/ensure.ts
+++ b/packages/core/src/operations/ensure.ts
@@ -1,22 +1,25 @@
-import { Operation, Resource } from '../operation';
-import { spawn } from './spawn';
+import { Operation } from '../operation';
+import { createFuture } from '../future';
 
-
-export function ensure<T>(fn: () => Operation<T> | void): Resource<undefined> {
-  return {
-    name: 'ensure',
-    *init() {
-      yield spawn(function*() {
-        try {
-          yield;
-        } finally {
-          let result = fn();
-          if(result) {
-            yield result;
-          }
-        }
-      }, { labels: { name: 'ensureHandler' } });
-      return undefined;
+export function ensure<T>(fn: () => Operation<T> | void): Operation<undefined> {
+  return function ensure(task) {
+    let { scope } = task.options;
+    if(!scope) {
+      throw new Error('cannot run `ensure` on a task without scope');
     }
+    scope.run(function* ensureHandler() {
+      try {
+        yield;
+      } finally {
+        let result = fn();
+        if(result) {
+          yield result;
+        }
+      }
+    });
+
+    let { future, produce } = createFuture<undefined>();
+    produce({ state: 'completed', value: undefined });
+    return future;
   };
 }

--- a/packages/core/src/operations/label.ts
+++ b/packages/core/src/operations/label.ts
@@ -1,11 +1,17 @@
-import { Resource } from '../operation';
+import { Operation } from '../operation';
 import { Labels } from '../labels';
+import { createFuture } from '../future';
+import { withLabels } from '../labels';
 
-export function label(labels: Labels): Resource<void> {
-  return {
-    name: 'label',
-    *init(scope) {
-      scope.setLabels(labels);
+export function label(labels: Labels): Operation<void> {
+  return withLabels((task) => {
+    let { scope } = task.options;
+    if(!scope) {
+      throw new Error('cannot run `label` on a task without scope');
     }
-  };
+    scope.setLabels(labels);
+    let { future, produce } = createFuture<undefined>();
+    produce({ state: 'completed', value: undefined });
+    return future;
+  }, { name: 'label' });
 }

--- a/packages/core/src/operations/spawn.ts
+++ b/packages/core/src/operations/spawn.ts
@@ -1,18 +1,26 @@
-import { Operation, Resource } from '../operation';
+import { Operation, OperationFunction } from '../operation';
+import { createFuture } from '../future';
 import type { Task, TaskOptions } from '../task';
 
-interface Spawn<T> extends Resource<Task<T>> {
+interface Spawn<T> extends OperationFunction<Task<T>> {
   within(scope: Task): Operation<Task<T>>;
 }
 
 export function spawn<T>(operation?: Operation<T>, options?: TaskOptions): Spawn<T> {
-  function* init(scope: Task) {
-    return scope.run(operation, options);
+  function spawn(task: Task) {
+    let { scope } = task.options;
+    if(!scope) {
+      throw new Error('cannot run `spawn` on a task without scope');
+    }
+    let result = scope.run(operation, options);
+    let { future, produce } = createFuture<Task<T>>();
+    produce({ state: 'completed', value: result });
+    return future;
   }
 
   function within(scope: Task) {
     return scope.spawn(operation, options);
   }
 
-  return { init, within, name: 'spawn' };
+  return Object.assign(spawn, { within });
 }

--- a/packages/core/src/run-loop.ts
+++ b/packages/core/src/run-loop.ts
@@ -8,7 +8,7 @@ export interface RunLoop {
 // up calling into themselves. This causes problems because it becomes very
 // difficult to reason about the underlying state. This could be seen as a sort
 // of synchronous mutex
-export function createRunLoop(): RunLoop {
+export function createRunLoop(name?: string): RunLoop {
   let didEnter = false;
   let runnables: Runnable[] = [];
 
@@ -23,7 +23,7 @@ export function createRunLoop(): RunLoop {
             try {
               runnable();
             } catch(e) {
-              console.error("Caught error in run loop:");
+              console.error(`Caught error in run loop \`${name}\`:`);
               console.error(e);
             }
           } else {

--- a/packages/core/src/state-machine.ts
+++ b/packages/core/src/state-machine.ts
@@ -27,6 +27,10 @@ export class StateMachine {
     this.emitter.emit('state', { from, to });
   }
 
+  get isFinalized(): boolean {
+    return this.current === 'errored' || this.current === 'completed' || this.current === 'halted';
+  }
+
   start(): void {
     this.transition('start', {
       'pending': 'running',

--- a/packages/core/src/task.ts
+++ b/packages/core/src/task.ts
@@ -6,7 +6,7 @@ import { EventEmitter } from 'events';
 import { StateMachine, State } from './state-machine';
 import { Labels } from './labels';
 import { addTrace } from './error';
-import { createFuture, Future, FutureLike, Value } from './future';
+import { createFutureOnRunLoop, Future, FutureLike, Value } from './future';
 import { createRunLoop } from './run-loop';
 import chalk from 'chalk';
 
@@ -68,7 +68,7 @@ export function createTask<TOut = unknown>(operation: Operation<TOut>, options: 
 
   let result: Value<TOut>;
   let runLoop = createRunLoop(`task ${id}`);
-  let { produce, future } = createFuture<TOut>({ runLoop });
+  let { produce, future } = createFutureOnRunLoop<TOut>(runLoop);
 
   let controller: Controller<TOut>;
 

--- a/packages/core/src/task.ts
+++ b/packages/core/src/task.ts
@@ -40,6 +40,7 @@ export interface Task<TOut = unknown> extends Promise<TOut>, FutureLike<TOut> {
   readonly children: Task[];
   readonly future: Future<TOut>;
   readonly yieldingTo: Task | undefined;
+  readonly resourceTask: Task | undefined;
   catchHalt(): Promise<TOut | undefined>;
   setLabels(labels: Labels): void;
   run<R>(operation?: Operation<R>, options?: TaskOptions): Task<R>;
@@ -94,6 +95,8 @@ export function createTask<TOut = unknown>(operation: Operation<TOut>, options: 
     get children() { return Array.from(children) },
 
     get yieldingTo() { return yieldingTo },
+
+    get resourceTask() { return controller.resourceTask },
 
     catchHalt() {
       return future.catch(swallowHalt);

--- a/packages/core/src/task.ts
+++ b/packages/core/src/task.ts
@@ -200,6 +200,10 @@ export function createTask<TOut = unknown>(operation: Operation<TOut>, options: 
       stateMachine.erroring();
       result = { state: 'errored', error: addTrace(value.error, task) };
       shutdown(true);
+    } else if(value.state === 'halted' && stateMachine.current !== 'erroring') {
+      stateMachine.halting();
+      result = { state: 'halted' };
+      shutdown(true);
     }
     finalize();
   });

--- a/packages/core/src/task.ts
+++ b/packages/core/src/task.ts
@@ -24,7 +24,7 @@ export interface TaskTree extends TaskInfo {
 }
 
 export interface TaskOptions {
-  readonly resourceScope?: Task;
+  readonly scope?: Task;
   readonly blockParent?: boolean;
   readonly ignoreChildErrors?: boolean;
   readonly ignoreError?: boolean;
@@ -108,7 +108,7 @@ export function createTask<TOut = unknown>(operation: Operation<TOut>, options: 
       if(stateMachine.current !== 'running') {
         throw new Error('cannot spawn a child on a task which is not running');
       }
-      let child = createTask(operation, { resourceScope: task, ...options });
+      let child = createTask(operation, { scope: task, ...options });
       link(child as Task);
       child.start();
       return child;

--- a/packages/core/src/task.ts
+++ b/packages/core/src/task.ts
@@ -24,7 +24,9 @@ export interface TaskTree extends TaskInfo {
 }
 
 export interface TaskOptions {
+  readonly type?: string;
   readonly scope?: Task;
+  readonly yieldScope?: Task;
   readonly blockParent?: boolean;
   readonly ignoreChildErrors?: boolean;
   readonly ignoreError?: boolean;
@@ -90,7 +92,7 @@ export function createTask<TOut = unknown>(operation: Operation<TOut>, options: 
 
     get state() { return stateMachine.current },
 
-    get type() { return controller.type },
+    get type() { return options.type || controller.type },
 
     get children() { return Array.from(children) },
 
@@ -150,7 +152,7 @@ export function createTask<TOut = unknown>(operation: Operation<TOut>, options: 
     toJSON() {
       return {
         id: id,
-        type: controller.type,
+        type: task.type,
         labels: labels,
         state: stateMachine.current,
         yieldingTo: yieldingTo?.toJSON(),

--- a/packages/core/src/task.ts
+++ b/packages/core/src/task.ts
@@ -8,6 +8,7 @@ import { Labels } from './labels';
 import { addTrace } from './error';
 import { createFuture, Future, FutureLike, Value } from './future';
 import { createRunLoop } from './run-loop';
+import chalk from 'chalk';
 
 let COUNTER = 0;
 
@@ -50,6 +51,7 @@ export interface Task<TOut = unknown> extends Promise<TOut>, FutureLike<TOut> {
   halt(): Promise<void>;
   start(): void;
   toJSON(): TaskTree;
+  toString(): string;
   on: EventEmitter['on'];
   off: EventEmitter['off'];
 }
@@ -158,6 +160,15 @@ export function createTask<TOut = unknown>(operation: Operation<TOut>, options: 
         yieldingTo: yieldingTo?.toJSON(),
         children: Array.from(children).map((c) => c.toJSON()),
       };
+    },
+
+    toString() {
+      let formattedLabels = Object.entries(labels).filter(([key]) => key !== 'name' && key !== 'expand').map(([key, value]) => `${key}=${chalk.yellow(JSON.stringify(value))}`).join(' ');
+      return [
+        [chalk.white(labels.name || 'task'), formattedLabels, chalk.grey(`[${task.type} ${id}]`)].filter(Boolean).join(' '),
+        yieldingTo && yieldingTo.toString().split('\n').map(l => '┃ ' + l).join('\n').replace(/^┃ /, `┣ ${chalk.green('yield')} `),
+        ...Array.from(children).map((c) => c.toString().split('\n').map(l => '┃ ' + l).join('\n').replace(/^┃/, '┣'),)
+      ].filter(Boolean).join('\n');
     },
 
     on: (...args) => emitter.on(...args),

--- a/packages/core/test/labels.test.ts
+++ b/packages/core/test/labels.test.ts
@@ -74,8 +74,6 @@ describe('labels', () => {
   it('applies labels of the resolved operation to a function operation', async () => {
     let task = run((() => () => () => withLabels(sleep(), { one: 1 })) as Operation<void>);
 
-    task.consume(value => console.log({ value }));
-
     expect(task.labels).toMatchObject({
       name: 'sleep',
       one: 1

--- a/packages/core/test/operations/ensure.test.ts
+++ b/packages/core/test/operations/ensure.test.ts
@@ -29,7 +29,7 @@ describe('ensure', () => {
   it('runs the given function at the end of the task', async () => {
     let state = 'pending';
 
-    let root = run(function*() {
+    let root = run(function* rootTask() {
       yield sleep(10);
       yield ensure(() => {
         state = 'completed';

--- a/packages/core/test/resource.test.ts
+++ b/packages/core/test/resource.test.ts
@@ -18,12 +18,14 @@ export const myResource: Resource<{ status: string }> = {
 };
 
 export const metaResource: Resource<{ status: string }> = {
+  name: 'metaResource',
   *init(scope: Task) {
     return yield scope.run(myResource);
   }
 };
 
 export const magicMetaResource: Resource<{ status: string }> = {
+  name: 'magicMetaResource',
   *init() {
     return yield myResource;
   }

--- a/packages/core/test/resource.test.ts
+++ b/packages/core/test/resource.test.ts
@@ -5,6 +5,7 @@ import expect from 'expect';
 import { Task, Resource, run, sleep } from '../src/index';
 
 export const myResource: Resource<{ status: string }> = {
+  name: 'myResource',
   *init(scope: Task) {
     let container = { status: 'pending' };
     scope.run(function*() {
@@ -46,6 +47,20 @@ describe('resource', () => {
       expect(result.status).toEqual('pending');
       await run(sleep(10));
       expect(result.status).toEqual('pending'); // is finished, should not switch to active
+    });
+
+    it('enables access to resource task', async () => {
+      await run(function*(task) {
+        let initTask = task.run(myResource);
+        let result = yield initTask;
+
+        expect(initTask.resourceTask?.state).toEqual('running');
+        expect(initTask.resourceTask?.labels.name).toEqual('myResource');
+
+        yield initTask.resourceTask?.halt();
+        yield sleep(10);
+        expect(result.status).toEqual('pending');
+      });
     });
   });
 

--- a/packages/core/test/task.future.test.ts
+++ b/packages/core/test/task.future.test.ts
@@ -53,4 +53,16 @@ describe('task with future', () => {
     await expect(task).rejects.toHaveProperty('message', 'halted');
     expect(task.state).toEqual('halted');
   });
+
+  it('can be synchronously continued even when already failed', async () => {
+    await expect(run((task) => {
+      task.run(function* florb() {
+        throw new Error('moo');
+      });
+
+      let { future, produce } = createFuture<undefined>();
+      produce({ state: 'completed', value: undefined });
+      return future;
+    })).rejects.toHaveProperty('message', 'moo');
+  });
 });

--- a/packages/core/test/task.test.ts
+++ b/packages/core/test/task.test.ts
@@ -61,7 +61,11 @@ describe('Task', () => {
       expect(run().type).toEqual('suspend');
       expect(run({ perform() { /* no op */ } }).type).toEqual('resolution');
       expect(run(createFuture().future).type).toEqual('future');
-      expect(run({ *init() { /* no op */ } }).type).toEqual('resource');
+      expect(run({ *init() { /* no op */ } }).type).toEqual('resource constructor');
+    });
+
+    it('can be overridden', async () => {
+      expect(run(undefined, { type: 'moo' }).type).toEqual('moo');
     });
   });
 

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@effection/core": "2.0.0-beta.11",
-    "chalk": "^4.1.1",
+    "chalk": "^4.1.2",
     "stacktrace-parser": "^0.1.10"
   },
   "devDependencies": {

--- a/packages/mocha/src/index.ts
+++ b/packages/mocha/src/index.ts
@@ -26,7 +26,7 @@ mocha.afterEach(async function() {
 
 function runInWorld(fn: TestFunction) {
   return async function(this: mocha.Context) {
-    await run({ init: fn.bind(this) }, { resourceScope: world! });
+    await run({ init: fn.bind(this) }, { scope: world! });
   };
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3237,10 +3237,10 @@ chalk@^4.0.0, chalk@^4.1.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.1.tgz#c80b3fab28bf6371e6863325eee67e618b77e6ad"
-  integrity sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==
+chalk@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
+  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"


### PR DESCRIPTION
## Motivation

This introduces the idea of task scope, as a lower level construct which can be used instead of resources.

Currently, some base operations, such as `spawn` and `label` are based on resources, because resources are the only escape hatch allowing one to "expand the scope" as we like to say, or it can be seen as "inlining" an operation.

However this has presented a problem for us: we want resources to introduce a task which "groups" a resources tasks, which can be seen in the inspector. But adding this additional layer is incompatible with e.g. `spawn` being a resource.

## Approach

This solves the problem by introducing the concept of task `scope`. Every task which is not a root task has a scope. Normally this scope is the parent task, but it does not necessarily have to be.

This scope is accessible to "inlining" operations such as `spawn`, and also indirectly to resources, since the newly introduce resourceTask is running inside the scope.

In this PR, there is no convenience added to access the `scope` for operations. Instead they must us `task.options.scope` to obtain the scope. This is also partly meant as "syntactic vinegar" since such operations probably should not be the norm.

### Alternate Designs

We have explored many, many alternative designs to this approach, but crucially it is very difficult to find an approach which composes well, and that is the main advantage of the current system

### Possible Drawbacks or Risks

We have seen with v0.1 of effection that using just a notion of `parent` does not compose well for building resource-like structures. This is why resources were introduced in the first place. There is some risk of repeating this mistake, but it is mitigated by the fact that we now have a solid resource system.

There are some complications with higher order operations. While this does prepare the way for making higher order operations such as `all` work better with resources, it is unclear what the exact semantics should be in the case of an error.

### TODOs and Open Questions

- [x] how does this interact with higher order operations?
- [x] do we provide access to the resource task to a consumer of the resource? and if so, how?