### PR TITLE
Add support for expand label

### DIFF
--- a/.changes/collapse-subscriptions.md
+++ b/.changes/collapse-subscriptions.md
@@ -1,0 +1,5 @@
+---
+"@effection/subscription": "patch"
+---
+
+Collapse subscription methods in the inspector by default.

--- a/.changes/expand-label.md
+++ b/.changes/expand-label.md
@@ -1,0 +1,5 @@
+---
+"@effection/inspect-ui": "minor"
+---
+
+Add support for special `expand` label which controls whether a given task is shown as expanded or collapsed in the inspector.

--- a/packages/inspect-ui/app/task-tree.tsx
+++ b/packages/inspect-ui/app/task-tree.tsx
@@ -17,10 +17,10 @@ type TreeProps = {
 }
 
 export function TaskTree({ tree }: TreeProps): JSX.Element {
-  let [isOpen, setOpen] = useState<boolean>(true);
+  let [isOpen, setOpen] = useState<boolean>((tree.labels.expand != null) ? !!tree.labels.expand : true);
   let name = tree.labels.name || 'task';
   let children = Object.values(tree.children);
-  let labels = Object.entries(tree.labels).filter(([key]) => key !== 'name');
+  let labels = Object.entries(tree.labels).filter(([key, value]) => key !== 'name' && key !== 'expand' && value != null);
   return (
     <div className={`task ${tree.state}`}>
       <div className={`task--state ${tree.state}`}>

--- a/packages/subscription/src/queue.ts
+++ b/packages/subscription/src/queue.ts
@@ -63,7 +63,7 @@ export function createQueue<T, TReturn = undefined>(name = 'queue'): Queue<T, TR
   };
 
   function withName<T>(operationName: string, operation: Operation<T>): Operation<T> {
-    return withLabels(operation, { name: `${name}.${operationName}()` });
+    return withLabels(operation, { name: `${name}.${operationName}()`, expand: false });
   }
 
   let subscription = {

--- a/packages/subscription/src/stream.ts
+++ b/packages/subscription/src/stream.ts
@@ -35,7 +35,7 @@ export function createStream<T, TReturn = undefined>(callback: Callback<T, TRetu
     task.run(function*() {
       let result = yield callback(queue.send);
       queue.closeWith(result);
-    }, { labels: { name: `publisher` } });
+    }, { labels: { name: 'publisher', expand: false } });
     return queue.subscription;
   };
 


### PR DESCRIPTION
This labels controls whether the task is shown expanded or collapsed in the inspector by default. This makes it possible to streamline the output in the inspector by hiding unimportant internal tasks.