### PR TITLE
fix note in process guide

### DIFF
--- a/website/docs/guides/processes.md
+++ b/website/docs/guides/processes.md
@@ -29,6 +29,7 @@ main(function*() {
 });
 ```
 > Note: every process has `stdout` and `stderr`  properties which can be consumed as [effection streams](./collections)
+
 Processes are automatically terminated when the operation in which they were
 created completed:
 


### PR DESCRIPTION
## Motivation 

block quotes need a newline after them in order to mark that they are finished. Because this note didn't have one, it was swallowing the content up to the next paragraph.



## Approach

Insert newline after block quote.
