### PR TITLE
Set base url to frontside.com/effection/api for typedoc

### DIFF
--- a/typedoc.js
+++ b/typedoc.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const Handlebars = require('handlebars');
 
-const BASE_URL="https://v2--effection-api.netlify.app/"; // for css
+const BASE_URL="https://frontside.com/effection/api/"; // for css
 
 Handlebars.registerHelper('relativeURL', function(url) {
   return BASE_URL + url;


### PR DESCRIPTION
## Motivation

If you click any of the sidebar links in the [api site](https://frontside.com/effection/api), it will resolve to the netlify url. This is to fix that problem.

## Approach

Change base url from `https://v2--effection-api.netlify.app/` to `https://frontside.com/effection/api/`. [It should still retain all of its styles](https://frontside.com/effection/api/assets/css/main.css).

If we merge this one quickly enough, it will trigger a deploy without having to merge a versions pr. 😅