### PR TITLE
📝Remove fetch as an entry point to main typedocs

### DIFF
--- a/typedoc.json
+++ b/typedoc.json
@@ -9,7 +9,6 @@
   "entryPoints": [
     "packages/atom",
     "packages/effection",
-    "packages/fetch",
     "packages/mocha",
     "packages/process",
     "packages/react",


### PR DESCRIPTION
## Motivation

`fetch()` and its associated APIs are now part of the main `effection` module and as such, `@effection/fetch` is more of a private API and should not appear as part of the typedocs since there's no guarantee that it won't be moved somewhere else at any point.

## Approach

remove it from the sidebar.