### PR TITLE
Baseurl needs to be set for styles

### DIFF
--- a/typedoc.js
+++ b/typedoc.js
@@ -1,3 +1,12 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const Handlebars = require('handlebars');
+
+const BASE_URL="https://v2--effection-api.netlify.app/"; // for css
+
+Handlebars.registerHelper('relativeURL', function(url) {
+  return BASE_URL + url;
+});
+
 module.exports = {
   "name": "effection",
   "out": "docs/api/v2",


### PR DESCRIPTION
## Motivation

The styles aren't loading for the api pages because [this](https://github.com/thefrontside/effection/commit/c05f170eff5def687eeeb07440fa8c1640dea127#diff-eae7508820fbc6c71a3f11c48f271a0e9deb5a6d9712b4907a78baba91e43a59L1-L9) should have never been removed.

## Approach

Added it back