### PR TITLE
Add shortcuts for resolves/rejected/halted future

### DIFF
--- a/.changes/future-constructors.md
+++ b/.changes/future-constructors.md
@@ -1,0 +1,5 @@
+---
+"@effection/core": "minor"
+---
+
+Add shortcuts to create resolved/rejected/halted futures via Future.resolve(123), etc...

--- a/packages/core/src/future.ts
+++ b/packages/core/src/future.ts
@@ -93,3 +93,23 @@ export function createFutureOnRunLoop<T>(runLoop: RunLoop): NewFuture<T> {
     halt: () => produce({ state: 'halted' }),
   };
 }
+
+export const Future = {
+  resolve<T>(value: T): Future<T> {
+    let { future, resolve } = createFuture<T>();
+    resolve(value);
+    return future;
+  },
+
+  reject<T = unknown>(error: Error): Future<T> {
+    let { future, reject } = createFuture<T>();
+    reject(error);
+    return future;
+  },
+
+  halt<T = unknown>(): Future<T> {
+    let { future, halt } = createFuture<T>();
+    halt();
+    return future;
+  },
+};

--- a/packages/core/src/operations/ensure.ts
+++ b/packages/core/src/operations/ensure.ts
@@ -1,5 +1,5 @@
 import { Operation } from '../operation';
-import { createFuture } from '../future';
+import { Future } from '../future';
 
 export function ensure<T>(fn: () => Operation<T> | void): Operation<undefined> {
   return function ensure(task) {
@@ -18,8 +18,6 @@ export function ensure<T>(fn: () => Operation<T> | void): Operation<undefined> {
       }
     });
 
-    let { future, produce } = createFuture<undefined>();
-    produce({ state: 'completed', value: undefined });
-    return future;
+    return Future.resolve(undefined);
   };
 }

--- a/packages/core/src/operations/label.ts
+++ b/packages/core/src/operations/label.ts
@@ -1,6 +1,6 @@
 import { Operation } from '../operation';
 import { Labels } from '../labels';
-import { createFuture } from '../future';
+import { Future } from '../future';
 import { withLabels } from '../labels';
 
 export function label(labels: Labels): Operation<void> {
@@ -10,8 +10,6 @@ export function label(labels: Labels): Operation<void> {
       throw new Error('cannot run `label` on a task without scope');
     }
     scope.setLabels(labels);
-    let { future, produce } = createFuture<undefined>();
-    produce({ state: 'completed', value: undefined });
-    return future;
+    return Future.resolve(undefined);
   }, { name: 'label' });
 }

--- a/packages/core/src/operations/spawn.ts
+++ b/packages/core/src/operations/spawn.ts
@@ -1,5 +1,5 @@
 import { Operation, OperationFunction } from '../operation';
-import { createFuture } from '../future';
+import { Future } from '../future';
 import type { Task, TaskOptions } from '../task';
 
 interface Spawn<T> extends OperationFunction<Task<T>> {
@@ -13,9 +13,7 @@ export function spawn<T>(operation?: Operation<T>, options?: TaskOptions): Spawn
       throw new Error('cannot run `spawn` on a task without scope');
     }
     let result = scope.run(operation, options);
-    let { future, produce } = createFuture<Task<T>>();
-    produce({ state: 'completed', value: result });
-    return future;
+    return Future.resolve(result);
   }
 
   function within(scope: Task) {

--- a/packages/core/test/future.test.ts
+++ b/packages/core/test/future.test.ts
@@ -2,7 +2,7 @@ import './setup';
 import { describe, it } from 'mocha';
 import expect from 'expect';
 
-import { createFuture } from '../src/index';
+import { createFuture, Future } from '../src/index';
 
 describe('Future', () => {
   it('can be resolved', async () => {
@@ -28,5 +28,21 @@ describe('Future', () => {
     let { future, produce } = createFuture();
     produce({ state: 'completed', value: 123 });
     await expect(future).resolves.toEqual(123);
+  });
+
+  it('can make resolved future', async () => {
+    let future = Future.resolve(123);
+    await expect(future).resolves.toEqual(123);
+  });
+
+  it('can make rejected future', async () => {
+    let error = new Error('boom');
+    let future = Future.reject(error);
+    await expect(future).rejects.toEqual(error);
+  });
+
+  it('can make halted future', async () => {
+    let future = Future.halt();
+    await expect(future).rejects.toHaveProperty('message', 'halted');
   });
 });


### PR DESCRIPTION
This adds shortcut methods like `Future.resolve(123)` to create a resolved future. Similar to the shortcuts for promises, like
`Promise.resolve(123)`

Closes #495