### PR TITLE
Fix inspect files export

### DIFF
--- a/.changes/fix-files-export.md
+++ b/.changes/fix-files-export.md
@@ -1,0 +1,5 @@
+---
+"@effection/inspect-utils": patch
+"@effection/inspect-ui": patch
+---
+fix files array in inspect package.json

--- a/packages/inspect-ui/package.json
+++ b/packages/inspect-ui/package.json
@@ -18,7 +18,7 @@
   "files": [
     "README.md",
     "CHANGELOG.md",
-    "dist/**/*",
+    "dist-*/**/*",
     "src/**/*"
   ],
   "scripts": {

--- a/packages/inspect-utils/package.json
+++ b/packages/inspect-utils/package.json
@@ -17,7 +17,7 @@
   "files": [
     "README.md",
     "CHANGELOG.md",
-    "dist/**/*",
+    "dist-*/**/*",
     "src/**/*"
   ],
   "scripts": {


### PR DESCRIPTION
## Motivation

Files array in `inspect-ui` and `inspect-utils` was pointing to the old `dist/**/*` setup.

## Approach

change to `dist-**/**/*`
