### PR TITLE
Catch errors thrown during resource init

### DIFF
--- a/.changes/catch-init-error.md
+++ b/.changes/catch-init-error.md
@@ -1,0 +1,5 @@
+---
+"@effection/core": "minor"
+---
+
+Adjust the propagation of errors for resources to make it possible to catch errors from `init`

--- a/packages/core/src/controller/resource-controller.ts
+++ b/packages/core/src/controller/resource-controller.ts
@@ -21,13 +21,19 @@ export function createResourceController<TOut>(task: Task<TOut>, resource: Resou
 
     initTask = resourceTask.run((task) => resource.init(resourceTask, task), {
       yieldScope: resourceTask,
-      labels: { name: 'init' }
+      labels: { name: 'init' },
+      ignoreError: true,
     });
-    initTask.consume(produce);
+    initTask.consume((value) => {
+      if(value.state !== 'completed') {
+        resourceTask.halt();
+      }
+      produce(value);
+    });
   }
 
   function halt() {
-    initTask?.halt();
+    resourceTask?.halt();
   }
 
   return {

--- a/packages/core/src/task.ts
+++ b/packages/core/src/task.ts
@@ -139,6 +139,7 @@ export function createTask<TOut = unknown>(operation: Operation<TOut>, options: 
     },
 
     async halt() {
+      controller.halt();
       if(stateMachine.current === 'running') {
         stateMachine.halting();
         result = { state: 'halted' };
@@ -216,6 +217,7 @@ export function createTask<TOut = unknown>(operation: Operation<TOut>, options: 
             stateMachine.erroring();
             result = { state: 'errored', error: addTrace(value.error, task) };
 
+            controller.halt();
             shutdown(true);
           }
           if(children.has(child)) {
@@ -231,7 +233,6 @@ export function createTask<TOut = unknown>(operation: Operation<TOut>, options: 
   }
 
   function shutdown(force: boolean) {
-    controller.halt();
     controller.future.consume(() => {
       let nextChild: Task | undefined;
       function haltNextChild() {


### PR DESCRIPTION
Closes #535

This adjusts the propagation of errors for resources so that errors thrown during `init` can be cought. Previously, an error thrown during `init` would propagate to the resource task, causing the resource task to fail. This would have the undesirable side-effect that even if the `init` error was caught (for example to retry), then the outer task would still fail, due to the failure in the resource task.

Instead, a failure in `init` now causes the resource task to become *halted* rather than *errored*, sort of as though it were a sibling, while still maintaining the existing hierarchy of the `init` task being a child.

This means that just as before, a failure in `init` will cause the resource to be shut down, but this failure will not propagate out to the outer task. Since the failure will always be thrown from the *resource constructor*, the failure will still propagate, but we have more control, since we can catch the error from the resource constructor if it is yielded to.