### PR TITLE
Fix ignore of docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 node_modules
-packages/*/docs
 .esm-cache
 .node-version
 .parcel-cache
@@ -16,7 +15,7 @@ yarn-error.log
 !website/yarn.lock
 .DS_Store
 .parcel-cache
-./docs
+docs
 
 # Local Netlify folder
 .netlify

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -10,3 +10,5 @@
 build
 sidebars
 public
+
+!docs


### PR DESCRIPTION
The `website/docs` folder should *not* be ignored, but all other `docs` folders should be.