### PR TITLE
Don't run each `it.eventually()` trial directly in the test's "each" scope

### DIFF
--- a/.changes/dont-run-eventually-in-each-scope.md
+++ b/.changes/dont-run-eventually-in-each-scope.md
@@ -1,0 +1,4 @@
+---
+"@effection/jest": patch
+---
+Do not run each trial of it.eventually() in each scope

--- a/packages/jest/src/index.ts
+++ b/packages/jest/src/index.ts
@@ -119,12 +119,13 @@ export const it: It = Object.assign(
 
       return it(
         name,
-        function* () {
+        function* (scope, current) {
+          let operation = fn.bind(this) as (scope: Task, current: Task) => Operation<void>;
           let error = new Error(`operation never succeeded within the ${limit}ms limit`);
           function* trial(): Operation<void> {
             while (true) {
               try {
-                yield runInEachScope(fn, name);
+                yield operation(scope, current);
                 break;
               } catch (e) {
                 error = e as Error;

--- a/packages/jest/test/jest.test.ts
+++ b/packages/jest/test/jest.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, beforeEach, captureError } from '../src/index';
 
-import { Task, Resource, spawn } from 'effection';
+import { Task, Resource, spawn, sleep } from 'effection';
 import { exec } from '@effection/process';
 
 let captured: Task;
@@ -105,6 +105,18 @@ describe('@effection/jest', () => {
 
     it('keeps running beyond the before each block', function*() {
       expect(captured.state).toEqual('running');
+    });
+  });
+
+  describe('.eventually()', () => {
+    beforeEach(function*() {
+      this.tries = 0;
+    });
+
+    it.eventually("passes if the operaton passes within timeout", function*() {
+      yield sleep(1);
+      (this.tries as number)++;
+      expect(this.tries).toBeGreaterThan(10);
     });
   });
 });


### PR DESCRIPTION
## Motivation

`it.eventually()` runs the test operation over and over again until it either passes, or times out. However, we were running each trial directly in the test's "each" scope, so if the trial failed, then it crashed the test's scope which then caused the test to crash, even though we were catching the error inside the eventually loop.

## Approach
This just calls the trial as a normal operation whithin the scope of the current task, that way it can either catch or propagate using the normal rules of nested tasks.