### PR TITLE
Publish New Versions

### DIFF
--- a/.changes/npm-workaround.md
+++ b/.changes/npm-workaround.md
@@ -1,4 +1,0 @@
----
-"@effection/core": patch
----
-workaround borked 2.0 release https://status.npmjs.org/incidents/wy4002vc8ryc

--- a/packages/atom/CHANGELOG.md
+++ b/packages/atom/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @effection/atom
 
+## \[2.0.1]
+
+- workaround borked 2.0 release https://status.npmjs.org/incidents/wy4002vc8ryc
+  - Bumped due to a bump in effection.
+  - [97711a7](https://github.com/thefrontside/effection/commit/97711a77419c8e539bff3060a9f3c1bae947f9b8) Work around borked NPM release on 2021-10-12
+
 ## \[2.0.0]
 
 - Release Effection 2.0.0

--- a/packages/atom/package.json
+++ b/packages/atom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/atom",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "State atom implementation for effection",
   "main": "dist-cjs/index.js",
   "types": "dist-esm/index.d.ts",
@@ -41,7 +41,7 @@
     "extends": "../../package.json"
   },
   "dependencies": {
-    "effection": "^2.0.0",
+    "effection": "2.0.1",
     "assert-ts": "^0.2.2",
     "fp-ts": "^2.8.2",
     "monocle-ts": "^2.3.3"

--- a/packages/channel/CHANGELOG.md
+++ b/packages/channel/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## \[2.0.1]
+
+- workaround borked 2.0 release https://status.npmjs.org/incidents/wy4002vc8ryc
+  - Bumped due to a bump in @effection/core.
+  - [97711a7](https://github.com/thefrontside/effection/commit/97711a77419c8e539bff3060a9f3c1bae947f9b8) Work around borked NPM release on 2021-10-12
+
 ## \[2.0.0]
 
 - Release Effection 2.0.0

--- a/packages/channel/package.json
+++ b/packages/channel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/channel",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "MPMC Channel implementation for effection",
   "main": "dist-cjs/index.js",
   "module": "dist-esm/index.js",
@@ -39,8 +39,8 @@
     "extends": "../../package.json"
   },
   "dependencies": {
-    "@effection/core": "2.0.0",
-    "@effection/events": "2.0.0",
-    "@effection/stream": "2.0.0"
+    "@effection/core": "2.0.1",
+    "@effection/events": "2.0.1",
+    "@effection/stream": "2.0.1"
   }
 }

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,10 @@
 # @effection/core
 
+## \[2.0.1]
+
+- workaround borked 2.0 release https://status.npmjs.org/incidents/wy4002vc8ryc
+  - [97711a7](https://github.com/thefrontside/effection/commit/97711a77419c8e539bff3060a9f3c1bae947f9b8) Work around borked NPM release on 2021-10-12
+
 ## \[2.0.0]
 
 - Release Effection 2.0.0

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/core",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "main": "dist-cjs/index.js",
   "module": "dist-esm/index.js",
   "sideEffects": false,

--- a/packages/duplex-channel/CHANGELOG.md
+++ b/packages/duplex-channel/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## \[2.0.1]
+
+- workaround borked 2.0 release https://status.npmjs.org/incidents/wy4002vc8ryc
+  - Bumped due to a bump in effection.
+  - [97711a7](https://github.com/thefrontside/effection/commit/97711a77419c8e539bff3060a9f3c1bae947f9b8) Work around borked NPM release on 2021-10-12
+
 ## \[2.0.0]
 
 - Release Effection 2.0.0

--- a/packages/duplex-channel/package.json
+++ b/packages/duplex-channel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/duplex-channel",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A bidirectional channel for effection",
   "main": "dist-cjs/index.js",
   "module": "dist-esm/index.js",
@@ -37,7 +37,7 @@
     "typescript": "^4.3.5"
   },
   "dependencies": {
-    "effection": "^2.0.0"
+    "effection": "2.0.1"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/effection/CHANGELOG.md
+++ b/packages/effection/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## \[2.0.1]
+
+- workaround borked 2.0 release https://status.npmjs.org/incidents/wy4002vc8ryc
+  - Bumped due to a bump in @effection/core.
+  - [97711a7](https://github.com/thefrontside/effection/commit/97711a77419c8e539bff3060a9f3c1bae947f9b8) Work around borked NPM release on 2021-10-12
+
 ## \[2.0.0]
 
 - Release Effection 2.0.0

--- a/packages/effection/package.json
+++ b/packages/effection/package.json
@@ -1,6 +1,6 @@
 {
   "name": "effection",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Effortlessly composable structured concurrency primitive for JavaScript",
   "homepage": "https://frontside.com/effection",
   "repository": {
@@ -28,13 +28,13 @@
     "prepack": "tsc --build tsconfig.esm.json && tsc --build tsconfig.cjs.json && cpy ../../README.md ."
   },
   "dependencies": {
-    "@effection/channel": "2.0.0",
-    "@effection/core": "2.0.0",
-    "@effection/events": "2.0.0",
-    "@effection/fetch": "2.0.0",
-    "@effection/main": "2.0.0",
-    "@effection/subscription": "2.0.0",
-    "@effection/stream": "2.0.0"
+    "@effection/channel": "2.0.1",
+    "@effection/core": "2.0.1",
+    "@effection/events": "2.0.1",
+    "@effection/fetch": "2.0.1",
+    "@effection/main": "2.0.1",
+    "@effection/subscription": "2.0.1",
+    "@effection/stream": "2.0.1"
   },
   "devDependencies": {
     "@babel/core": "^7.14.8",

--- a/packages/events/CHANGELOG.md
+++ b/packages/events/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## \[2.0.1]
+
+- workaround borked 2.0 release https://status.npmjs.org/incidents/wy4002vc8ryc
+  - Bumped due to a bump in @effection/core.
+  - [97711a7](https://github.com/thefrontside/effection/commit/97711a77419c8e539bff3060a9f3c1bae947f9b8) Work around borked NPM release on 2021-10-12
+
 ## \[2.0.0]
 
 - Release Effection 2.0.0

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/events",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Helpers for listening to events with effection",
   "main": "dist-cjs/index.js",
   "module": "dist-esm/index.js",
@@ -28,8 +28,8 @@
     "mocha": "mocha -r ts-node/register"
   },
   "dependencies": {
-    "@effection/core": "2.0.0",
-    "@effection/stream": "2.0.0"
+    "@effection/core": "2.0.1",
+    "@effection/stream": "2.0.1"
   },
   "devDependencies": {
     "@frontside/tsconfig": "^1.2.0",

--- a/packages/fetch/CHANGELOG.md
+++ b/packages/fetch/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @effection/fetch
 
+## \[2.0.1]
+
+- workaround borked 2.0 release https://status.npmjs.org/incidents/wy4002vc8ryc
+  - Bumped due to a bump in @effection/core.
+  - [97711a7](https://github.com/thefrontside/effection/commit/97711a77419c8e539bff3060a9f3c1bae947f9b8) Work around borked NPM release on 2021-10-12
+
 ## \[2.0.0]
 
 - Release Effection 2.0.0

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/fetch",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Fetch operation for Effection",
   "main": "dist-cjs/index.js",
   "module": "dist-esm/index.js",
@@ -36,7 +36,7 @@
     "typescript": "^4.3.5"
   },
   "dependencies": {
-    "@effection/core": "2.0.0",
+    "@effection/core": "2.0.1",
     "abort-controller": "^3.0.0",
     "cross-fetch": "^3.0.4",
     "node-fetch": "^2.6.1"

--- a/packages/inspect-server/CHANGELOG.md
+++ b/packages/inspect-server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @effection/inspect-server
 
+## \[2.0.1]
+
+- workaround borked 2.0 release https://status.npmjs.org/incidents/wy4002vc8ryc
+  - Bumped due to a bump in effection.
+  - [97711a7](https://github.com/thefrontside/effection/commit/97711a77419c8e539bff3060a9f3c1bae947f9b8) Work around borked NPM release on 2021-10-12
+
 ## \[2.0.0]
 
 - Release Effection 2.0.0

--- a/packages/inspect-server/package.json
+++ b/packages/inspect-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/inspect-server",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Inspect server for inspecting effection processes",
   "main": "dist-cjs/index.js",
   "types": "dist-esm/index.d.ts",
@@ -29,11 +29,11 @@
     "examples:basic": "ts-node ./examples/basic.ts"
   },
   "dependencies": {
-    "@effection/atom": "^2.0.0",
-    "@effection/inspect-ui": "2.0.0",
-    "@effection/inspect-utils": "2.0.0",
-    "@effection/websocket-server": "^2.0.0",
-    "effection": "^2.0.0",
+    "@effection/atom": "2.0.1",
+    "@effection/inspect-ui": "2.0.1",
+    "@effection/inspect-utils": "2.0.1",
+    "@effection/websocket-server": "2.0.1",
+    "effection": "2.0.1",
     "node-static": "^0.7.11",
     "websocket": "^1.0.34"
   },

--- a/packages/inspect-ui/CHANGELOG.md
+++ b/packages/inspect-ui/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @effection/inspect-ui
 
+## \[2.0.1]
+
+- workaround borked 2.0 release https://status.npmjs.org/incidents/wy4002vc8ryc
+  - Bumped due to a bump in effection.
+  - [97711a7](https://github.com/thefrontside/effection/commit/97711a77419c8e539bff3060a9f3c1bae947f9b8) Work around borked NPM release on 2021-10-12
+
 ## \[2.0.0]
 
 - Release Effection 2.0.0

--- a/packages/inspect-ui/package.json
+++ b/packages/inspect-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/inspect-ui",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Web interface for inspecting effection applications",
   "main": "index.js",
   "types": "index.d.ts",
@@ -32,10 +32,10 @@
   },
   "devDependencies": {
     "@bigtest/interactor": "^0.29.0",
-    "effection": "^2.0.0",
-    "@effection/inspect-utils": "2.0.0",
-    "@effection/react": "^2.0.0",
-    "@effection/websocket-client": "^2.0.0",
+    "effection": "2.0.1",
+    "@effection/inspect-utils": "2.0.1",
+    "@effection/react": "2.0.1",
+    "@effection/websocket-client": "2.0.1",
     "@frontside/tsconfig": "^1.2.0",
     "@parcel/transformer-typescript-types": "2.0.0-beta.1",
     "@types/jsdom-global": "^3.0.2",

--- a/packages/inspect-utils/CHANGELOG.md
+++ b/packages/inspect-utils/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @effection/inspect-utils
 
+## \[2.0.1]
+
+- workaround borked 2.0 release https://status.npmjs.org/incidents/wy4002vc8ryc
+  - Bumped due to a bump in effection.
+  - [97711a7](https://github.com/thefrontside/effection/commit/97711a77419c8e539bff3060a9f3c1bae947f9b8) Work around borked NPM release on 2021-10-12
+
 ## \[2.0.0]
 
 - Release Effection 2.0.0

--- a/packages/inspect-utils/package.json
+++ b/packages/inspect-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/inspect-utils",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Helper functions and types for inspecting effection applications",
   "main": "dist-cjs/index.js",
   "types": "dist-esm/index.d.ts",
@@ -28,8 +28,8 @@
     "mocha": "mocha -r ts-node/register"
   },
   "dependencies": {
-    "@effection/atom": "^2.0.0",
-    "effection": "^2.0.0"
+    "@effection/atom": "2.0.1",
+    "effection": "2.0.1"
   },
   "devDependencies": {
     "@frontside/tsconfig": "^1.2.0",

--- a/packages/inspect/CHANGELOG.md
+++ b/packages/inspect/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @effection/inspect
 
+## \[2.0.1]
+
+- workaround borked 2.0 release https://status.npmjs.org/incidents/wy4002vc8ryc
+  - Bumped due to a bump in @effection/inspect-server.
+  - [97711a7](https://github.com/thefrontside/effection/commit/97711a77419c8e539bff3060a9f3c1bae947f9b8) Work around borked NPM release on 2021-10-12
+
 ## \[2.0.0]
 
 - Release Effection 2.0.0

--- a/packages/inspect/package.json
+++ b/packages/inspect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/inspect",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Injects an inspector into an Effection application",
   "main": "index.cjs.js",
   "module": "index.esm.js",
@@ -23,7 +23,7 @@
     "docs": "echo noop"
   },
   "dependencies": {
-    "@effection/inspect-server": "2.0.0"
+    "@effection/inspect-server": "2.0.1"
   },
   "volta": {
     "node": "12.16.0",

--- a/packages/main/CHANGELOG.md
+++ b/packages/main/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @effection/main
 
+## \[2.0.1]
+
+- workaround borked 2.0 release https://status.npmjs.org/incidents/wy4002vc8ryc
+  - Bumped due to a bump in @effection/core.
+  - [97711a7](https://github.com/thefrontside/effection/commit/97711a77419c8e539bff3060a9f3c1bae947f9b8) Work around borked NPM release on 2021-10-12
+
 ## \[2.0.0]
 
 - Release Effection 2.0.0

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/main",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Main entry point for Effection applications",
   "main": "dist-cjs/node.js",
   "module": "dist-esm/node.js",
@@ -28,7 +28,7 @@
     "mocha": "mocha -r ts-node/register"
   },
   "dependencies": {
-    "@effection/core": "2.0.0",
+    "@effection/core": "2.0.1",
     "chalk": "^4.1.2",
     "stacktrace-parser": "^0.1.10"
   },

--- a/packages/mocha/CHANGELOG.md
+++ b/packages/mocha/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @effection/mocha
 
+## \[2.0.1]
+
+- workaround borked 2.0 release https://status.npmjs.org/incidents/wy4002vc8ryc
+  - Bumped due to a bump in effection.
+  - [97711a7](https://github.com/thefrontside/effection/commit/97711a77419c8e539bff3060a9f3c1bae947f9b8) Work around borked NPM release on 2021-10-12
+
 ## \[2.0.0]
 
 - Release Effection 2.0.0

--- a/packages/mocha/package.json
+++ b/packages/mocha/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/mocha",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Effection Subscriptions",
   "main": "dist-cjs/index.js",
   "module": "dist-esm/index.js",
@@ -27,7 +27,7 @@
     "mocha": "mocha -r ts-node/register"
   },
   "dependencies": {
-    "effection": "^2.0.0"
+    "effection": "2.0.1"
   },
   "peerDependencies": {
     "mocha": "^8.0.0"

--- a/packages/process/CHANGELOG.md
+++ b/packages/process/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @effection/process
 
+## \[2.0.1]
+
+- workaround borked 2.0 release https://status.npmjs.org/incidents/wy4002vc8ryc
+  - Bumped due to a bump in effection.
+  - [97711a7](https://github.com/thefrontside/effection/commit/97711a77419c8e539bff3060a9f3c1bae947f9b8) Work around borked NPM release on 2021-10-12
+
 ## \[2.0.0]
 
 - Release Effection 2.0.0

--- a/packages/process/package.json
+++ b/packages/process/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/process",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Spawn and manage external processes with Effection",
   "main": "dist-cjs/index.js",
   "module": "dist-esm/index.js",
@@ -39,7 +39,7 @@
     "typescript": "^4.3.5"
   },
   "dependencies": {
-    "effection": "^2.0.0",
+    "effection": "2.0.1",
     "cross-spawn": "^7.0.3",
     "ctrlc-windows": "^2.0.0",
     "shellwords": "^0.1.1"

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @effection/react
 
+## \[2.0.1]
+
+- workaround borked 2.0 release https://status.npmjs.org/incidents/wy4002vc8ryc
+  - Bumped due to a bump in effection.
+  - [97711a7](https://github.com/thefrontside/effection/commit/97711a77419c8e539bff3060a9f3c1bae947f9b8) Work around borked NPM release on 2021-10-12
+
 ## \[2.0.0]
 
 - Release Effection 2.0.0

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/react",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Hooks for integrating effection into react applications",
   "main": "dist-cjs/index.js",
   "module": "dist-esm/index.js",
@@ -28,7 +28,7 @@
     "mocha": "mocha -r ts-node/register"
   },
   "dependencies": {
-    "effection": "^2.0.0",
+    "effection": "2.0.1",
     "react": "^17.0.2"
   },
   "devDependencies": {

--- a/packages/stream/CHANGELOG.md
+++ b/packages/stream/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## \[2.0.1]
+
+- workaround borked 2.0 release https://status.npmjs.org/incidents/wy4002vc8ryc
+  - Bumped due to a bump in @effection/core.
+  - [97711a7](https://github.com/thefrontside/effection/commit/97711a77419c8e539bff3060a9f3c1bae947f9b8) Work around borked NPM release on 2021-10-12
+
 ## \[2.0.0]
 
 - Release Effection 2.0.0

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/stream",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Effection Stream",
   "main": "dist-cjs/index.js",
   "module": "dist-esm/index.js",
@@ -28,8 +28,8 @@
     "mocha": "mocha -r ts-node/register"
   },
   "dependencies": {
-    "@effection/core": "2.0.0",
-    "@effection/subscription": "2.0.0"
+    "@effection/core": "2.0.1",
+    "@effection/subscription": "2.0.1"
   },
   "devDependencies": {
     "@frontside/tsconfig": "^1.2.0",

--- a/packages/subscription/CHANGELOG.md
+++ b/packages/subscription/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @effection/subscription
 
+## \[2.0.1]
+
+- workaround borked 2.0 release https://status.npmjs.org/incidents/wy4002vc8ryc
+  - Bumped due to a bump in @effection/core.
+  - [97711a7](https://github.com/thefrontside/effection/commit/97711a77419c8e539bff3060a9f3c1bae947f9b8) Work around borked NPM release on 2021-10-12
+
 ## \[2.0.0]
 
 - Release Effection 2.0.0

--- a/packages/subscription/package.json
+++ b/packages/subscription/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/subscription",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Effection Subscriptions",
   "main": "dist-cjs/index.js",
   "module": "dist-esm/index.js",
@@ -28,7 +28,7 @@
     "mocha": "mocha -r ts-node/register"
   },
   "dependencies": {
-    "@effection/core": "2.0.0"
+    "@effection/core": "2.0.1"
   },
   "devDependencies": {
     "@frontside/tsconfig": "^1.2.0",

--- a/packages/websocket-client/CHANGELOG.md
+++ b/packages/websocket-client/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @effection/websocket-client
 
+## \[2.0.1]
+
+- workaround borked 2.0 release https://status.npmjs.org/incidents/wy4002vc8ryc
+  - Bumped due to a bump in effection.
+  - [97711a7](https://github.com/thefrontside/effection/commit/97711a77419c8e539bff3060a9f3c1bae947f9b8) Work around borked NPM release on 2021-10-12
+
 ## \[2.0.0]
 
 - Release Effection 2.0.0

--- a/packages/websocket-client/package.json
+++ b/packages/websocket-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/websocket-client",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A websocket client for Effection in node and browser",
   "main": "dist-cjs/index.js",
   "module": "dist-esm/index.js",
@@ -28,7 +28,7 @@
     "mocha": "mocha -r ts-node/register"
   },
   "dependencies": {
-    "effection": "^2.0.0",
+    "effection": "2.0.1",
     "isomorphic-ws": "^4.0.1"
   },
   "devDependencies": {

--- a/packages/websocket-server/CHANGELOG.md
+++ b/packages/websocket-server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @effection/websocket-server
 
+## \[2.0.1]
+
+- workaround borked 2.0 release https://status.npmjs.org/incidents/wy4002vc8ryc
+  - Bumped due to a bump in effection.
+  - [97711a7](https://github.com/thefrontside/effection/commit/97711a77419c8e539bff3060a9f3c1bae947f9b8) Work around borked NPM release on 2021-10-12
+
 ## \[2.0.0]
 
 - Release Effection 2.0.0

--- a/packages/websocket-server/package.json
+++ b/packages/websocket-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/websocket-server",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A simple websocket server for Effection",
   "main": "dist-cjs/index.js",
   "module": "dist-esm/index.js",
@@ -28,7 +28,7 @@
     "mocha": "mocha -r ts-node/register"
   },
   "dependencies": {
-    "effection": "^2.0.0",
+    "effection": "2.0.1",
     "ws": "^7.4.6"
   },
   "devDependencies": {


### PR DESCRIPTION
# Version Updates

Merging this PR will release new versions of the following packages based on your change files.




# @effection/channel

## [2.0.1]
- workaround borked 2.0 release https://status.npmjs.org/incidents/wy4002vc8ryc
  - Bumped due to a bump in @effection/core.
  - [97711a7](https://github.com/thefrontside/effection/commit/97711a77419c8e539bff3060a9f3c1bae947f9b8) Work around borked NPM release on 2021-10-12



# @effection/duplex-channel

## [2.0.1]
- workaround borked 2.0 release https://status.npmjs.org/incidents/wy4002vc8ryc
  - Bumped due to a bump in effection.
  - [97711a7](https://github.com/thefrontside/effection/commit/97711a77419c8e539bff3060a9f3c1bae947f9b8) Work around borked NPM release on 2021-10-12



# @effection/atom

## [2.0.1]
- workaround borked 2.0 release https://status.npmjs.org/incidents/wy4002vc8ryc
  - Bumped due to a bump in effection.
  - [97711a7](https://github.com/thefrontside/effection/commit/97711a77419c8e539bff3060a9f3c1bae947f9b8) Work around borked NPM release on 2021-10-12



# @effection/core

## [2.0.1]
- workaround borked 2.0 release https://status.npmjs.org/incidents/wy4002vc8ryc
  - [97711a7](https://github.com/thefrontside/effection/commit/97711a77419c8e539bff3060a9f3c1bae947f9b8) Work around borked NPM release on 2021-10-12



# effection

## [2.0.1]
- workaround borked 2.0 release https://status.npmjs.org/incidents/wy4002vc8ryc
  - Bumped due to a bump in @effection/core.
  - [97711a7](https://github.com/thefrontside/effection/commit/97711a77419c8e539bff3060a9f3c1bae947f9b8) Work around borked NPM release on 2021-10-12



# @effection/events

## [2.0.1]
- workaround borked 2.0 release https://status.npmjs.org/incidents/wy4002vc8ryc
  - Bumped due to a bump in @effection/core.
  - [97711a7](https://github.com/thefrontside/effection/commit/97711a77419c8e539bff3060a9f3c1bae947f9b8) Work around borked NPM release on 2021-10-12



# @effection/fetch

## [2.0.1]
- workaround borked 2.0 release https://status.npmjs.org/incidents/wy4002vc8ryc
  - Bumped due to a bump in @effection/core.
  - [97711a7](https://github.com/thefrontside/effection/commit/97711a77419c8e539bff3060a9f3c1bae947f9b8) Work around borked NPM release on 2021-10-12



# @effection/inspect

## [2.0.1]
- workaround borked 2.0 release https://status.npmjs.org/incidents/wy4002vc8ryc
  - Bumped due to a bump in @effection/inspect-server.
  - [97711a7](https://github.com/thefrontside/effection/commit/97711a77419c8e539bff3060a9f3c1bae947f9b8) Work around borked NPM release on 2021-10-12



# @effection/inspect-server

## [2.0.1]
- workaround borked 2.0 release https://status.npmjs.org/incidents/wy4002vc8ryc
  - Bumped due to a bump in effection.
  - [97711a7](https://github.com/thefrontside/effection/commit/97711a77419c8e539bff3060a9f3c1bae947f9b8) Work around borked NPM release on 2021-10-12



# @effection/inspect-utils

## [2.0.1]
- workaround borked 2.0 release https://status.npmjs.org/incidents/wy4002vc8ryc
  - Bumped due to a bump in effection.
  - [97711a7](https://github.com/thefrontside/effection/commit/97711a77419c8e539bff3060a9f3c1bae947f9b8) Work around borked NPM release on 2021-10-12



# @effection/main

## [2.0.1]
- workaround borked 2.0 release https://status.npmjs.org/incidents/wy4002vc8ryc
  - Bumped due to a bump in @effection/core.
  - [97711a7](https://github.com/thefrontside/effection/commit/97711a77419c8e539bff3060a9f3c1bae947f9b8) Work around borked NPM release on 2021-10-12



# @effection/mocha

## [2.0.1]
- workaround borked 2.0 release https://status.npmjs.org/incidents/wy4002vc8ryc
  - Bumped due to a bump in effection.
  - [97711a7](https://github.com/thefrontside/effection/commit/97711a77419c8e539bff3060a9f3c1bae947f9b8) Work around borked NPM release on 2021-10-12



# @effection/process

## [2.0.1]
- workaround borked 2.0 release https://status.npmjs.org/incidents/wy4002vc8ryc
  - Bumped due to a bump in effection.
  - [97711a7](https://github.com/thefrontside/effection/commit/97711a77419c8e539bff3060a9f3c1bae947f9b8) Work around borked NPM release on 2021-10-12



# @effection/react

## [2.0.1]
- workaround borked 2.0 release https://status.npmjs.org/incidents/wy4002vc8ryc
  - Bumped due to a bump in effection.
  - [97711a7](https://github.com/thefrontside/effection/commit/97711a77419c8e539bff3060a9f3c1bae947f9b8) Work around borked NPM release on 2021-10-12



# @effection/subscription

## [2.0.1]
- workaround borked 2.0 release https://status.npmjs.org/incidents/wy4002vc8ryc
  - Bumped due to a bump in @effection/core.
  - [97711a7](https://github.com/thefrontside/effection/commit/97711a77419c8e539bff3060a9f3c1bae947f9b8) Work around borked NPM release on 2021-10-12



# @effection/stream

## [2.0.1]
- workaround borked 2.0 release https://status.npmjs.org/incidents/wy4002vc8ryc
  - Bumped due to a bump in @effection/core.
  - [97711a7](https://github.com/thefrontside/effection/commit/97711a77419c8e539bff3060a9f3c1bae947f9b8) Work around borked NPM release on 2021-10-12



# @effection/websocket-client

## [2.0.1]
- workaround borked 2.0 release https://status.npmjs.org/incidents/wy4002vc8ryc
  - Bumped due to a bump in effection.
  - [97711a7](https://github.com/thefrontside/effection/commit/97711a77419c8e539bff3060a9f3c1bae947f9b8) Work around borked NPM release on 2021-10-12



# @effection/websocket-server

## [2.0.1]
- workaround borked 2.0 release https://status.npmjs.org/incidents/wy4002vc8ryc
  - Bumped due to a bump in effection.
  - [97711a7](https://github.com/thefrontside/effection/commit/97711a77419c8e539bff3060a9f3c1bae947f9b8) Work around borked NPM release on 2021-10-12



# @effection/inspect-ui

## [2.0.1]
- workaround borked 2.0 release https://status.npmjs.org/incidents/wy4002vc8ryc
  - Bumped due to a bump in effection.
  - [97711a7](https://github.com/thefrontside/effection/commit/97711a77419c8e539bff3060a9f3c1bae947f9b8) Work around borked NPM release on 2021-10-12