### PR TITLE
Use Object.create to create error object with trace

### DIFF
--- a/.changes/error-object-create.md
+++ b/.changes/error-object-create.md
@@ -1,0 +1,5 @@
+---
+"@effection/core": "minor"
+---
+
+Use Object.create to wrap error objects rather than copying properties

--- a/packages/core/src/error.ts
+++ b/packages/core/src/error.ts
@@ -12,10 +12,10 @@ export function addTrace(error: Error & Partial<HasEffectionTrace>, task: Task):
     state: task.state,
   };
 
-  let properties = Object.getOwnPropertyDescriptors(error);
-  properties.effectionTrace = {
-    value: [...(error.effectionTrace || []), info],
-    enumerable: true,
-  };
-  return Object.create(Object.getPrototypeOf(error), properties);
+  return Object.create(error, {
+    effectionTrace: {
+      value: [...(error.effectionTrace || []), info],
+      enumerable: true,
+    }
+  });
 }


### PR DESCRIPTION
Closes #485 

Unfortunately copying the properties to the error objects as we did before does not work in all JS engines, notably Firefox, see #485

This option gives us a less clean prototype chain, but the properties do seem to at least be correctly available on all JS engines.

Another option for implementing this would be using a proxy object, but I don't think there is any benefit to doing so here.