### PR TITLE
Change named import from a package.json file to default.

### DIFF
--- a/.changes/no-named-package-json-import.md
+++ b/.changes/no-named-package-json-import.md
@@ -1,4 +1,4 @@
 ---
 "@effection/core": patch
 ---
-Change named import from a package.json file to default.
+Change named import from a package.json file to default

--- a/.changes/no-named-package-json-import.md
+++ b/.changes/no-named-package-json-import.md
@@ -1,0 +1,4 @@
+---
+"@effection/core": patch
+---
+Change named import from a package.json file to default.

--- a/packages/core/src/effection.ts
+++ b/packages/core/src/effection.ts
@@ -2,7 +2,9 @@
 import { Task, createTask } from './task';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
-import { version } from '../package.json';
+import packageInfo from '../package.json';
+
+const { version } = packageInfo;
 
 const MAJOR_VERSION = version.split('.')[0];
 const GLOBAL_PROPERTY = `__effectionV${MAJOR_VERSION}`;

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "baseUrl": ".",
-    "noEmit": true
+    "noEmit": true,
+    "resolveJsonModule": false
   },
   "include": [
     "test/**/*.ts",

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "baseUrl": ".",
-    "noEmit": true,
-    "resolveJsonModule": false
+    "noEmit": true
   },
   "include": [
     "test/**/*.ts",


### PR DESCRIPTION
## Motivation

While upgrading some code to `webpack 5`,  I discovered that webpack 5 does not like named exports from json files, like the following code in `effection.ts`:

```ts
import { version } from '../package.json';
```

Webpack errors with the following:

> Should not import the named export 'version'.'split' (imported as 'version') from default-exporting module (only default export is available soon).

A  look at the [webpack 5 release notes](https://webpack.js.org/blog/2020-10-10-webpack-5-release/#json-modules) verifies that this is an issue.

> JSON modules now align with the proposal and emit a warning when a non-default export is used. JSON modules no longer have named exports when importing from a strict ECMAScript module.

While we do not use webpack, lots of sad people (like me) do use webpack.

## Approach

Import `package.json` as a default export
