### PR TITLE
Add @effection/jest to covector

### DIFF
--- a/.changes/add-jest-to-covector.md
+++ b/.changes/add-jest-to-covector.md
@@ -1,0 +1,4 @@
+---
+"@effection/jest": patch
+---
+depends on effection 2.0.3

--- a/.changes/config.json
+++ b/.changes/config.json
@@ -112,6 +112,13 @@
         "effection"
       ]
     },
+    "@effection/jest": {
+      "path": "./packages/jest",
+      "manager": "javascript",
+      "dependencies": [
+        "effection"
+      ]
+    },
     "@effection/process": {
       "path": "./packages/process",
       "manager": "javascript",

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -26,7 +26,7 @@
     "prepack": "tsc --build tsconfig.esm.json && tsc --build tsconfig.cjs.json"
   },
   "dependencies": {
-    "effection": "2.0.2",
+    "effection": "^2.0.3",
     "assert-ts": "^0.3.4"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Motivation
In order to have the version numbers advance automatically with changesets like the other packages.

## Approach
The initial release of a package needs to be manual, but after that we can add them to covector. This also adjusts the version of effection that it depends on to be the most recent.
