### PR TITLE
Improve naming scheme of exec labels

### DIFF
--- a/.changes/improved-exec-labels.md
+++ b/.changes/improved-exec-labels.md
@@ -1,0 +1,5 @@
+---
+"@effection/process": "patch"
+---
+
+Improve naming scheme for process labels

--- a/packages/process/src/daemon.ts
+++ b/packages/process/src/daemon.ts
@@ -13,7 +13,7 @@ export interface Daemon extends Resource<Process> {}
 
 export function daemon(command: string, options: ExecOptions = {}): Daemon {
   return {
-    name: `daemon \`${command}\``,
+    name: `daemon(${JSON.stringify(command)})`,
     labels: {
       expand: false,
     },

--- a/packages/process/src/exec.ts
+++ b/packages/process/src/exec.ts
@@ -33,7 +33,7 @@ export function exec(command: string, options: ExecOptions = {}): Exec {
   let opts = { ...options, arguments: args.concat(options.arguments || []) };
 
   return {
-    name: `exec \`${cmd} ${args.join(' ')}\``,
+    name: `exec(${JSON.stringify(command)})`,
     labels: {
       expand: false
     },
@@ -49,7 +49,7 @@ export function exec(command: string, options: ExecOptions = {}): Exec {
         let stderr = yield process.stderr.expect();
 
         return { ...status, stdout, stderr };
-      }, { name: `exec join \`${cmd} ${args.join(' ')}\``, expand: false });
+      }, { name: `exec(${JSON.stringify(command)}).join()`, expand: false });
     },
     expect() {
       return withLabels(function*() {
@@ -60,7 +60,7 @@ export function exec(command: string, options: ExecOptions = {}): Exec {
         let stderr = yield process.stderr.expect();
 
         return { ...status, stdout, stderr };
-      }, { name: `exec expect \`${cmd} ${args.join(' ')}\``, expand: false });
+      }, { name: `exec(${JSON.stringify(command)}).expect()`, expand: false });
     }
   };
 }

--- a/packages/process/test/exec.test.ts
+++ b/packages/process/test/exec.test.ts
@@ -22,6 +22,10 @@ describe('exec', () => {
       expect(result.stdout).toEqual('hello world\n');
       expect(result.stderr).toEqual('boom\n');
     });
+
+    it('applies labels', function*() {
+      expect(exec("foo").join()?.labels?.name).toEqual('exec("foo").join()');
+    });
   });
 
   describe('.expect', () => {
@@ -38,6 +42,14 @@ describe('exec', () => {
 
       expect(error.name).toEqual('ExecError');
     });
+
+    it('applies labels', function*() {
+      expect(exec("foo").expect()?.labels?.name).toEqual('exec("foo").expect()');
+    });
+  });
+
+  it('applies labels to resource', function*() {
+    expect(exec("foo").name).toEqual('exec("foo")');
   });
 
   describe('spawning', () => {


### PR DESCRIPTION
This adopts the same naming scheme for the labels in @effection/process as we're adding to fetch and atom.