### PR TITLE
Allow channels to be named

### DIFF
--- a/.changes/channel-name.md
+++ b/.changes/channel-name.md
@@ -1,0 +1,5 @@
+---
+"@effection/channel": "minor"
+---
+
+Allow channels to be named so their internal stream gets named

--- a/packages/channel/src/channel.ts
+++ b/packages/channel/src/channel.ts
@@ -8,6 +8,7 @@ export type Send<T> = Writable<T>['send'];
 
 export type ChannelOptions = {
   maxSubscribers?: number;
+  name?: string;
 }
 
 export interface Channel<T, TClose = undefined> extends WritableStream<T, T, TClose> {
@@ -34,7 +35,7 @@ export function createChannel<T, TClose = undefined>(options: ChannelOptions = {
         publish(next.value);
       }
     }
-  });
+  }, options.name);
 
   let send: Send<T> = (message: T) => {
     bus.emit('event', { done: false, value: message });


### PR DESCRIPTION
This adds a name option which gets passed down to the underlying stream