### PR TITLE
Fix yielding non operation bug

### DIFF
--- a/.changes/yield-non-operation.md
+++ b/.changes/yield-non-operation.md
@@ -1,0 +1,5 @@
+---
+"@effection/core": "patch"
+---
+
+Yielding to something which is not an operation no longer throws an internal error, but properly rejects the task.

--- a/packages/core/src/controller/controller.ts
+++ b/packages/core/src/controller/controller.ts
@@ -37,7 +37,7 @@ export function createController<T>(task: Task<T>, operation: Operation<T>, opti
     return createPromiseController(task, operation);
   } else if (isGenerator(operation)) {
     return createIteratorController(task, operation, options);
+  } else {
+    return createFutureController(task, Future.reject(new Error(`unkown type of operation: ${operation}`)));
   }
-
-  throw new Error(`unkown type of operation: ${operation}`);
 }

--- a/packages/core/test/iterator.test.ts
+++ b/packages/core/test/iterator.test.ts
@@ -2,7 +2,7 @@ import { createNumber, blowUp } from './setup';
 import { describe, it } from 'mocha';
 import expect from 'expect';
 
-import { run, sleep, Task, createFuture } from '../src/index';
+import { run, sleep, Task, Operation, createFuture } from '../src/index';
 
 describe('generator function', () => {
   it('can compose multiple promises via generator', async () => {
@@ -258,5 +258,13 @@ describe('generator function', () => {
     });
 
     await expect(task).rejects.toHaveProperty('message', 'bang');
+  });
+
+  it('can throw error when yield point is not a valid operation', async () => {
+    let task = run(function*() {
+      yield "I am not an operation" as unknown as Operation<unknown>;
+    });
+
+    await expect(task).rejects.toHaveProperty('message', 'unkown type of operation: I am not an operation');
   });
 });


### PR DESCRIPTION
Yielding to something which is not an operation no longer throws an internal error, but properly rejects the task.

See https://github.com/thefrontside/simulacrum/issues/134 for an example of this.