### PR TITLE
rename effection's `OperationIterator` to `OperationGenerator` to avoid naming issues with another `OperationIterator`

### DIFF
--- a/packages/core/src/controller/iterator-controller.ts
+++ b/packages/core/src/controller/iterator-controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Options } from './controller';
-import { OperationIterator } from '../operation';
+import { OperationGenerator } from '../operation';
 import { createTask, Task } from '../task';
 import { Operation } from '../operation';
 import { createFuture, Value } from '../future';
@@ -12,7 +12,7 @@ interface Claimable {
   [claimed]?: boolean;
 }
 
-export function createIteratorController<TOut>(task: Task<TOut>, iterator: OperationIterator<TOut> & Claimable, options: Options): Controller<TOut> {
+export function createIteratorController<TOut>(task: Task<TOut>, iterator: OperationGenerator<TOut> & Claimable, options: Options): Controller<TOut> {
   let didHalt = false;
   let yieldingTo: Task | undefined;
 

--- a/packages/core/src/operation.ts
+++ b/packages/core/src/operation.ts
@@ -8,7 +8,7 @@ export interface Labelled {
   labels?: Labels;
 }
 
-export interface OperationIterator<TOut> extends Generator<Operation<any>, TOut | undefined, any>, Labelled {
+export interface OperationGenerator<TOut> extends Generator<Operation<any>, TOut | undefined, any>, Labelled {
 }
 
 export interface OperationPromise<TOut> extends PromiseLike<TOut>, Labelled {
@@ -33,7 +33,7 @@ export interface Resource<TOut> extends Labelled {
    * @param resourceTask a handle to the resource task that the resource is running
    * @param initTask a handle to the task of the `init` itself
    */
-  init(resourceTask: Task, initTask: Task): OperationIterator<TOut>;
+  init(resourceTask: Task, initTask: Task): OperationGenerator<TOut>;
 }
 
 export interface OperationFunction<TOut> extends Labelled {
@@ -49,7 +49,7 @@ export interface OperationFunction<TOut> extends Labelled {
  */
 export type Operation<TOut> =
   OperationPromise<TOut> |
-  OperationIterator<TOut> |
+  OperationGenerator<TOut> |
   OperationFuture<TOut> |
   OperationFunction<TOut> |
   Resource<TOut> |


### PR DESCRIPTION
## Motivation

There are two different `OperationIterator` types. The one is in core package and another is in subscription package. https://github.com/thefrontside/effection/blob/41101923824849238a462969e5be3945f2fcc139/packages/subscription/src/operation-iterator.ts#L6


## Approach

That one from core package is actually extends from `Generator` so I decided to rename it to `OperationGenerator`