### PR TITLE
Remove deprecated `once` from atom

### DIFF
--- a/.changes/atom-once.md
+++ b/.changes/atom-once.md
@@ -1,0 +1,5 @@
+---
+"@effection/atom": "minor"
+---
+
+Remove deprecated `once` from atom

--- a/packages/atom/src/atom.ts
+++ b/packages/atom/src/atom.ts
@@ -1,7 +1,6 @@
 import * as O from 'fp-ts/Option';
 import * as Op from 'monocle-ts/Optional';
 import { pipe } from 'fp-ts/function';
-import { Operation } from '@effection/core';
 import { createStream } from '@effection/subscription';
 import { createChannel, ChannelOptions } from '@effection/channel';
 import { MakeSlice, Slice } from './types';
@@ -112,12 +111,6 @@ export function createAtom<S>(initialState: S, options: ChannelOptions = {}): Sl
         setState(O.toUndefined(next) as S);
       }
 
-      let once = function onceWithWarning(predicate: (state: A[P]) => boolean): Operation<A[P]> {
-        console.warn('DEPRECATION: every slice of an atom is now an instance of Stream, and so calls to  once() can be converted to `filter(predicate).expect()`');
-        once = (predicate) => stream.filter(predicate).expect();
-        return once(predicate);
-      };
-
       function remove() {
         let next = pipe(
           sliceOptional,
@@ -133,7 +126,6 @@ export function createAtom<S>(initialState: S, options: ChannelOptions = {}): Sl
         set,
         update,
         stream,
-        once,
         slice: sliceMaker(fullPath, sliceOptional),
         remove,
       }, stream);

--- a/packages/atom/src/types.ts
+++ b/packages/atom/src/types.ts
@@ -1,12 +1,10 @@
 import { Stream } from '@effection/subscription';
-import { Operation } from '@effection/core';
 
 export interface Slice<S> extends Stream<S> {
   get(): S;
   set(value: S): void;
   update(fn: (state: S) => S): void;
   slice: MakeSlice<S>;
-  once(predicate: (state: S) => boolean): Operation<S>;
   remove(): void;
   stream: Stream<S>;
 }

--- a/packages/atom/test/atom.test.ts
+++ b/packages/atom/test/atom.test.ts
@@ -168,40 +168,6 @@ describe('@bigtest/atom createAtom', () => {
     });
   });
 
-  describe('.once()', () => {
-    let result: Promise<State>;
-    let subject: Slice<State>;
-
-    describe('when initial state matches', () => {
-      beforeEach(function*(world) {
-        subject = createAtom({foo: 'bar'});
-        result = world.run(subject.once((state) => state.foo === 'bar'));
-
-        subject.update(() => ({ foo: 'baz' }));
-      });
-
-      it('gets the first state that passes the given predicate', function*() {
-        expect(yield result).toEqual({ foo: 'bar' });
-        expect(subject.get()).toEqual({ foo: 'baz' });
-      });
-    });
-
-    describe('when initial state does not match', () => {
-      beforeEach(function*(world) {
-        result = world.run(subject.once((state) => state.foo === 'baz'));
-
-        subject.update(() => ({ foo: 'bar' }));
-        subject.update(() => ({ foo: 'baz' }));
-        subject.update(() => ({ foo: 'quox' }));
-      });
-
-      it('gets the first state that passes the given predicate', function*() {
-        expect(yield result).toEqual({ foo: 'baz' });
-        expect(subject.get()).toEqual({ foo: 'quox' });
-      });
-    });
-  });
-
   type Subject = {
     foo: string;
   }

--- a/packages/atom/test/slice.test.ts
+++ b/packages/atom/test/slice.test.ts
@@ -93,46 +93,6 @@ describe('@bigtest/atom Slice', () => {
     });
   });
 
-  describe('.once()', () => {
-    let result: Promise<string | undefined>;
-    let atom: Slice<Data>;
-    let slice: Slice<string>;
-
-    beforeEach(function*() {
-      atom = createAtom({ data: 'foo' });
-      slice = atom.slice('data');
-    });
-
-    describe('when initial state matches', () => {
-      beforeEach(function*() {
-        result = yield spawn(slice.once((state) => state === 'foo'));
-
-        slice.update(() => 'bar');
-      });
-
-      it('gets the first state that passes the given predicate', function*() {
-        expect(yield result).toEqual('foo');
-        expect(slice.get()).toEqual('bar');
-      });
-    });
-
-    describe('when initial state does not match', () => {
-      beforeEach(function*() {
-        result = yield spawn(slice.once((state) => state === 'baz'));
-
-        slice.update(() => 'bar');
-        slice.update(() => 'baz');
-        slice.update(() => 'quox');
-      });
-
-      it('gets the first state that passes the given predicate', function*() {
-        expect(yield result).toEqual('baz');
-        expect(slice.get()).toEqual('quox');
-      });
-    });
-  });
-
-
   describe('subscribe', () => {
     let atom: Slice<Data>;
     let slice: Slice<string>;


### PR DESCRIPTION
We should remove this before v2 is relased.

Closes #514