### PR TITLE
Fix halting children for blockParent tasks

### DIFF
--- a/.changes/block-parent-halt-children.md
+++ b/.changes/block-parent-halt-children.md
@@ -1,0 +1,5 @@
+---
+"@effection/core": "patch"
+---
+
+Fix a bug when using blockParent where the children are not getting halt on an explicit halt.

--- a/packages/core/src/task.ts
+++ b/packages/core/src/task.ts
@@ -395,8 +395,8 @@ export function createTask<TOut = unknown>(operation: Operation<TOut>, options: 
       if(stateMachine.current === 'running') {
         stateMachine.halting();
         result = { state: 'halted' };
-        shutdown(true);
       }
+      shutdown(true);
       await future.catch(() => {
         // TODO: should this catch all errors, or only halt errors?
         // see https://github.com/jnicklas/mini-effection/issues/23

--- a/packages/core/test/spawn.test.ts
+++ b/packages/core/test/spawn.test.ts
@@ -212,5 +212,21 @@ describe('spawn', () => {
       expect(root.state).toEqual('completed');
       expect(child && child.state).toEqual('completed');
     });
+
+    it('halts children on explicit halt', async () => {
+      let child: Task<string> | undefined;
+      let root = run(function*(context: Task) {
+        child = context.run(function*() {
+          yield sleep(20);
+          return 'foo';
+        }, { blockParent: true });
+
+        return 1;
+      });
+
+      root.halt();
+
+      await expect(child).rejects.toHaveProperty('message', 'halted');
+    });
   });
 });


### PR DESCRIPTION
When a task has a child with `blockParent: true`, it will not forcibly halt that child when it completes successfully. However if it is explicitly halted, then it should shut the child down as well. In `halt` we currently assume that if we are already in a shutdown procedure, we don't need to do anything, but if the task is completing, then it needs to also initiate a forcible shutdown.