### PR TITLE
Enable side effects in inspect-ui package

### DIFF
--- a/.changes/inspect-tree-shaking.md
+++ b/.changes/inspect-tree-shaking.md
@@ -1,0 +1,5 @@
+---
+"@effection/inspect-ui": "patch"
+---
+
+Fix tree shaking being to aggressive by using sideEffects:true

--- a/packages/inspect-ui/app/index.html
+++ b/packages/inspect-ui/app/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title>Effection Inspector</title>
-    <script src="./index.tsx"></script>
+    <script src="./index.tsx" type="module"></script>
     <link rel="stylesheet" href="./index.css"></link>
     <meta charset="utf-8"/>
   </head>

--- a/packages/inspect-ui/package.json
+++ b/packages/inspect-ui/package.json
@@ -60,6 +60,12 @@
     "ts-node": "^8.9.0",
     "typescript": "^3.7.0"
   },
+  "sideEffects": true,
+  "targets": {
+    "browser": {
+      "optimize": false
+    }
+  },
   "volta": {
     "node": "12.16.0",
     "yarn": "1.19.1"


### PR DESCRIPTION
Otherwise when packages using `yarn prepack`, everything in `index.tsx` will be tree-shaken away, and the inspector will just be a blank page.