### PR TITLE
Update core dependency

### DIFF
--- a/.changes/mocha-core-dep.md
+++ b/.changes/mocha-core-dep.md
@@ -1,0 +1,5 @@
+---
+"@effection/mocha": "patch"
+---
+
+Update core dependency

--- a/packages/mocha/package.json
+++ b/packages/mocha/package.json
@@ -27,7 +27,7 @@
     "mocha": "mocha -r ts-node/register"
   },
   "peerDependencies": {
-    "@effection/core": "2.0.0-beta.4",
+    "@effection/core": "2.0.0-beta.10",
     "mocha": "^8.0.0"
   },
   "devDependencies": {
@@ -41,8 +41,5 @@
   "volta": {
     "node": "12.16.0",
     "yarn": "1.19.1"
-  },
-  "dependencies": {
-    "@effection/core": "^2.0.0-beta.3"
   }
 }


### PR DESCRIPTION
The dependency in `@effection/mocha` is not getting properly bumped. Presumably because it has both a normal and peer dependency. Let's set it as just peer dependency and see what happens.