### PR TITLE
Create totally independent scopes for before{All/Each}()

### DIFF
--- a/.changes/independent-test-scopes.md
+++ b/.changes/independent-test-scopes.md
@@ -1,0 +1,4 @@
+---
+"@effection/jest": patch
+---
+test suite and each test get independent sibling scopes.

--- a/packages/jest/test/beforeach-spawned-failure.ts
+++ b/packages/jest/test/beforeach-spawned-failure.ts
@@ -1,0 +1,15 @@
+import { describe, beforeEach, it } from '../src/index';
+import { spawn, sleep } from 'effection';
+
+describe('@effection/jest', () => {
+  beforeEach(function*() {
+    yield spawn(function*() {
+      yield sleep(10);
+      throw new Error('boom');
+    });
+  });
+
+  it('throws error when spawn in beforeEach fails', function*() {
+    yield sleep(100);
+  });
+});

--- a/packages/jest/test/error-in-beforeall.failure.ts
+++ b/packages/jest/test/error-in-beforeall.failure.ts
@@ -1,0 +1,14 @@
+import { describe, beforeAll, it } from '../src/index';
+import { spawn, sleep } from 'effection';
+
+describe('@effection/jest', () => {
+  beforeAll(function*() {
+    yield spawn(function*() {
+      yield sleep(50);
+      throw new Error('boom!');
+    });
+  });
+  it('throws the error', function*() {
+    yield sleep(100);
+  });
+});

--- a/packages/jest/test/jest.test.ts
+++ b/packages/jest/test/jest.test.ts
@@ -32,6 +32,20 @@ describe('@effection/jest', () => {
     expect(stderr).toContain('boom');
   }, process.env.CI ? 30000 : undefined);
 
+  it('throws error on failure in suite scope', function*() {
+    let { code, stderr } = yield exec('yarn jest --testMatch "**/test/error-in-beforeall.failure.ts" --no-colors').join();
+    expect(code).toEqual(1);
+    expect(stderr).toContain('boom');
+  }, process.env.CI ? 30000 : undefined);
+
+  it('throws error on failure in suite scope', function*() {
+    let { code, stderr } = yield exec('yarn jest --testMatch "**/test/beforeach-spawned-failure.ts" --no-colors').join();
+    expect(code).toEqual(1);
+    expect(stderr).toContain('boom');
+  }, process.env.CI ? 30000 : undefined);
+
+
+
   it.todo('can have pending tasks (note: this is not actually pending)');
 
   describe('accessing the Jest Context API', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1597,15 +1597,6 @@
     cross-fetch "^3.0.4"
     node-fetch "^2.6.1"
 
-"@effection/fetch@2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@effection/fetch/-/fetch-2.0.2.tgz#32047f4976a4a226e9561b201027698309294204"
-  integrity sha512-OBzlbDT2u68aZBTrbItby6iXfahEKYrSu2+oC9EmOPgWSmJVYCALVRCK/cWpnH9Sk6dw9Ymafc63+jl0sPeQhw==
-  dependencies:
-    "@effection/core" "2.1.0"
-    cross-fetch "^3.0.4"
-    node-fetch "^2.6.1"
-
 "@effection/main@2.0.1":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@effection/main/-/main-2.0.1.tgz#becbaf0b28665e401b05e429d4cad8c2c5c84ee2"
@@ -5074,19 +5065,6 @@ effection@2.0.1:
     "@effection/main" "2.0.1"
     "@effection/stream" "2.0.1"
     "@effection/subscription" "2.0.1"
-
-effection@2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/effection/-/effection-2.0.2.tgz#f0ff74476e5f68a6266c3759796cce3b2bdaaf57"
-  integrity sha512-GZmUfLjiW8im/FXSXsYSfZ6nODG2oR9UAlcq5LXTXZ5glAayLN0WXfhvZZQCa+EZIU2bRXxpKpJ1AEQOCFo2vA==
-  dependencies:
-    "@effection/channel" "2.0.2"
-    "@effection/core" "2.1.0"
-    "@effection/events" "2.0.2"
-    "@effection/fetch" "2.0.2"
-    "@effection/main" "2.0.2"
-    "@effection/stream" "2.0.2"
-    "@effection/subscription" "2.0.2"
 
 effection@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Motivation
It turns out that you don't actually want to have the `beforeEach` scope to descend from the `beforeAll` because if we have a failure in that scope, the parent needs to outlive it so that it is around when the second test runs. As it is now, if you have two testcases:

+ before all
   -> it does one thing
   -> it does another thing

If the first test fails, it will kill the `beforeAll` scope because it is a child and so the error propagates to the parent.

## Approach
This makes breaks that problematic error propagation by making the suite scope and the test scope *independent siblings* so that a test can fail without crashing the suite.

This also adds some checks to make sure both before and after a test runs that both scopes are in good order and if they are failing, the error is raised.