### PR TITLE
Add stream merge function

### DIFF
--- a/.changes/stream-merge.md
+++ b/.changes/stream-merge.md
@@ -1,0 +1,5 @@
+---
+"@effection/subscription": "minor"
+---
+
+Add `Stream.merge` function to merge multiple streams into one

--- a/packages/stream/src/stream.ts
+++ b/packages/stream/src/stream.ts
@@ -1,5 +1,5 @@
 import { createQueue, Subscription } from '@effection/subscription';
-import { Operation, Task, Resource } from '@effection/core';
+import { Operation, Task, Resource, spawn } from '@effection/core';
 import { DeepPartial, matcher } from './match';
 import { OperationIterable, ToOperationIterator } from './operation-iterable';
 import { SymbolOperationIterable } from './symbol-operation-iterable';
@@ -144,3 +144,15 @@ export function createStream<T, TReturn = undefined>(callback: Callback<T, TRetu
 
   return stream;
 }
+
+export const Stream = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  merge<T>(streams: Stream<T, any>[]): Stream<T> {
+    return createStream<T>(function*(publish) {
+      for(let stream of streams) {
+        yield spawn(stream.forEach(publish), { blockParent: true });
+      }
+      return undefined;
+    });
+  }
+};

--- a/packages/stream/test/stream.test.ts
+++ b/packages/stream/test/stream.test.ts
@@ -1,5 +1,6 @@
 import expect from 'expect';
 import { describe, it, beforeEach, captureError } from '@effection/mocha';
+import { sleep } from '@effection/core';
 import { EventEmitter } from 'events';
 
 import { createStream, Stream, StringBufferStream } from '../src/index';
@@ -23,6 +24,26 @@ const emptyStream: Stream<Thing, number> = createStream(() => function*() {
 });
 
 describe('Stream', () => {
+  describe('merge', () => {
+    it('merges multiple streams', function*() {
+      let people = createStream<Thing, void>(function*(publish) {
+        yield sleep(5);
+        publish({ name: 'bob', type: 'person' });
+        publish({ name: 'alice', type: 'person' });
+      });
+      let planets = createStream<Thing, void>(function*(publish) {
+        yield sleep(10);
+        publish({ name: 'world', type: 'planet', moon: 'Luna' });
+      });
+      let result = yield Stream.merge([people, planets]).toArray();
+      expect(result).toEqual([
+        {name: 'bob', type: 'person' },
+        {name: 'alice', type: 'person' },
+        {name: 'world', type: 'planet', moon: 'Luna' },
+      ])
+    });
+  });
+
   describe('join', () => {
     it('returns the result of the stream', function*() {
       let result = yield stuff.join();


### PR DESCRIPTION
This allows us to merge multiple streams of the same name into one stream. This is useful in many cases where streams from multiple sources need to be combined.

For example, to combine the stdout and stderr streams of a process, we could do this:

``` typescript
let myProcess = yield exec('./my-program');
let output = Stream.merge([myProcess.stdout, myProcess.stderr]);
```