### PR TITLE
Run resolved value from promise as operation

### DIFF
--- a/packages/core/src/controller/controller.ts
+++ b/packages/core/src/controller/controller.ts
@@ -10,6 +10,7 @@ import { createFutureController } from './future-controller';
 import { createResourceController } from './resource-controller';
 import { Future } from '../future';
 import { Symbol } from '../symbol';
+import { UnknownOperationTypeError } from '../error';
 
 export interface Controller<TOut> {
   type: string;
@@ -37,10 +38,10 @@ export function createController<T>(task: Task<T>, operation: Operation<T>, opti
   } else if (isFuture<T>(operation)) {
     return createFutureController(task, operation);
   } else if(isPromise(operation)) {
-    return createPromiseController(task, operation);
+    return createPromiseController(task, operation, value => createController(task, value, options));
   } else if (isGenerator(operation)) {
     return createIteratorController(task, operation, options);
   } else {
-    return createFutureController(task, Future.reject(new Error(`unkown type of operation: ${operation}`)));
+    return createFutureController(task, Future.reject(new UnknownOperationTypeError(`unknown type of operation: ${operation}`)));
   }
 }

--- a/packages/core/src/controller/promise-controller.ts
+++ b/packages/core/src/controller/promise-controller.ts
@@ -1,14 +1,38 @@
 import { Controller } from './controller';
 import { Task } from '../task';
 import { createFuture } from '../future';
+import { extractLabels } from '../labels';
+import { Operation } from '../operation';
+import { UnknownOperationTypeError } from '../error';
 
-export function createPromiseController<TOut>(task: Task<TOut>, promise: PromiseLike<TOut>): Controller<TOut> {
+export function createPromiseController<TOut>(task: Task<TOut>, promise: PromiseLike<TOut>, createController: (value: Operation<TOut>) => Controller<TOut>): Controller<TOut> {
+  let delegate: Controller<TOut>;
   let { produce, future } = createFuture<TOut>();
 
   function start() {
     Promise.race([promise, future]).then(
       (value) => {
-        produce({ state: 'completed', value });
+        if (!value) {
+          produce({ state: 'completed', value });
+        }
+        try {
+          delegate = createController(value as unknown as Operation<TOut>);
+          task.setLabels({
+            ...extractLabels(delegate.operation),
+            ...extractLabels(promise)
+          });
+        } catch (error) {
+          produce({ state: 'errored', error });
+          return;
+        }
+        delegate.future.consume((futureValue) => {
+          if (futureValue.state == 'errored' && futureValue.error instanceof UnknownOperationTypeError) {
+            produce({ state: 'completed', value });
+          } else {
+            produce(futureValue);
+          }
+        });
+        delegate.start();
       },
       (error) => {
         produce({ state: 'errored', error });
@@ -17,8 +41,29 @@ export function createPromiseController<TOut>(task: Task<TOut>, promise: Promise
   }
 
   function halt() {
-    produce({ state: 'halted' });
+    if (delegate) {
+      delegate.halt();
+    } else {
+      produce({ state: 'halted' });
+    }
   }
 
-  return { start, halt, future, type: 'promise', operation: promise };
+  return {
+    get type() {
+      if(delegate) {
+        return delegate.type;
+      } else {
+        return 'promise';
+      }
+    },
+    get operation() {
+      return delegate?.operation;
+    },
+    get resourceTask() {
+      return delegate?.resourceTask;
+    },
+    future,
+    start,
+    halt,
+  };
 }

--- a/packages/core/src/error.ts
+++ b/packages/core/src/error.ts
@@ -22,3 +22,7 @@ export function addTrace(error: Error & Partial<HasEffectionTrace>, task: Task):
     }
   });
 }
+
+export class UnknownOperationTypeError extends Error {
+  name = "UnknownOperationTypeError";
+}

--- a/packages/core/test/iterator.test.ts
+++ b/packages/core/test/iterator.test.ts
@@ -265,6 +265,6 @@ describe('generator function', () => {
       yield "I am not an operation" as unknown as Operation<unknown>;
     });
 
-    await expect(task).rejects.toHaveProperty('message', 'unkown type of operation: I am not an operation');
+    await expect(task).rejects.toHaveProperty('message', 'unknown type of operation: I am not an operation');
   });
 });

--- a/packages/core/test/promise.test.ts
+++ b/packages/core/test/promise.test.ts
@@ -11,6 +11,12 @@ describe('promise', () => {
     expect(task.state).toEqual('completed');
   });
 
+  it('can run resolved value as operation', async () => {
+    let task = run(Promise.resolve(async () => 123));
+    await expect(task).resolves.toEqual(123);
+    expect(task.state).toEqual('completed');
+  });
+
   it('rejects a failed promise', async () => {
     let error = new Error('boom');
     let task = run(Promise.reject(error));


### PR DESCRIPTION
## Motivation

I this PR https://github.com/thefrontside/interactors/pull/166 effection was added to interactors to able execute interactions as operations. But there is one problem. BigTest adds its own interaction wrapper [here](https://github.com/thefrontside/bigtest/blob/v0/packages/agent/app/run-lane.ts#L117-L123). That wrapper is async function. The original action function executes `converge`, which returns a generator. The problem is when we `run` that BigTest wrapper returns a promise that resolves in `converge` generator. But effection handle that `generator` as a end result value and `converge` function is never been executed.

## Approach

Handle resolved value as operation.

### Alternate Designs

- Rewrite interaction wrappers to accept only generators

### Possible Drawbacks or Risks

There is something similar implementation for `FutureOperation` that maybe also should be fixed in the same manner.

### TODOs and Open Questions

I noticed that any `falsy` value treated for suspending task. So if `FunctionOperation` returns falsy value it means task will be suspended. But there are possible scenarios where resolved value from `PromiseOperation` could be `0` or `null` or `false` even empty string and it's could be a valid value. For `FunctionOperation` that behavior is different.