### PR TITLE
Improve process streams

### DIFF
--- a/.changes/buffer-resource.md
+++ b/.changes/buffer-resource.md
@@ -1,0 +1,5 @@
+---
+"@effection/subscription": "minor"
+---
+
+The `buffer` method on `Stream` returns a resource and can receive an optional limit using a ring buffer for efficient bounded caching

--- a/.changes/config.json
+++ b/.changes/config.json
@@ -119,7 +119,6 @@
       "path": "./packages/process",
       "manager": "javascript",
       "dependencies": [
-        "@effection/channel",
         "@effection/core",
         "@effection/events",
         "@effection/stream"

--- a/.changes/process-std.md
+++ b/.changes/process-std.md
@@ -1,0 +1,5 @@
+---
+"@effection/process": "minor"
+---
+
+The `stdout` and `stderr` properties now return `OutputStream` instead of regular `Stream`. Addiotionally, the `buffered` option has been removed.

--- a/.changes/remove-string-buffer.md
+++ b/.changes/remove-string-buffer.md
@@ -1,0 +1,5 @@
+---
+"@effection/subscription": "minor"
+---
+
+Remove the `stringBuffer` method on `Stream`

--- a/packages/main/test/node.test.ts
+++ b/packages/main/test/node.test.ts
@@ -1,17 +1,20 @@
 import expect from 'expect';
 import { describe, it, beforeEach } from '@effection/mocha';
+import { Stream } from '@effection/stream';
 
 import { exec, Process, ProcessResult } from '@effection/process';
 import { terminate, interrupt } from './helpers';
 
 describe('main', () => {
   let child: Process;
+  let stdout: Stream<string>;
 
   describe('with successful process', () => {
     beforeEach(function*() {
-      child = yield exec(`ts-node ./test/fixtures/text-writer.ts`, { buffered: true });
+      child = yield exec(`ts-node ./test/fixtures/text-writer.ts`);
+      stdout = yield child.stdout.lines().buffer();
 
-      yield child.stdout.filter((s) => s.includes("started")).expect();
+      yield stdout.grep("started").expect();
     });
 
     describe('interrupting the process', () => {
@@ -21,7 +24,7 @@ describe('main', () => {
       });
 
       it('shuts down gracefully', function*() {
-        yield child.stdout.filter((s) => s.includes("stopped")).expect();
+        yield stdout.grep("stopped").expect();
       });
     });
 
@@ -32,7 +35,7 @@ describe('main', () => {
       });
 
       it('shuts down gracefully', function*() {
-        yield child.stdout.filter((s) => s.includes("stopped")).expect();
+        yield stdout.grep("stopped").expect();
       });
     });
   });

--- a/packages/process/package.json
+++ b/packages/process/package.json
@@ -40,7 +40,6 @@
     "typescript": "^4.3.5"
   },
   "dependencies": {
-    "@effection/channel": "2.0.0-beta.16",
     "@effection/core": "2.0.0-beta.14",
     "@effection/events": "2.0.0-beta.16",
     "@effection/stream": "2.0.0-beta.1",

--- a/packages/process/src/exec.ts
+++ b/packages/process/src/exec.ts
@@ -1,7 +1,7 @@
 /// <reference types="../types/shellwords" />
 import { split } from 'shellwords';
 
-import { Task, Operation, Resource, withLabels } from '@effection/core';
+import { Task, Operation, Resource, spawn, withLabels } from '@effection/core';
 import { ExecOptions, Process, ProcessResult, CreateOSProcess } from './exec/api';
 import { createPosixProcess } from './exec/posix';
 import { createWin32Process, isWin32 } from './exec/win32';
@@ -42,22 +42,30 @@ export function exec(command: string, options: ExecOptions = {}): Exec {
     },
     join() {
       return withLabels(function*() {
-        let process = yield createProcess(cmd, { ...opts, buffered: true });
+        let process: Process = yield createProcess(cmd, opts);
+
+        let stdout = "";
+        let stderr = "";
+
+        yield spawn(process.stdout.forEach((chunk) => { stdout += chunk }));
+        yield spawn(process.stderr.forEach((chunk) => { stderr += chunk }));
 
         let status = yield process.join();
-        let stdout = yield process.stdout.expect();
-        let stderr = yield process.stderr.expect();
 
         return { ...status, stdout, stderr };
       }, { name: `exec(${JSON.stringify(command)}).join()`, expand: false });
     },
     expect() {
       return withLabels(function*() {
-        let process = yield createProcess(cmd, { ...opts, buffered: true });
+        let process: Process = yield createProcess(cmd, opts);
+
+        let stdout = "";
+        let stderr = "";
+
+        yield spawn(process.stdout.forEach((chunk) => { stdout += chunk }));
+        yield spawn(process.stderr.forEach((chunk) => { stderr += chunk }));
 
         let status = yield process.expect();
-        let stdout = yield process.stdout.expect();
-        let stderr = yield process.stderr.expect();
 
         return { ...status, stdout, stderr };
       }, { name: `exec(${JSON.stringify(command)}).expect()`, expand: false });

--- a/packages/process/src/exec/api.ts
+++ b/packages/process/src/exec/api.ts
@@ -1,5 +1,5 @@
 import { Operation, Resource } from '@effection/core';
-import { Stream } from '@effection/stream';
+import { OutputStream } from '../output-stream';
 
 // TODO: import from subscription package once #236 is merged
 export interface Writable<T> {
@@ -49,16 +49,11 @@ export interface ExecOptions {
    * Sets the working directory of the process
    */
   cwd?: string;
-
-  /**
-   * Skip buffering of output streams
-   */
-  buffered?: boolean;
 }
 
 export interface StdIO {
-  stdout: Stream<string>;
-  stderr: Stream<string>;
+  stdout: OutputStream;
+  stderr: OutputStream;
   stdin: Writable<string>;
 }
 

--- a/packages/process/src/exec/posix.ts
+++ b/packages/process/src/exec/posix.ts
@@ -1,9 +1,9 @@
 import { spawn, Task, createFuture, withLabels } from '@effection/core';
-import { createChannel } from '@effection/channel';
 import { on, once, onceEmit } from '@effection/events';
 import { spawn as spawnProcess } from 'child_process';
 import { Writable, ExitStatus, CreateOSProcess } from './api';
 import { ExecError } from './error';
+import { createOutputStream } from '../output-stream';
 
 type Result = { type: 'error'; value: unknown } | { type: 'status'; value: [number?, string?] };
 
@@ -50,8 +50,17 @@ export const createPosixProcess: CreateOSProcess = (command, options) => {
 
       let { pid } = childProcess;
 
-      let stdoutChannel = createChannel<string>({ name: 'stdout' });
-      let stderrChannel = createChannel<string>({ name: 'stderr' });
+      let stdout = createOutputStream(function*(publish) {
+        yield spawn(on<Buffer>(childProcess.stdout, 'data').forEach(publish));
+        yield future;
+        return undefined;
+      }, 'stdout');
+
+      let stderr = createOutputStream(function*(publish) {
+        yield spawn(on<Buffer>(childProcess.stderr, 'data').forEach(publish));
+        yield future;
+        return undefined;
+      }, 'stderr');
 
       let stdin: Writable<string> = {
         send(data: string) {
@@ -66,16 +75,11 @@ export const createPosixProcess: CreateOSProcess = (command, options) => {
           scope.setLabels({ state: 'errored' });
         });
 
-        yield spawn(on<Buffer>(childProcess.stdout, 'data', 'stdout').map((c) => c.toString()).forEach(stdoutChannel.send));
-        yield spawn(on<Buffer>(childProcess.stderr, 'data', 'stderr').map((c) => c.toString()).forEach(stderrChannel.send));
-
         try {
           let value = yield onceEmit(childProcess, 'exit');
           produce({ state: 'completed', value: { type: 'status', value } });
           scope.setLabels({ state: 'terminated', exitCode: value[0], signal: value[1] });
         } finally {
-          stdoutChannel.close();
-          stderrChannel.close();
           try {
             if(typeof childProcess.pid === 'undefined') {
               throw new Error('no pid for childProcess');
@@ -86,14 +90,6 @@ export const createPosixProcess: CreateOSProcess = (command, options) => {
           }
         }
       });
-
-      let { stream: stdout } = stdoutChannel;
-      let { stream: stderr } = stderrChannel;
-
-      if(options.buffered) {
-        stdout = stdout.stringBuffer(scope);
-        stderr = stderr.stringBuffer(scope);
-      }
 
       return { pid: pid as number, stdin, stdout, stderr, join, expect };
     }

--- a/packages/process/src/exec/win32.ts
+++ b/packages/process/src/exec/win32.ts
@@ -1,11 +1,11 @@
 import { platform } from "os";
 import { spawn, Task, Operation, createFuture } from '@effection/core';
-import { createChannel } from '@effection/channel';
 import { on, once, onceEmit } from "@effection/events";
 import { spawn as spawnProcess } from "cross-spawn";
 import { ctrlc } from "ctrlc-windows";
 import { ExitStatus, CreateOSProcess } from "./api";
 import { ExecError } from "./error";
+import { createOutputStream } from '../output-stream';
 
 type Result =
   | { type: "error"; value: unknown }
@@ -57,8 +57,18 @@ export const createWin32Process: CreateOSProcess = (command, options) => {
 
       let { pid } = childProcess;
 
-      let stdoutChannel = createChannel<string>({ name: 'stdout' });
-      let stderrChannel = createChannel<string>({ name: 'stderr' });
+      let stdout = createOutputStream(function*(publish) {
+        yield spawn(on<Buffer>(childProcess.stdout, 'data').forEach(publish));
+        yield future;
+        return undefined;
+      }, 'stdout');
+
+      let stderr = createOutputStream(function*(publish) {
+        yield spawn(on<Buffer>(childProcess.stderr, 'data').forEach(publish));
+        yield future;
+        return undefined;
+      }, 'stderr');
+
       let stdin = {
         send(data: string) {
           childProcess.stdin.write(data);
@@ -72,16 +82,11 @@ export const createWin32Process: CreateOSProcess = (command, options) => {
           scope.setLabels({ state: 'errored' });
         });
 
-        yield spawn(on<Buffer>(childProcess.stdout, 'data', 'stdout').map((c) => c.toString()).forEach(stdoutChannel.send));
-        yield spawn(on<Buffer>(childProcess.stderr, 'data', 'stderr').map((c) => c.toString()).forEach(stderrChannel.send));
-
         try {
           let value = yield onceEmit(childProcess, 'exit');
           produce({ state: 'completed', value: { type: 'status', value } });
           scope.setLabels({ state: 'terminated', exitCode: value[0], signal: value[1] });
         } finally {
-          stdoutChannel.close();
-          stderrChannel.close();
           if (pid) {
             ctrlc(pid);
             let stdin = childProcess.stdin;
@@ -95,14 +100,6 @@ export const createWin32Process: CreateOSProcess = (command, options) => {
           }
         }
       });
-
-      let { stream: stdout } = stdoutChannel;
-      let { stream: stderr } = stderrChannel;
-
-      if(options.buffered) {
-        stdout = stdout.stringBuffer(scope);
-        stderr = stderr.stringBuffer(scope);
-      }
 
       return { pid: pid as number, stdin, stdout, stderr, join, expect };
     }

--- a/packages/process/src/output-stream.ts
+++ b/packages/process/src/output-stream.ts
@@ -1,0 +1,40 @@
+import { Operation } from '@effection/core';
+import { Stream, createStream } from '@effection/stream';
+
+export type Callback<T,TReturn> = (publish: (value: T) => void) => Operation<TReturn>;
+
+export interface OutputStream extends Stream<Buffer> {
+  text(): Stream<string>;
+  lines(): Stream<string>;
+}
+
+export function createOutputStream(callbackOrStream: Stream<Buffer> | Callback<Buffer, undefined>, name = 'iostream'): OutputStream {
+  let stream: Stream<Buffer>;
+  if(typeof(callbackOrStream) === 'function') {
+    stream = createStream<Buffer, undefined>(callbackOrStream, name);
+  } else {
+    stream = callbackOrStream;
+  }
+
+  return Object.assign(stream, {
+    text() {
+      return stream.map((c) => c.toString());
+    },
+    lines() {
+      return createStream<string, undefined>(function*(publish) {
+        let current = "";
+        yield stream.forEach(function*(chunk) {
+          let lines = (current + chunk.toString()).split('\n');
+          lines.slice(0, -1).forEach(publish);
+          current = lines.slice(-1)[0];
+        });
+
+        if(current) {
+          publish(current);
+        }
+
+        return undefined;
+      }, name);
+    }
+  });
+}

--- a/packages/process/test/exec.test.ts
+++ b/packages/process/test/exec.test.ts
@@ -89,13 +89,12 @@ describe('exec', () => {
         proc = yield exec("node './fixtures/echo-server.js'", {
           env: { PORT: '29000', PATH: process.env.PATH as string },
           cwd: __dirname,
-          buffered: true,
         });
 
         joinStdout = yield spawn(proc.stdout.join());
         joinStderr = yield spawn(proc.stderr.join());
 
-        yield proc.stdout.filter((v) => v.includes('listening')).expect();
+        yield proc.stdout.lines().filter((v) => v.includes('listening')).expect();
       });
 
       it('has a pid', function*() {
@@ -120,10 +119,6 @@ describe('exec', () => {
 
         it('closes stdout and stderr', function*() {
           yield proc.expect();
-          let output = yield proc.stdout.expect();
-          let errput = yield proc.stderr.expect();
-          expect(output).toContain('exit(0)');
-          expect(errput).toContain('got request');
           expect(yield joinStdout).toEqual(undefined);
           expect(yield joinStderr).toEqual(undefined);
         });

--- a/packages/process/test/helpers.ts
+++ b/packages/process/test/helpers.ts
@@ -1,14 +1,9 @@
-import { performance } from 'perf_hooks';
-import { beforeEach } from 'mocha';
-import expect from 'expect';
-import { run, Task } from '@effection/core';
-import { Channel } from '@effection/channel';
 import { ctrlc } from 'ctrlc-windows';
-import { exec, Process } from '../src/exec';
+import { Process } from '../src/exec';
 
 const isWin32 = global.process.platform === 'win32';
 
-export function terminate(process: Process) {
+export function terminate(process: Process): void {
   if (isWin32) {
     ctrlc(process.pid);
     //Terminate batch process? (Y/N)
@@ -21,7 +16,7 @@ export function terminate(process: Process) {
 // cross platform user initiated graceful shutdown request. What would
 // be sent to the process by the Operating system when
 // a users requests an interrupt via CTRL-C or equivalent.
-export function interrupt(process: Process) {
+export function interrupt(process: Process): void {
   if (isWin32) {
     ctrlc(process.pid);
     //Terminate batch process? (Y/N)

--- a/packages/process/test/output-stream.test.ts
+++ b/packages/process/test/output-stream.test.ts
@@ -1,0 +1,66 @@
+import expect from 'expect';
+import { describe, it } from '@effection/mocha';
+import { createStream } from '@effection/stream';
+
+import { createOutputStream } from '../src/output-stream';
+
+const b = (value: string) => Buffer.from(value, 'utf8');
+
+describe('createOutputStream', () => {
+  it('can be created from regular stream', function*() {
+    let stream = createStream<Buffer>(function*(publish) {
+      publish(b("foo"));
+      publish(b("bar"));
+      publish(b("baz"));
+      return undefined;
+    });
+    let ioStream = createOutputStream(stream);
+    let values: Buffer[] = [];
+
+    yield ioStream.forEach((item) => function*() { values.push(item); });
+    expect(values).toEqual([b("foo"), b("bar"), b("baz")]);
+  });
+
+  it('works like a regular stream', function*() {
+    let stream = createOutputStream(function*(publish) {
+      publish(b("foo"));
+      publish(b("bar"));
+      publish(b("baz"));
+      return undefined;
+    });
+    let values: Buffer[] = [];
+
+    yield stream.forEach((item) => function*() { values.push(item); });
+    expect(values).toEqual([b("foo"), b("bar"), b("baz")]);
+  });
+
+  describe('text()', () => {
+    it('maps output to string', function*() {
+      let stream = createOutputStream(function*(publish) {
+        publish(b("foo"));
+        publish(b("bar"));
+        publish(b("baz"));
+        return undefined;
+      });
+      let values: string[] = [];
+
+      yield stream.text().forEach((item) => function*() { values.push(item); });
+      expect(values).toEqual(["foo", "bar", "baz"]);
+    });
+  });
+
+  describe('lines()', () => {
+    it('combines output into complete lines', function*() {
+      let stream = createOutputStream(function*(publish) {
+        publish(b("foo\nhello"));
+        publish(b("world\n"));
+        publish(b("something"));
+        return undefined;
+      });
+      let values: string[] = [];
+
+      yield stream.lines().forEach((item) => function*() { values.push(item); });
+      expect(values).toEqual(["foo", "helloworld", "something"]);
+    });
+  });
+});

--- a/packages/process/tsconfig.cjs.json
+++ b/packages/process/tsconfig.cjs.json
@@ -6,7 +6,6 @@
     "noEmit": false
   },
   "references": [
-    { "path": "../channel/tsconfig.cjs.json" },
     { "path": "../core/tsconfig.cjs.json" },
     { "path": "../events/tsconfig.cjs.json" },
     { "path": "../subscription/tsconfig.cjs.json" }

--- a/packages/process/tsconfig.esm.json
+++ b/packages/process/tsconfig.esm.json
@@ -5,7 +5,6 @@
     "module": "ESNext"
   },
   "references": [
-    { "path": "../channel/tsconfig.esm.json" },
     { "path": "../core/tsconfig.esm.json" },
     { "path": "../events/tsconfig.esm.json" },
     { "path": "../subscription/tsconfig.esm.json" }

--- a/packages/process/tsconfig.json
+++ b/packages/process/tsconfig.json
@@ -3,9 +3,8 @@
   "compilerOptions": {
     "baseUrl": ".",
     "noEmit": true
-  },  
+  },
   "references": [
-    { "path": "../channel/tsconfig.cjs.json" },
     { "path": "../core/tsconfig.cjs.json" },
     { "path": "../events/tsconfig.cjs.json" },
     { "path": "../subscription/tsconfig.cjs.json" }

--- a/packages/stream/src/buffer.ts
+++ b/packages/stream/src/buffer.ts
@@ -1,0 +1,32 @@
+export interface Buffer<T> extends Iterable<T> {
+  push(value: T): void;
+}
+
+export function createBuffer<T>(size = Infinity): Buffer<T> {
+  if(size === Infinity) {
+    return new Array<T>();
+  } else {
+    return createRingBuffer<T>(size);
+  }
+}
+
+export function createRingBuffer<T>(size: number): Buffer<T> {
+  let head = 0;
+  let buffer: T[] = [];
+
+  return {
+    push(value: T): void {
+      buffer[head] = value;
+      head += 1;
+      if(head >= size) {
+        head = 0;
+      }
+    },
+
+    *[Symbol.iterator]() {
+      for(let current = 0; current < buffer.length; current++) {
+        yield buffer[(current + head) % buffer.length];
+      }
+    }
+  };
+}

--- a/packages/stream/src/index.ts
+++ b/packages/stream/src/index.ts
@@ -1,4 +1,4 @@
 export { SymbolOperationIterable } from './symbol-operation-iterable';
 export { OperationIterable } from './operation-iterable';
-export { createStream, Stream, StringBufferStream } from './stream';
+export { createStream, Stream } from './stream';
 export { Writable, WritableStream } from './writable-stream';

--- a/packages/stream/src/stream.ts
+++ b/packages/stream/src/stream.ts
@@ -1,10 +1,11 @@
 import { createQueue, Subscription } from '@effection/subscription';
-import { Operation, Task, Resource } from '@effection/core';
+import { Operation, Task, Resource, spawn } from '@effection/core';
 import { DeepPartial, matcher } from './match';
 import { OperationIterable, ToOperationIterator } from './operation-iterable';
 import { SymbolOperationIterable } from './symbol-operation-iterable';
+import { createBuffer } from './buffer';
 
-type Callback<T,TReturn> = (publish: (value: T) => void) => Operation<TReturn>;
+export type Callback<T,TReturn> = (publish: (value: T) => void) => Operation<TReturn>;
 
 export interface Stream<T, TReturn = undefined> extends OperationIterable<T, TReturn>, Resource<Subscription<T, TReturn>> {
   filter<R extends T>(predicate: (value: T) => value is R): Stream<R, TReturn>;
@@ -21,12 +22,7 @@ export interface Stream<T, TReturn = undefined> extends OperationIterable<T, TRe
   collect(): Operation<Iterator<T, TReturn>>;
   toArray(): Operation<T[]>;
   subscribe(scope: Task): Subscription<T, TReturn>;
-  buffer(scope: Task): Stream<T, TReturn>;
-  stringBuffer(scope: Task): StringBufferStream<TReturn>;
-}
-
-export interface StringBufferStream<TReturn = undefined> extends Stream<string, TReturn> {
-  value: string;
+  buffer(limit?: number): Resource<Stream<T, TReturn>>;
 }
 
 export function createStream<T, TReturn = undefined>(callback: Callback<T, TReturn>, name = 'stream'): Stream<T, TReturn> {
@@ -104,35 +100,19 @@ export function createStream<T, TReturn = undefined>(callback: Callback<T, TRetu
       return task => subscribe(task).toArray();
     },
 
-    buffer(scope: Task): Stream<T, TReturn> {
-      let buffer: T[] = [];
-
-      scope.run(stream.forEach((m) => { buffer.push(m) }));
-
-      return createStream((publish) => function*() {
-        buffer.forEach(publish);
-        return yield stream.forEach(publish);
-      });
-    },
-
-    stringBuffer(scope: Task): StringBufferStream<TReturn> {
-      let buffer = "";
-
-      scope.run(stream.forEach((m) => { buffer += `${m}` }));
-
-      let result = createStream<string, TReturn>((publish) => function*() {
-        let internalBuffer = buffer;
-        publish(internalBuffer);
-        return yield stream.forEach((m: T) => {
-          internalBuffer += `${m}`;
-          publish(internalBuffer);
-        });
-      });
-
+    buffer(limit = Infinity): Resource<Stream<T, TReturn>> {
       return {
-        ...result,
-        get value(): string {
-          return buffer;
+        *init() {
+          let buffer = createBuffer<T>(limit);
+
+          yield spawn(stream.forEach((value) => { buffer.push(value) }));
+
+          return createStream<T, TReturn>((publish) => function*() {
+            for(let value of buffer) {
+              publish(value);
+            }
+            return yield stream.forEach(publish);
+          });
         }
       };
     },

--- a/packages/stream/test/buffer.test.ts
+++ b/packages/stream/test/buffer.test.ts
@@ -1,0 +1,72 @@
+import expect from 'expect';
+import { describe, it } from '@effection/mocha';
+
+import { createBuffer } from '../src/buffer';
+
+describe('createBuffer', () => {
+  it('limits pushed values', function*() {
+    let buffer = createBuffer<number>(3);
+
+    buffer.push(1);
+    buffer.push(2);
+    expect(Array.from(buffer)).toEqual([1,2]);
+
+    buffer.push(3);
+    expect(Array.from(buffer)).toEqual([1,2,3]);
+
+    buffer.push(4);
+    expect(Array.from(buffer)).toEqual([2,3,4]);
+  });
+
+  it('can iterate half full buffer', function*() {
+    let buffer = createBuffer<number>(3);
+
+    buffer.push(1);
+    buffer.push(2);
+
+    let result = [];
+    for(let value of buffer) {
+      result.push(value);
+    }
+    expect(result).toEqual([1,2]);
+  });
+
+  it('can iterate full buffer', function*() {
+    let buffer = createBuffer<number>(3);
+
+    buffer.push(1);
+    buffer.push(2);
+    buffer.push(3);
+
+    let result = [];
+    for(let value of buffer) {
+      result.push(value);
+    }
+    expect(result).toEqual([1,2,3]);
+  });
+
+  it('can iterate overfull buffer', function*() {
+    let buffer = createBuffer<number>(3);
+
+    buffer.push(1);
+    buffer.push(2);
+    buffer.push(3);
+    buffer.push(4);
+
+    let result = [];
+    for(let value of buffer) {
+      result.push(value);
+    }
+    expect(result).toEqual([2,3,4]);
+  });
+
+  it('does nothing when iterating empty buffer', function*() {
+    let buffer = createBuffer<number>(3);
+
+    let result = [];
+    for(let value of buffer) {
+      result.push(value);
+    }
+    expect(result).toEqual([]);
+  });
+});


### PR DESCRIPTION
This makes a number of pretty significant and breaking changes to process streams, in the hopes of making them more useful, more consistent and easier to understand.

While we have found a pretty intuitive API for working with the processes themselves, their stdout and stderr streams have been a bit neglected. We are already foreseeing some things that we want to do in bigtest that are difficult to do with the current API.

First of all we create a solid foundation by making the std streams over Buffers. This is what node exposes by default, and since we would pay a performance penalty in cases where we unncessarily convert to strings, we should just expose this.

However, working with raw buffers is tedious, so we expose two smart mapping functions on iostreams `text()` and `lines()`. `text()` just converts the buffers into strings. `lines` is a bit fancier and creates a new stream which emits once for each printed line (waiting until the line is complete).

Additionally we improve the `buffer` function on `Stream` by making it return a resource, and also taking an optional limit, so we can create a bounded buffer using a RingBuffer behind the scenes.

In bigtest we have previously wanted to cache the previous X number of lines. With this change, something like the following becomes possible, which was previously pretty challenging:

``` typescript
let app = yield exec(options.appCommand);
let lines = yield app.stdout.lines.buffer(1000);

yield lines.filter((l) => l.includes('ready')).expect();
```