### PR TITLE
Ignore externals in typedocs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ packages/*/docs
 .node-version
 .parcel-cache
 dist*/
+docs
 *.tgz
 pkg/
 .nyc_output/

--- a/typedoc.js
+++ b/typedoc.js
@@ -15,6 +15,7 @@ module.exports = {
   "customCss": "typedoc.css",
   "name": "Effection API Reference",
   "entryPointStrategy": "packages",
+  "excludeExternals": true,
   "entryPoints": [
     "packages/atom",
     "packages/effection",


### PR DESCRIPTION
## Motivation

There is no need to include symbols from external libraries, especially ones that are not re-exported. Maybe there is a reason that this is the default, but for me they only seem to clutter things up.

## Approach

Leave 'em out!

## Screenshots

**before**

![image](https://user-images.githubusercontent.com/4205/135443909-baaa53c1-11c7-4295-9d94-c6e5b6ece79f.png)

**after**

![image](https://user-images.githubusercontent.com/4205/135443931-cf8489ef-407a-452d-a311-d333ada3f44d.png)
