### PR TITLE
Extract abort-controller from fetch to core 

### DIFF
--- a/.changes/abort-signal.md
+++ b/.changes/abort-signal.md
@@ -1,0 +1,6 @@
+---
+"@effection/fetch": "minor"
+"@effection/core": "minor"
+---
+
+Extract `AbortSignal` from `@effection/fetch` to `@effection/core` as a resource

--- a/.changes/abort-signal.md
+++ b/.changes/abort-signal.md
@@ -1,5 +1,5 @@
 ---
-"@effection/fetch": "minor"
+"@effection/fetch": "patch"
 "@effection/core": "minor"
 ---
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,6 +26,9 @@
     "dist-*/**/*",
     "src/**/*"
   ],
+  "dependencies": {
+    "abort-controller": "^3.0.0"
+  },
   "devDependencies": {
     "@frontside/tsconfig": "^1.2.0",
     "@types/mocha": "^7.0.2",
@@ -37,7 +40,6 @@
     "ts-node": "^10.4.0",
     "typescript": "^4.3.5"
   },
-  "dependencies": {},
   "volta": {
     "extends": "../../package.json"
   }

--- a/packages/core/src/abort-signal.ts
+++ b/packages/core/src/abort-signal.ts
@@ -1,8 +1,8 @@
 import { spawn } from './operations/spawn';
 import { Resource } from "./operation";
-import { AbortController } from 'abort-controller';
+import { AbortController, AbortSignal } from 'abort-controller';
 
-function createAbortSignal(): Resource<any> {
+function createAbortSignal(): Resource<AbortSignal> {
   return {
     *init() {
       let controller = new AbortController();
@@ -12,10 +12,10 @@ function createAbortSignal(): Resource<any> {
         } finally {
           controller.abort();
         }
-      })
+      });
       return controller.signal;
     }
-  }
+  };
 }
 
-export { createAbortSignal };
+export { createAbortSignal, AbortSignal };

--- a/packages/core/src/abort-signal.ts
+++ b/packages/core/src/abort-signal.ts
@@ -2,6 +2,25 @@ import { spawn } from './operations/spawn';
 import { Resource } from "./operation";
 import { AbortController, AbortSignal } from 'abort-controller';
 
+/**
+ * Create an [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) bound 
+ * to the current scope. Whenever that scope is completed, errored, or halted, the abort signal will 
+ * be triggered.
+ *
+ * Cancellation and teardown is handled handled automatically in Effection, but in systems where
+ * it is not, the lifespan of a transaction needs to be explicitly modeled. A very common way to do this is with 
+ * the `AbortSignal`. By creating an abort signal bound to an Effection task, we can pass that signal down to 
+ * 3rd party consumers that can use it to register shutdown callbacks that will be invoked whenever the task is done
+ * (either by completion, failure, or cancellation). An example is the native [`fetch()`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch#syntax) API which takes a `signal` parameter in order to trigger when the HTTP request should
+ * be cancelled.  This is how you would bind the lifetime of the HTTP request to the lifetime of the current task.
+ * 
+ * ```js
+ * function* request() {
+ *   let signal = yield createAbortSignal();
+ *   return yield fetch('/some/url', { signal });
+ * }
+ * ```
+ */
 function createAbortSignal(): Resource<AbortSignal> {
   return {
     name: 'AbortSignal',

--- a/packages/core/src/abort-signal.ts
+++ b/packages/core/src/abort-signal.ts
@@ -3,17 +3,24 @@ import { Resource } from "./operation";
 import { AbortController, AbortSignal } from 'abort-controller';
 
 /**
- * Create an [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) bound 
- * to the current scope. Whenever that scope is completed, errored, or halted, the abort signal will 
- * be triggered.
+ * Create an
+ * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal)
+ * bound to the current scope. Whenever that scope is completed,
+ * errored, or halted, the abort signal will be triggered.
  *
- * Cancellation and teardown is handled handled automatically in Effection, but in systems where
- * it is not, the lifespan of a transaction needs to be explicitly modeled. A very common way to do this is with 
- * the `AbortSignal`. By creating an abort signal bound to an Effection task, we can pass that signal down to 
- * 3rd party consumers that can use it to register shutdown callbacks that will be invoked whenever the task is done
- * (either by completion, failure, or cancellation). An example is the native [`fetch()`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch#syntax) API which takes a `signal` parameter in order to trigger when the HTTP request should
- * be cancelled.  This is how you would bind the lifetime of the HTTP request to the lifetime of the current task.
- * 
+ * Cancellation and teardown is handled automatically in Effection,
+ * but in systems where it is not, the lifespan of a transaction needs
+ * to be explicitly modeled. A very common way to do this is with the
+ * `AbortSignal`. By creating an abort signal bound to an Effection
+ * task, we can pass that signal down to 3rd party consumers that can
+ * use it to register shutdown callbacks that will be invoked whenever
+ * the task is done (either by completion, failure, or
+ * cancellation). An example is the native
+ * [`fetch()`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch#syntax)
+ * API which takes a `signal` parameter in order to trigger when the
+ * HTTP request should be cancelled.  This is how you would bind the
+ * lifetime of the HTTP request to the lifetime of the current task.
+ *
  * ```js
  * function* request() {
  *   let signal = yield createAbortSignal();

--- a/packages/core/src/abort-signal.ts
+++ b/packages/core/src/abort-signal.ts
@@ -1,0 +1,21 @@
+import { spawn } from './operations/spawn';
+import { Resource } from "./operation";
+import { AbortController } from 'abort-controller';
+
+function createAbortSignal(): Resource<any> {
+  return {
+    *init() {
+      let controller = new AbortController();
+      yield spawn(function* () {
+        try {
+          yield;
+        } finally {
+          controller.abort();
+        }
+      })
+      return controller.signal;
+    }
+  }
+}
+
+export { createAbortSignal };

--- a/packages/core/src/abort-signal.ts
+++ b/packages/core/src/abort-signal.ts
@@ -4,9 +4,7 @@ import { AbortController, AbortSignal } from 'abort-controller';
 
 function createAbortSignal(): Resource<AbortSignal> {
   return {
-    labels: {
-      name: 'createAbortSignal()'
-    },
+    name: 'AbortSignal',
     *init() {
       let controller = new AbortController();
       yield spawn(function* () {
@@ -17,7 +15,7 @@ function createAbortSignal(): Resource<AbortSignal> {
         }
       }, {
         labels: {
-          name: 'controller.abort()'
+          name: 'ensure signal aborted'
         }
       });
       return controller.signal;

--- a/packages/core/src/abort-signal.ts
+++ b/packages/core/src/abort-signal.ts
@@ -4,6 +4,9 @@ import { AbortController, AbortSignal } from 'abort-controller';
 
 function createAbortSignal(): Resource<AbortSignal> {
   return {
+    labels: {
+      name: 'createAbortSignal()'
+    },
     *init() {
       let controller = new AbortController();
       yield spawn(function* () {
@@ -11,6 +14,10 @@ function createAbortSignal(): Resource<AbortSignal> {
           yield;
         } finally {
           controller.abort();
+        }
+      }, {
+        labels: {
+          name: 'controller.abort()'
         }
       });
       return controller.signal;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,6 +10,7 @@ export { deprecated } from './deprecated';
 export { Labels, withLabels, setLabels } from './labels';
 export { HasEffectionTrace } from './error';
 export { createFuture, Future, FutureLike } from './future';
+export { createAbortSignal } from './abort-signal';
 
 export { sleep } from './operations/sleep';
 export { ensure } from './operations/ensure';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,7 +10,7 @@ export { deprecated } from './deprecated';
 export { Labels, withLabels, setLabels } from './labels';
 export { HasEffectionTrace } from './error';
 export { createFuture, Future, FutureLike } from './future';
-export { createAbortSignal } from './abort-signal';
+export { createAbortSignal, AbortSignal } from './abort-signal';
 
 export { sleep } from './operations/sleep';
 export { ensure } from './operations/ensure';

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -37,7 +37,6 @@
   },
   "dependencies": {
     "@effection/core": "2.0.1",
-    "abort-controller": "^3.0.0",
     "cross-fetch": "^3.0.4",
     "node-fetch": "^2.6.1"
   },

--- a/packages/fetch/src/fetch.ts
+++ b/packages/fetch/src/fetch.ts
@@ -1,6 +1,5 @@
-import { ensure, withLabels, Operation, Resource } from '@effection/core';
+import { AbortSignal, createAbortSignal, withLabels, Operation, Resource } from '@effection/core';
 import { fetch as nativeFetch } from 'cross-fetch';
-import { AbortController } from 'abort-controller';
 
 /**
  * A resource that can be used to create an HTTP request. This is the return
@@ -89,12 +88,8 @@ export interface Fetch extends Resource<Response> {
  */
 export function fetch(info: RequestInfo, requestInit: RequestInit = {}): Fetch {
   function* init() {
-    let controller = new AbortController();
-
-    yield ensure(() => { controller.abort() });
-
-    requestInit.signal = controller.signal;
-
+    let signal: AbortSignal = yield createAbortSignal();
+    requestInit.signal = signal;
     let response: Response = yield nativeFetch(info, requestInit);
     return response;
   }


### PR DESCRIPTION
## Motivation

To address #589

## Approach

I put the new resource in `@effection/core` instead of creating a new package

## TODOs

- [x] Add typedocs