### PR TITLE
Publish New Versions

### DIFF
--- a/.changes/string-shell.md
+++ b/.changes/string-shell.md
@@ -1,5 +1,0 @@
----
-"@effection/process": minor
----
-
-The shell option now accepts a string which allows one to specify an exact shell to run a command. This is helpful on windows as the default generally doesn't handle bash-like syntax.

--- a/packages/process/CHANGELOG.md
+++ b/packages/process/CHANGELOG.md
@@ -1,5 +1,10 @@
 # @effection/process
 
+## \[2.1.0]
+
+- The shell option now accepts a string which allows one to specify an exact shell to run a command. This is helpful on windows as the default generally doesn't handle bash-like syntax.
+  - [31d8512](https://github.com/thefrontside/effection/commit/31d85123535903820c7ee2c58891ad4f7ae385e5) change file on 2022-03-29
+
 ## \[2.0.4]
 
 - Allow pass object with `Symbol.operation` as an operation

--- a/packages/process/package.json
+++ b/packages/process/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/process",
-  "version": "2.0.4",
+  "version": "2.1.0",
   "description": "Spawn and manage external processes with Effection",
   "main": "dist-cjs/index.js",
   "module": "dist-esm/index.js",


### PR DESCRIPTION
# Version Updates

Merging this PR will release new versions of the following packages based on your change files.




# @effection/process

## [2.1.0]
- The shell option now accepts a string which allows one to specify an exact shell to run a command. This is helpful on windows as the default generally doesn't handle bash-like syntax.
  - [31d8512](https://github.com/thefrontside/effection/commit/31d85123535903820c7ee2c58891ad4f7ae385e5) change file on 2022-03-29