### PR TITLE
Make React a flexible peer dependency

### DIFF
--- a/.changes/inspect-ui-react-peer-dep.md
+++ b/.changes/inspect-ui-react-peer-dep.md
@@ -1,0 +1,4 @@
+---
+"@effection/react": patch
+---
+make react a flexible peer dependency for 16,17

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -28,8 +28,7 @@
     "mocha": "mocha -r ts-node/register"
   },
   "dependencies": {
-    "effection": "2.0.4",
-    "react": "^17.0.2"
+    "effection": "^2.0.0"
   },
   "devDependencies": {
     "@frontside/tsconfig": "^1.2.0",
@@ -40,9 +39,13 @@
     "eslint-plugin-react-hooks": "^4.2.0",
     "expect": "^25.4.0",
     "mocha": "^8.3.1",
+    "react": "^17.0.2",
     "react-test-renderer": "^17.0.2",
     "ts-node": "^10.4.0",
     "typescript": "^4.3.5"
+  },
+  "peerDependencies": {
+    "react": "^16.13.1 || ^17.0.0"
   },
   "volta": {
     "extends": "../../package.json"


### PR DESCRIPTION
## Motivation
React is very finicky about having more than one copy of the react code itself in a single app

https://reactjs.org/warnings/invalid-hook-call-warning.html

Having a hard dependency on React 17 means then that a local copy of React 17 will be installed in this package and that it will be incompatible with React 16 apps.

## Approach
This changes the dependency on react to a peer dependency, and furthermore allows it to work on react 16 versions that have hooks, and version 17.
