### PR TITLE
Share event loop among controller, task and future

### DIFF
--- a/.changes/shared-event-loop.md
+++ b/.changes/shared-event-loop.md
@@ -1,0 +1,5 @@
+---
+"@effection/core": "minor"
+---
+
+Share internal run loop among task, task future and task controller. Prevents race conditions which cause internal errors.

--- a/packages/core/src/controller/controller.ts
+++ b/packages/core/src/controller/controller.ts
@@ -1,4 +1,5 @@
 import type { Task } from '../task';
+import type { RunLoop } from '../run-loop';
 import type { Operation } from '../operation';
 import { isResource, isResolution, isFuture, isPromise, isGenerator } from '../predicates';
 import { createFunctionController } from './function-controller';
@@ -19,17 +20,18 @@ export interface Controller<TOut> {
 }
 
 export type Options = {
+  runLoop: RunLoop;
   resourceScope?: Task;
   onYieldingToChange?: (task: Task | undefined) => void;
 }
 
-export function createController<T>(task: Task<T>, operation: Operation<T>, options: Options = {}): Controller<T> {
+export function createController<T>(task: Task<T>, operation: Operation<T>, options: Options): Controller<T> {
   if (typeof(operation) === 'function') {
     return createFunctionController(task, operation, () => createController(task, operation(task), options));
   } else if(!operation) {
     return createSuspendController();
   } else if (isResource(operation)) {
-    return createResourceController(task, operation);
+    return createResourceController(task, operation, options);
   } else if (isFuture<T>(operation)) {
     return createFutureController(task, operation);
   } else if (isResolution<T>(operation)) {

--- a/packages/core/src/controller/iterator-controller.ts
+++ b/packages/core/src/controller/iterator-controller.ts
@@ -3,7 +3,6 @@ import { OperationIterator } from '../operation';
 import { createTask, Task } from '../task';
 import { Operation } from '../operation';
 import { createFuture, Value } from '../future';
-import { createRunLoop } from '../run-loop';
 
 const claimed = Symbol.for('effection/v2/iterator-controller/claimed');
 
@@ -13,12 +12,11 @@ interface Claimable {
   [claimed]?: boolean;
 }
 
-export function createIteratorController<TOut>(task: Task<TOut>, iterator: OperationIterator<TOut> & Claimable, options: Options = {}): Controller<TOut> {
+export function createIteratorController<TOut>(task: Task<TOut>, iterator: OperationIterator<TOut> & Claimable, options: Options): Controller<TOut> {
   let didHalt = false;
   let yieldingTo: Task | undefined;
 
   let { produce, future } = createFuture<TOut>();
-  let runLoop = createRunLoop();
 
   function start() {
     if (iterator[claimed]) {
@@ -32,7 +30,7 @@ export function createIteratorController<TOut>(task: Task<TOut>, iterator: Opera
   }
 
   function resume(iter: NextFn) {
-    runLoop.run(() => {
+    options.runLoop.run(() => {
       let next;
       try {
         next = iter();

--- a/packages/core/src/controller/resource-controller.ts
+++ b/packages/core/src/controller/resource-controller.ts
@@ -1,10 +1,10 @@
-import { Controller } from './controller';
+import { Controller, Options } from './controller';
 import { createIteratorController } from './iterator-controller';
 import { Resource } from '../operation';
 import { Task } from '../task';
 import { createFuture } from '../future';
 
-export function createResourceController<TOut>(task: Task<TOut>, resource: Resource<TOut>): Controller<TOut> {
+export function createResourceController<TOut>(task: Task<TOut>, resource: Resource<TOut>, options: Options): Controller<TOut> {
   let delegate: Controller<TOut>;
   let { resourceScope } = task.options;
   let { produce, future } = createFuture<TOut>();
@@ -20,7 +20,7 @@ export function createResourceController<TOut>(task: Task<TOut>, resource: Resou
       produce({ state: 'errored', error });
       return;
     }
-    delegate = createIteratorController(task, init, { resourceScope });
+    delegate = createIteratorController(task, init, { resourceScope, runLoop: options.runLoop });
     delegate.future.consume((value) => {
       produce(value);
     });

--- a/packages/core/src/future.ts
+++ b/packages/core/src/future.ts
@@ -1,7 +1,11 @@
 import { HaltError } from './halt-error';
-import { createRunLoop } from './run-loop';
+import { createRunLoop, RunLoop } from './run-loop';
 
 export type State = 'pending' | 'errored' | 'completed' | 'halted';
+
+export type Options = {
+  runLoop?: RunLoop;
+}
 
 export type Value<T> =
   | { state: 'errored'; error: Error }
@@ -27,8 +31,8 @@ export interface NewFuture<T> {
   resolve(value: Value<T>): void;
 }
 
-export function createFuture<T>(): NewFuture<T> {
-  let runLoop = createRunLoop();
+export function createFuture<T>(options: Options = {}): NewFuture<T> {
+  let runLoop = options.runLoop || createRunLoop('future');
   let consumers: Consumer<T>[] = [];
   let result: Value<T>;
 

--- a/packages/core/src/run-loop.ts
+++ b/packages/core/src/run-loop.ts
@@ -8,7 +8,7 @@ export interface RunLoop {
 // up calling into themselves. This causes problems because it becomes very
 // difficult to reason about the underlying state. This could be seen as a sort
 // of synchronous mutex
-export function createRunLoop(): RunLoop {
+export function createRunLoop(name?: string): RunLoop {
   let didEnter = false;
   let runnables: Runnable[] = [];
 
@@ -23,7 +23,7 @@ export function createRunLoop(): RunLoop {
             try {
               runnable();
             } catch(e) {
-              console.error("Caught error in run loop:");
+              console.error(`Caught error in run loop \`${name}\`:`);
               console.error(e);
             }
           } else {

--- a/packages/core/src/state-machine.ts
+++ b/packages/core/src/state-machine.ts
@@ -27,6 +27,10 @@ export class StateMachine {
     this.emitter.emit('state', { from, to });
   }
 
+  get isFinalized(): boolean {
+    return this.current === 'errored' || this.current === 'completed' || this.current === 'halted';
+  }
+
   start(): void {
     this.transition('start', {
       'pending': 'running',

--- a/packages/core/test/task.future.test.ts
+++ b/packages/core/test/task.future.test.ts
@@ -53,4 +53,16 @@ describe('task with future', () => {
     await expect(task).rejects.toHaveProperty('message', 'halted');
     expect(task.state).toEqual('halted');
   });
+
+  it('can be synchronously continued even when already failed', async () => {
+    await expect(run((task) => {
+      task.run(function* florb() {
+        throw new Error('moo');
+      });
+
+      let { future, produce } = createFuture<undefined>();
+      produce({ state: 'completed', value: undefined });
+      return future;
+    })).rejects.toHaveProperty('message', 'moo');
+  });
 });


### PR DESCRIPTION
We currently have three different event loops for a single task, the one in the future, the one in the task, and the one in the iterator controller. This unifies all three event loops so we only have one loop. Additionally there are some tweaks to which sections are protected by the event loop. Hopefully this will solve some reentrancy issues, but it is a little bit of a stab in the dark.