### PR TITLE
Standardize build tools for all packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "volta": {
     "node": "14.17.1",
-    "yarn": "1.22.4"
+    "yarn": "1.22.17"
   },
   "devDependencies": {
     "@frontside/eslint-config": "2.1.0",

--- a/packages/inspect-ui/package.json
+++ b/packages/inspect-ui/package.json
@@ -63,7 +63,6 @@
     }
   },
   "volta": {
-    "node": "12.16.0",
-    "yarn": "1.19.1"
+    "extends": "../../package.json"
   }
 }

--- a/packages/inspect-utils/package.json
+++ b/packages/inspect-utils/package.json
@@ -42,7 +42,6 @@
     "typescript": "^3.7.0"
   },
   "volta": {
-    "node": "12.16.0",
-    "yarn": "1.19.1"
+    "extends": "../../package.json"
   }
 }

--- a/packages/inspect/package.json
+++ b/packages/inspect/package.json
@@ -26,7 +26,6 @@
     "@effection/inspect-server": "2.1.2"
   },
   "volta": {
-    "node": "12.16.0",
-    "yarn": "1.19.1"
+    "extends": "../../package.json"
   }
 }

--- a/packages/mocha/package.json
+++ b/packages/mocha/package.json
@@ -41,7 +41,6 @@
     "typescript": "^4.3.5"
   },
   "volta": {
-    "node": "12.16.0",
-    "yarn": "1.19.1"
+    "extends": "../../package.json"
   }
 }

--- a/packages/websocket-server/package.json
+++ b/packages/websocket-server/package.json
@@ -41,7 +41,6 @@
     "typescript": "^4.3.5"
   },
   "volta": {
-    "node": "12.16.0",
-    "yarn": "1.19.1"
+    "extends": "../../package.json"
   }
 }


### PR DESCRIPTION
## Motivation

While trying to build a `@effection/jest` integration, I was getting unrelated yarn errors because of an old version of parcel being incompatible with a certain yarn version. We need to upgrade parcel in inspect-ui, but first we need to make sure that we're using the name node and yarn everywhere.

## Approach
It turns out that there were several packages that were using their own volta configs. This points all of them at the same config from the base of the repo

Note that there is no changeset, since this only effects which version of yarn is used to install a subset of packages, and which version of node is used to run repository management.