### PR TITLE
Add resolve/reject/halt functions when creating future

### DIFF
--- a/packages/core/src/future.ts
+++ b/packages/core/src/future.ts
@@ -23,8 +23,9 @@ export interface Future<T> extends Promise<T>, FutureLike<T> {
 export interface NewFuture<T> {
   future: Future<T>;
   produce(value: Value<T>): void;
-  /** @deprecated Use produce(value) instead */
-  resolve(value: Value<T>): void;
+  resolve(value: T): void;
+  reject(error: Error): void;
+  halt(): void;
 }
 
 export function createFuture<T>(): NewFuture<T> {
@@ -57,12 +58,6 @@ export function createFuture<T>(): NewFuture<T> {
     }
   }
 
-  function resolve(value: Value<T>) {
-    console.warn(`DEPRECATED: resolve() is deprecated and will be changed or removed prior to the release of effection 2.0\nuse produce() instead`);
-    produce(value);
-  }
-
-
   let promise: Promise<T>;
 
   function getPromise(): Promise<T> {
@@ -89,6 +84,8 @@ export function createFuture<T>(): NewFuture<T> {
       finally: (...args) => getPromise().finally(...args),
       [Symbol.toStringTag]: '[continuation]',
     },
-    resolve
+    resolve: (value: T) => produce({ state: 'completed', value }),
+    reject: (error: Error) => produce({ state: 'errored', error }),
+    halt: () => produce({ state: 'halted' }),
   };
 }

--- a/packages/core/test/future.test.ts
+++ b/packages/core/test/future.test.ts
@@ -1,0 +1,32 @@
+import './setup';
+import { describe, it } from 'mocha';
+import expect from 'expect';
+
+import { createFuture } from '../src/index';
+
+describe('Future', () => {
+  it('can be resolved', async () => {
+    let { future, resolve } = createFuture();
+    resolve(123);
+    await expect(future).resolves.toEqual(123);
+  });
+
+  it('can be rejected', async () => {
+    let error = new Error('boom');
+    let { future, reject } = createFuture();
+    reject(error);
+    await expect(future).rejects.toEqual(error);
+  });
+
+  it('can be halted', async () => {
+    let { future, halt } = createFuture();
+    halt();
+    await expect(future).rejects.toHaveProperty('message', 'halted');
+  });
+
+  it('can produce value', async () => {
+    let { future, produce } = createFuture();
+    produce({ state: 'completed', value: 123 });
+    await expect(future).resolves.toEqual(123);
+  });
+});


### PR DESCRIPTION
This makes future more ergonomic to use, since the `produce` function is a little awkward, especially when used from plain-JS.