### PR TITLE
Publish New Versions

### DIFF
--- a/.changes/pre.json
+++ b/.changes/pre.json
@@ -28,6 +28,7 @@
     ".changes/task-scope.md",
     ".changes/task-spawn-operation.md",
     ".changes/task-to-string.md",
-    ".changes/typescript-bumps.md"
+    ".changes/typescript-bumps.md",
+    ".changes/version-fix.md"
   ]
 }

--- a/packages/effection/CHANGELOG.md
+++ b/packages/effection/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## \[2.0.0-beta.15]
+
+- Fix dependency versions
+  - Bumped due to a bump in @effection/fetch.
+  - [5054ac0](https://github.com/thefrontside/effection/commit/5054ac0f10970bb5654e05545375c5349f18d43a) Add changeset on 2021-09-07
+
 ## \[2.0.0-beta.14]
 
 - Add @effection/fetch as a dependency and reexport it

--- a/packages/effection/package.json
+++ b/packages/effection/package.json
@@ -1,6 +1,6 @@
 {
   "name": "effection",
-  "version": "2.0.0-beta.14",
+  "version": "2.0.0-beta.15",
   "description": "Effortlessly composable structured concurrency primitive for JavaScript",
   "homepage": "https://github.com/thefrontside/effection",
   "repository": {
@@ -31,7 +31,7 @@
     "@effection/channel": "2.0.0-beta.14",
     "@effection/core": "2.0.0-beta.12",
     "@effection/events": "2.0.0-beta.14",
-    "@effection/fetch": "2.0.0-beta.14",
+    "@effection/fetch": "2.0.0-beta.15",
     "@effection/main": "2.0.0-beta.14",
     "@effection/subscription": "2.0.0-beta.14"
   },

--- a/packages/fetch/CHANGELOG.md
+++ b/packages/fetch/CHANGELOG.md
@@ -1,5 +1,10 @@
 # @effection/fetch
 
+## \[2.0.0-beta.15]
+
+- Fix dependency versions
+  - [5054ac0](https://github.com/thefrontside/effection/commit/5054ac0f10970bb5654e05545375c5349f18d43a) Add changeset on 2021-09-07
+
 ## \[2.0.0-beta.14]
 
 - Add labels for fetch operations

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/fetch",
-  "version": "2.0.0-beta.14",
+  "version": "2.0.0-beta.15",
   "description": "Fetch operation for Effection",
   "main": "dist-cjs/index.js",
   "module": "dist-esm/index.js",

--- a/packages/mocha/CHANGELOG.md
+++ b/packages/mocha/CHANGELOG.md
@@ -1,5 +1,10 @@
 # @effection/mocha
 
+## \[2.0.0-beta.10]
+
+- Fix dependency versions
+  - [5054ac0](https://github.com/thefrontside/effection/commit/5054ac0f10970bb5654e05545375c5349f18d43a) Add changeset on 2021-09-07
+
 ## \[2.0.0-beta.9]
 
 - Update core dependency

--- a/packages/mocha/package.json
+++ b/packages/mocha/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/mocha",
-  "version": "2.0.0-beta.9",
+  "version": "2.0.0-beta.10",
   "description": "Effection Subscriptions",
   "main": "dist-cjs/index.js",
   "module": "dist-esm/index.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1317,11 +1317,6 @@
     "@effection/subscription" "^1.0.0"
     effection "^1.0.0"
 
-"@effection/core@2.0.0-beta.11":
-  version "2.0.0-beta.11"
-  resolved "https://registry.yarnpkg.com/@effection/core/-/core-2.0.0-beta.11.tgz#8582287085f6b6c873bb0748dc7680666f821199"
-  integrity sha512-cgxARBSmRn/7MMwdeIscp/kz62YdB67Soj8psj8OXruQMfTy7chuB+mSNQd4sp1M1vcdYqh//DFyrFYQiXqBiQ==
-
 "@effection/events@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@effection/events/-/events-1.0.0.tgz#4430ed538377bf04a5efd7c3b6d40a7b4e2b0607"
@@ -1330,15 +1325,10 @@
     "@effection/subscription" "^1.0.0"
     effection "^1.0.0"
 
-"@effection/fetch@2.0.0-beta.13":
-  version "2.0.0-beta.13"
-  resolved "https://registry.yarnpkg.com/@effection/fetch/-/fetch-2.0.0-beta.13.tgz#87506b70633c916c0dd95a62ec23d3acab026809"
-  integrity sha512-j2pImidM/+axBsteuapWzq04dTvpTl/ktBmiAtIO7pQ14s5hNxm8MunLSNGM7evDGpLd6+RjTcIf6mv51G03wg==
-  dependencies:
-    "@effection/core" "2.0.0-beta.11"
-    abort-controller "^3.0.0"
-    cross-fetch "^3.0.4"
-    node-fetch "^2.6.1"
+"@effection/mocha@2.0.0-beta.9":
+  version "2.0.0-beta.9"
+  resolved "https://registry.yarnpkg.com/@effection/mocha/-/mocha-2.0.0-beta.9.tgz#672e3acdfe714c37d6bee9666ae10dfe60154978"
+  integrity sha512-7PQI+BsPdWrPhdg0vkeFH0YiNcYeNIsYb1VLZQyD7MgxqGp7CnSAW9hSgav6/fgQvCQkjG0LHFXXJOGd6ncO9w==
 
 "@effection/node@^1.0.2":
   version "1.0.2"


### PR DESCRIPTION
# Version Updates

Merging this PR will bump all of the applicable packages based on your change files.




# effection

## [2.0.0-beta.15]
- Fix dependency versions
  - Bumped due to a bump in @effection/fetch.
  - [5054ac0](https://github.com/thefrontside/effection/commit/5054ac0f10970bb5654e05545375c5349f18d43a) Add changeset on 2021-09-07



# @effection/fetch

## [2.0.0-beta.15]
- Fix dependency versions
  - [5054ac0](https://github.com/thefrontside/effection/commit/5054ac0f10970bb5654e05545375c5349f18d43a) Add changeset on 2021-09-07



# @effection/mocha

## [2.0.0-beta.10]
- Fix dependency versions
  - [5054ac0](https://github.com/thefrontside/effection/commit/5054ac0f10970bb5654e05545375c5349f18d43a) Add changeset on 2021-09-07