### PR TITLE
Stream `buffer` returns the actual buffer

### DIFF
--- a/.changes/stream-buffer-access.md
+++ b/.changes/stream-buffer-access.md
@@ -1,0 +1,5 @@
+---
+"@effection/stream": "minor"
+---
+
+Stream `buffer` returns the actual buffer and gives direct access to it

--- a/packages/main/test/node.test.ts
+++ b/packages/main/test/node.test.ts
@@ -1,20 +1,19 @@
 import expect from 'expect';
 import { describe, it, beforeEach } from '@effection/mocha';
-import { Stream } from '@effection/stream';
 
 import { exec, Process, ProcessResult } from '@effection/process';
 import { terminate, interrupt } from './helpers';
 
 describe('main', () => {
   let child: Process;
-  let stdout: Stream<string>;
+  let stdout: Iterable<string>;
 
   describe('with successful process', () => {
     beforeEach(function*() {
       child = yield exec(`ts-node ./test/fixtures/text-writer.ts`);
       stdout = yield child.stdout.lines().buffer();
 
-      yield stdout.grep("started").expect();
+      yield child.stdout.lines().grep("started").expect();
     });
 
     describe('interrupting the process', () => {
@@ -24,7 +23,7 @@ describe('main', () => {
       });
 
       it('shuts down gracefully', function*() {
-        yield stdout.grep("stopped").expect();
+        expect(Array.from(stdout).filter((t) => t.includes("stopped")).length).toEqual(1);
       });
     });
 
@@ -35,7 +34,7 @@ describe('main', () => {
       });
 
       it('shuts down gracefully', function*() {
-        yield stdout.grep("stopped").expect();
+        expect(Array.from(stdout).filter((t) => t.includes("stopped")).length).toEqual(1);
       });
     });
   });

--- a/packages/stream/test/stream.test.ts
+++ b/packages/stream/test/stream.test.ts
@@ -154,7 +154,7 @@ describe('Stream', () => {
   });
 
   describe('buffer', () => {
-    it('replays all previously sent messages with unlimited buffer', function*(world) {
+    it('adds emitted values to unlimited size buffer', function*(world) {
       let emitter = new EventEmitter();
       let stream = createStream<string>((publish) => function*() {
         try {
@@ -168,20 +168,17 @@ describe('Stream', () => {
 
       emitter.emit('message', 'ignored');
 
-      let bufferedStream = yield stream.buffer();
+      let buffer = yield stream.buffer();
 
       emitter.emit('message', 'hello');
       emitter.emit('message', 'world');
       emitter.emit('message', 'monkey');
 
-      let iterator = bufferedStream.subscribe(world);
+      expect(Array.from(buffer)).toEqual(['hello', 'world', 'monkey']);
 
       emitter.emit('message', 'blah');
 
-      expect(yield iterator.next()).toEqual({ done: false, value: 'hello' });
-      expect(yield iterator.next()).toEqual({ done: false, value: 'world' });
-      expect(yield iterator.next()).toEqual({ done: false, value: 'monkey' });
-      expect(yield iterator.next()).toEqual({ done: false, value: 'blah' });
+      expect(Array.from(buffer)).toEqual(['hello', 'world', 'monkey', 'blah']);
     });
 
     it('replays previously sent messages with limited buffer', function*(world) {
@@ -198,19 +195,17 @@ describe('Stream', () => {
 
       emitter.emit('message', 'ignored');
 
-      let bufferedStream = yield stream.buffer(2);
+      let buffer = yield stream.buffer(2);
 
       emitter.emit('message', 'hello');
       emitter.emit('message', 'world');
       emitter.emit('message', 'monkey');
 
-      let iterator = bufferedStream.subscribe(world);
+      expect(Array.from(buffer)).toEqual(['world', 'monkey']);
 
       emitter.emit('message', 'blah');
 
-      expect(yield iterator.next()).toEqual({ done: false, value: 'world' });
-      expect(yield iterator.next()).toEqual({ done: false, value: 'monkey' });
-      expect(yield iterator.next()).toEqual({ done: false, value: 'blah' });
+      expect(Array.from(buffer)).toEqual(['monkey', 'blah']);
     });
   });
 


### PR DESCRIPTION
Rather than returning a new Stream, we return the actual buffer. This gives us direct access to the buffered data, making it easier to extract.