### PR TITLE
Add grep method to Stream

### DIFF
--- a/.changes/stream-grep.md
+++ b/.changes/stream-grep.md
@@ -1,0 +1,5 @@
+---
+"@effection/subscription": "minor"
+---
+
+Add `grep` method to streams to scan items for given substring or regexp

--- a/packages/subscription/src/stream.ts
+++ b/packages/subscription/src/stream.ts
@@ -12,6 +12,7 @@ export interface Stream<T, TReturn = undefined> extends OperationIterable<T, TRe
   filter(predicate: (value: T) => boolean): Stream<T, TReturn>;
   filter(predicate: (value: T) => boolean): Stream<T, TReturn>;
   match(reference: DeepPartial<T>): Stream<T,TReturn>;
+  grep(search: string | RegExp): Stream<T,TReturn>;
   map<R>(mapper: (value: T) => R): Stream<R, TReturn>;
 
   first(): Operation<T | undefined>;
@@ -62,6 +63,14 @@ export function createStream<T, TReturn = undefined>(callback: Callback<T, TRetu
 
     match(reference: DeepPartial<T>): Stream<T,TReturn> {
       return stream.filter(matcher(reference));
+    },
+
+    grep(search: string | RegExp): Stream<T,TReturn> {
+      if(typeof(search) === 'string') {
+        return stream.filter((value) => String(value).includes(search));
+      } else {
+        return stream.filter((value) => !!String(value).match(search));
+      }
     },
 
     map<R>(mapper: (value: T) => R): Stream<R, TReturn> {

--- a/packages/subscription/test/stream.test.ts
+++ b/packages/subscription/test/stream.test.ts
@@ -118,6 +118,21 @@ describe('Stream', () => {
     });
   });
 
+  describe('grep', () => {
+    it('filters the values based on the given regexp', function*() {
+      let matched = yield stuff.map((v) => v.name).grep(/bob|alice/).collect();
+      expect(matched.next()).toEqual({ done: false, value: 'bob' });
+      expect(matched.next()).toEqual({ done: false, value: 'alice' });
+      expect(matched.next()).toEqual({ done: true, value: 3 });
+    });
+
+    it('filters the values based on the given substring', function*() {
+      let matched = yield stuff.map((v) => v.name).grep('ob').collect();
+      expect(matched.next()).toEqual({ done: false, value: 'bob' });
+      expect(matched.next()).toEqual({ done: true, value: 3 });
+    });
+  });
+
   describe('first', () => {
     it('returns the first item in the subscription', function*() {
       expect(yield stuff.first()).toEqual({ name: 'bob', type: 'person' });


### PR DESCRIPTION
This adds a grep method to stream, the point of this is to make it easier to scan for a given string, especially in the upcoming iostreams.

``` typescript
// before
yield myProcess.stdout.lines().filter((l) => l.includes("ready")).expect();
// after
yield myProcess.stdout.lines().grep("ready").expect();
```