### PR TITLE
Work around borked NPM release

### DIFF
--- a/.changes/npm-workaround.md
+++ b/.changes/npm-workaround.md
@@ -1,0 +1,4 @@
+---
+"@effection/core": patch
+---
+workaround borked 2.0 release https://status.npmjs.org/incidents/wy4002vc8ryc


### PR DESCRIPTION
## Motivation

While releasing all of the 2.0 packages, NPM had a techincal issue that cause 7 of our 19 to be in an inconsistent state where they were received, but not viewable. After contacting NPM, they said that the old version, in this case 2.0.0 was not usable anymore. See https://status.npmjs.org/incidents/wy4002vc8ryc for details.

## Approach

This introduces a patch to @effection/core that does not accompany any changes, but is just there to cause every other version to increase which will in turn trigger a new release PR.
