### PR TITLE
Remove internal dev dependencies

### DIFF
--- a/.changes/config.json
+++ b/.changes/config.json
@@ -143,7 +143,8 @@
       "path": "./packages/stream",
       "manager": "javascript",
       "dependencies": [
-        "@effection/core"
+        "@effection/core",
+        "@effection/subscription"
       ]
     },
     "@effection/websocket-client": {

--- a/packages/atom/package.json
+++ b/packages/atom/package.json
@@ -29,8 +29,6 @@
     "mocha": "mocha -r ts-node/register"
   },
   "devDependencies": {
-    "@effection/mocha": "2.0.0-beta.9",
-    "@effection/subscription": "2.0.0-beta.16",
     "@frontside/tsconfig": "^1.2.0",
     "@types/node": "^16.3.2",
     "dtslint": "^4.0.7",

--- a/packages/channel/package.json
+++ b/packages/channel/package.json
@@ -28,7 +28,6 @@
     "mocha": "mocha -r ts-node/register"
   },
   "devDependencies": {
-    "@effection/mocha": "2.0.0-beta.9",
     "@frontside/tsconfig": "^1.2.0",
     "@types/node": "^16.3.2",
     "expect": "^25.4.0",

--- a/packages/duplex-channel/package.json
+++ b/packages/duplex-channel/package.json
@@ -28,7 +28,6 @@
     "mocha": "mocha -r ts-node/register"
   },
   "devDependencies": {
-    "@effection/mocha": "^2.0.0-beta.9",
     "@frontside/tsconfig": "^1.2.0",
     "@types/mocha": "^7.0.1",
     "@types/node": "^13.13.4",

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -32,8 +32,6 @@
     "@effection/stream": "2.0.0-beta.1"
   },
   "devDependencies": {
-    "@effection/mocha": "2.0.0-beta.9",
-    "@effection/subscription": "2.0.0-beta.16",
     "@frontside/tsconfig": "^1.2.0",
     "@types/node": "16.3.2",
     "expect": "^25.4.0",

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -28,7 +28,6 @@
     "mocha": "mocha -r ts-node/register"
   },
   "devDependencies": {
-    "@effection/mocha": "2.0.0-beta.9",
     "@frontside/tsconfig": "^1.2.0",
     "@types/node": "^16.3.2",
     "expect": "26.0.1",

--- a/packages/inspect-server/package.json
+++ b/packages/inspect-server/package.json
@@ -41,7 +41,6 @@
     "websocket": "^1.0.34"
   },
   "devDependencies": {
-    "@effection/mocha": "2.0.0-beta.9",
     "@frontside/tsconfig": "^1.2.0",
     "@types/node": "^13.13.5",
     "@types/node-static": "^0.7.6",

--- a/packages/inspect-utils/package.json
+++ b/packages/inspect-utils/package.json
@@ -35,7 +35,6 @@
     "@effection/subscription": "2.0.0-beta.16"
   },
   "devDependencies": {
-    "@effection/mocha": "2.0.0-beta.9",
     "@frontside/tsconfig": "^1.2.0",
     "@types/node": "^13.13.5",
     "expect": "^25.4.0",

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -33,8 +33,6 @@
     "stacktrace-parser": "^0.1.10"
   },
   "devDependencies": {
-    "@effection/mocha": "2.0.0-beta.9",
-    "@effection/process": "2.0.0-beta.16",
     "@frontside/tsconfig": "^1.2.0",
     "@types/node": "^16.3.2",
     "expect": "^25.4.0",

--- a/packages/process/package.json
+++ b/packages/process/package.json
@@ -28,7 +28,6 @@
     "mocha": "mocha -r ts-node/register"
   },
   "devDependencies": {
-    "@effection/mocha": "2.0.0-beta.9",
     "@frontside/tsconfig": "^1.2.0",
     "@types/cross-spawn": "^6.0.2",
     "@types/node": "^16.3.2",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -33,7 +33,6 @@
     "react": "^17.0.2"
   },
   "devDependencies": {
-    "@effection/mocha": "2.0.0-beta.9",
     "@frontside/tsconfig": "^1.2.0",
     "@types/node": "^16.3.2",
     "@types/react": "^17.0.8",

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -32,7 +32,6 @@
     "@effection/subscription": "2.0.0-beta.16"
   },
   "devDependencies": {
-    "@effection/mocha": "2.0.0-beta.9",
     "@frontside/tsconfig": "^1.2.0",
     "@types/mocha": "^8.0.3",
     "expect": "^25.4.0",

--- a/packages/subscription/package.json
+++ b/packages/subscription/package.json
@@ -31,7 +31,6 @@
     "@effection/core": "2.0.0-beta.14"
   },
   "devDependencies": {
-    "@effection/mocha": "2.0.0-beta.9",
     "@frontside/tsconfig": "^1.2.0",
     "@types/mocha": "^8.0.3",
     "expect": "^25.4.0",

--- a/packages/websocket-client/package.json
+++ b/packages/websocket-client/package.json
@@ -34,7 +34,6 @@
     "isomorphic-ws": "^4.0.1"
   },
   "devDependencies": {
-    "@effection/mocha": "2.0.0-beta.9",
     "@frontside/tsconfig": "^1.2.0",
     "@types/node": "^16.3.2",
     "@types/ws": "^7.4.4",

--- a/packages/websocket-server/package.json
+++ b/packages/websocket-server/package.json
@@ -34,7 +34,6 @@
     "ws": "^7.4.6"
   },
   "devDependencies": {
-    "@effection/mocha": "2.0.0-beta.9",
     "@frontside/tsconfig": "^1.2.0",
     "@types/node": "^16.3.2",
     "@types/ws": "^7.4.4",


### PR DESCRIPTION
Covector can currently not distinguish between dev dependencies and regular dependencies. We settled on not specifying dev depencies as covector dependencies, but this leads to a situation where they are not getting bumped at all, causing us to depend on old versions. Since yarn is able to resolve the packages anyway, as long as they are in the same workspace, we can just get rid of the devDependency entries for them entirely.