### PR TITLE
Fix API Reference link

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "lint": "yarn workspaces run lint",
     "build:tsc": "tsc -b ./tsconfig.packages.json",
     "watch:tsc": "yarn build && \"$(npm bin)/tsc\" -b ./tsconfig.packages.json --watch",
-    "docs": "rm -rf docs && yarn typedoc --options typedoc.js",
+    "docs": "rm -rf docs && yarn typedoc --options typedoc.json",
     "docs:preview": "yarn parcel docs/api/v2/index.html"
   },
   "volta": {

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,13 +1,4 @@
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const Handlebars = require('handlebars');
-
-const BASE_URL="https://frontside.com/effection/api/"; // for css
-
-Handlebars.registerHelper('relativeURL', function(url) {
-  return BASE_URL + url;
-});
-
-module.exports = {
+{
   "name": "effection",
   "out": "docs/api/v2",
   "hideGenerator": true,
@@ -25,4 +16,4 @@ module.exports = {
     "packages/websocket-client",
     "packages/websocket-server"
   ]
-};
+}

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -28,7 +28,7 @@ module.exports = {
           position: 'left'
         },
         {
-          href: 'https://frontside.com/effection/api',
+          href: 'https://frontside.com/effection/api/index.html',
           label: 'API Reference',
           position: 'left',
           sameWindow: true


### PR DESCRIPTION
The link doesn't work properly unless we link to the `html` file directly.