### PR TITLE
Enable resource support for higher order operations

### DIFF
--- a/.changes/higher-order-operations.md
+++ b/.changes/higher-order-operations.md
@@ -1,0 +1,5 @@
+---
+"@effection/core": "minor"
+---
+
+Enable support for resources in higher order operations `all`, `race` and `withTimeout`.

--- a/packages/core/src/operations/race.ts
+++ b/packages/core/src/operations/race.ts
@@ -1,20 +1,29 @@
 import type { Operation } from '../operation';
+import type { Task } from '../task';
 import { withLabels } from '../labels';
+import { createFuture } from '../future';
 
 export function race<T>(operations: Operation<T>[]): Operation<T> {
-  return withLabels((scope) => ({
-    perform: (resolve, reject) => {
-      for (let operation of operations) {
-        if(scope.state === 'running') {
-          scope.run(function*() {
-            try {
-              resolve(yield operation);
-            } catch (e) {
-              reject(e);
-            }
-          });
-        }
+  return withLabels(function*(task) {
+    let { resolve, future } = createFuture<Task>();
+    let tasks: Task[] = [];
+
+    for (let operation of operations) {
+      if(task.state === 'running') {
+        let child = task.run(operation, { ignoreError: true, scope: task.options.scope });
+        child.consume(() => resolve(child));
+        tasks.push(child);
       }
     }
-  }), { name: 'race', count: operations.length });
+
+    let resultChild = yield future;
+
+    for(let child of tasks) {
+      if(child !== resultChild) {
+        child.halt();
+      }
+    }
+
+    return yield resultChild;
+  }, { name: 'race', count: operations.length });
 }

--- a/packages/core/src/operations/with-timeout.ts
+++ b/packages/core/src/operations/with-timeout.ts
@@ -1,11 +1,11 @@
 import { Operation } from '../operation';
 import { timeout } from './timeout';
-import { spawn } from './spawn';
-import { withLabels } from '../labels';
+import { race } from './race';
+import { setLabels } from '../labels';
 
 export function withTimeout<T>(duration: number, operation: Operation<T>): Operation<T> {
-  return withLabels(function*() {
-    yield spawn(timeout(duration));
-    return yield operation;
-  }, { name: 'withTimeout', duration });
+  return setLabels(
+    race([timeout(duration) as Operation<T>, operation]),
+    { name: 'withTimeout', duration }
+  );
 }

--- a/packages/core/test/operations/with-timeout.test.ts
+++ b/packages/core/test/operations/with-timeout.test.ts
@@ -1,4 +1,4 @@
-import '../setup';
+import { asyncResource } from '../setup';
 import { describe, it } from 'mocha';
 import expect from 'expect';
 
@@ -21,6 +21,36 @@ describe('withTimeout', () => {
     }));
 
     await expect(root).rejects.toHaveProperty('message', 'timed out after 5ms');
+  });
+
+  describe("with resource", () => {
+    it("resolves when resources resolves before timeout", async () => {
+      await run(function*() {
+        let fooStatus = { status: 'pending' };
+        let result = yield withTimeout(30, asyncResource(10, "foo", fooStatus));
+
+        expect(result).toEqual('foo');
+        expect(fooStatus.status).toEqual('pending');
+        yield sleep(60);
+        expect(fooStatus.status).toEqual('active');
+      });
+    });
+
+    it("rejects when one of the operations reject", async () => {
+      await run(function*() {
+        let fooStatus = { status: 'pending' };
+        let error;
+        try {
+          yield withTimeout(10, asyncResource(30, "foo", fooStatus));
+        } catch(err) {
+          error = err;
+        }
+
+        expect(error).toHaveProperty("message", "timed out after 10ms");
+        yield sleep(60);
+        expect(fooStatus.status).toEqual('pending');
+      });
+    });
   });
 
   it('applies labels', () => {

--- a/packages/core/test/setup.ts
+++ b/packages/core/test/setup.ts
@@ -1,4 +1,4 @@
-import { Effection, Operation, sleep } from '../src/index';
+import { Effection, Operation, Resource, sleep, spawn } from '../src/index';
 import { beforeEach } from 'mocha';
 
 beforeEach(async () => {
@@ -35,3 +35,15 @@ export function *syncReject(value: string): Operation<string> {
   throw new Error(`boom: ${value}`);
 }
 
+export function asyncResource(duration: number, value: string, status: { status: string }): Resource<string> {
+  return {
+    *init() {
+      yield spawn(function*() {
+        yield sleep(duration + 10);
+        status.status = 'active';
+      });
+      yield sleep(duration);
+      return value;
+    }
+  };
+}


### PR DESCRIPTION
See #502 

This makes the `all`, `race` and `withTimeout` operations work properly with resources

Depends on #533 