### PR TITLE
Add `setLabels` helper

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,7 +7,7 @@ export { createTask, Task, TaskOptions, TaskInfo, TaskTree } from './task';
 export { Operation, Resource } from './operation';
 export { Effection } from './effection';
 export { deprecated } from './deprecated';
-export { Labels, withLabels } from './labels';
+export { Labels, withLabels, setLabels } from './labels';
 export { HasEffectionTrace } from './error';
 export { createFuture, Future, FutureLike } from './future';
 

--- a/packages/core/src/labels.ts
+++ b/packages/core/src/labels.ts
@@ -8,3 +8,10 @@ export function withLabels<T>(operation: Operation<T>, labels: Labels): Operatio
   }
   return operation;
 }
+
+export function setLabels<T>(operation: Operation<T>, labels: Labels): Operation<T> {
+  if(operation) {
+    operation.labels = labels;
+  }
+  return operation;
+}


### PR DESCRIPTION
We already have `withLabels`, which is adds the given labels to the existing labels. Sometimes however, we already have some labels and we want to completely override them, for these cases `setLabels` simply replaces the labels of an operation. This is useful when composing operations out of other operations which already have labels:

``` typescript
const withTimeout = (duration, operation) => setLabels(race(timeout(duration), operation), { name: 'withTimeout, duration });
```