### PR TITLE
Add homepage for API docs and include more packages

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,0 +1,24 @@
+# Effection
+
+Here you will find a complete API reference for all effection subpackages. The
+[effection][] package reexports several other packages,
+so note that you will likely not use these packages directly.
+
+The following packages are included in the [effection][] package:
+
+- [@effection/channel][]
+- [@effection/core][]
+- [@effection/events][]
+- [@effection/fetch][]
+- [@effection/main][]
+- [@effection/subscription][]
+- [@effection/stream][]
+
+[effection]: ./modules/effection.html
+[channel]: ./modules/_effection_channel.html
+[core]: ./modules/_effection_core.html
+[events]: ./modules/_effection_events.html
+[fetch]: ./modules/_effection_fetch.html
+[main]: ./modules/_effection_main.html
+[subscription]: ./modules/_effection_subscription.html
+[stream]: ./modules/_effection_stream.html

--- a/typedoc.json
+++ b/typedoc.json
@@ -7,13 +7,22 @@
   "name": "Effection API Reference",
   "entryPointStrategy": "packages",
   "entryPoints": [
-    "packages/atom",
     "packages/effection",
-    "packages/fetch",
+    "packages/core",
+    "packages/main",
     "packages/mocha",
+    "packages/subscription",
+    "packages/stream",
+    "packages/events",
+    "packages/channel",
+    "packages/duplex-channel",
+    "packages/atom",
     "packages/process",
+    "packages/fetch",
     "packages/react",
     "packages/websocket-client",
-    "packages/websocket-server"
+    "packages/websocket-server",
+    "packages/inspect-utils",
+    "packages/inspect-server",
   ]
 }


### PR DESCRIPTION
Rather than using the README for the typedoc documentation, we add a specific home page which explains the structure of the documentation and links to the relevant packages.

We explain the purpose of Effection in the guides and other sections of the homepage, so repeating it here is unnecessary and unhelpful.

Before:

<img width="1192" alt="Screenshot 2021-09-23 at 14 12 30" src="https://user-images.githubusercontent.com/134/134504616-6f555c2a-7c3e-4620-ad8e-0a162c0cd650.png">

After:

<img width="1192" alt="Screenshot 2021-09-23 at 14 11 21" src="https://user-images.githubusercontent.com/134/134504638-b6cf1bb0-7813-4435-8234-68dd3720cb2a.png">

