### PR TITLE
Upgraded to inspector-ui to react-router@6.3.0

### DIFF
--- a/packages/inspect-ui/app/app.tsx
+++ b/packages/inspect-ui/app/app.tsx
@@ -4,7 +4,7 @@ import { Slice } from '@effection/atom';
 import { InspectState } from '@effection/inspect-utils';
 import { SettingsMenu, SettingsContext, DEFAULT_SETTINGS } from './settings';
 import { TaskPage } from './task-page';
-import { TaskTreeRoot } from './task-tree-root';
+import { TaskTreePage } from './task-tree-page';
 
 export type InspectStateSlice = Slice<InspectState>;
 
@@ -18,7 +18,7 @@ export function App({ slice }: AppProps): JSX.Element {
       children: [
         {
           index: true,
-          element: <TaskTreeRoot slice={slice} />,
+          element: <TaskTreePage slice={slice} />,
         },
         {
           path: "tasks/:id",

--- a/packages/inspect-ui/app/app.tsx
+++ b/packages/inspect-ui/app/app.tsx
@@ -1,71 +1,36 @@
 import React, { useState } from 'react';
-import { Switch, Route, Link, Redirect, RouteComponentProps } from 'react-router-dom';
+import { RouteObject, useRoutes } from 'react-router-dom';
 import { Slice } from '@effection/atom';
-import { useSlice } from '@effection/react';
 import { InspectState } from '@effection/inspect-utils';
-import { TaskTree } from './task-tree';
 import { SettingsMenu, SettingsContext, DEFAULT_SETTINGS } from './settings';
+import { TaskPage } from './task-page';
+import { TaskTreeRoot } from './task-tree-root';
+
+export type InspectStateSlice = Slice<InspectState>;
 
 type AppProps = {
-  slice: Slice<InspectState>;
+  slice: InspectStateSlice
 }
-
-function findSliceById(slice: Slice<InspectState>, targetId: number): Slice<InspectState> | undefined {
-  let task = slice.get();
-
-  if(task.id === targetId) {
-    return slice;
-  }
-
-  if(task.yieldingTo) {
-    let result = findSliceById(slice.slice('yieldingTo') as Slice<InspectState>, targetId);
-    if(result) {
-      return result;
-    }
-  }
-
-  for(let [index] of task.children.entries()) {
-    let result = findSliceById(slice.slice('children', index), targetId);
-    if(result) {
-      return result;
-    }
-  }
-
-  return undefined;
-}
-
-function TaskTreeRoot({ slice }: { slice: Slice<InspectState> }) {
-  let task = useSlice(slice);
-
-  if(task) {
-    return <TaskTree task={task}/>;
-  } else {
-    return <Redirect to="/"/>;
-  }
-}
-
 
 export function App({ slice }: AppProps): JSX.Element {
+  let routes: RouteObject[] = [
+    {
+      children: [
+        {
+          index: true,
+          element: <TaskTreeRoot slice={slice} />,
+        },
+        {
+          path: "tasks/:id",
+          element: <TaskPage slice={slice} />
+        }
+      ],
+    },
+  ];
+
   let [settings, setSettings] = useState(DEFAULT_SETTINGS);
 
-  function AllTasksPage(): JSX.Element {
-    return <TaskTreeRoot slice={slice}/>;
-  }
-
-  function TaskPage({ match }: RouteComponentProps<{ id: string }>): JSX.Element {
-    let targetSlice = findSliceById(slice, Number(match.params.id));
-    if(targetSlice) {
-      return (
-        <div>
-          <p><Link to='/' className="inspector--main--return">← Show all</Link></p>
-
-          <TaskTreeRoot slice={targetSlice}/>
-        </div>
-      );
-    } else {
-      return <Redirect to="/"/>;
-    }
-  }
+  let element = useRoutes(routes);
 
   return (
     <SettingsContext.Provider value={{ settings, setSettings }}>
@@ -73,15 +38,10 @@ export function App({ slice }: AppProps): JSX.Element {
         <div className="inspector--menu">
           <h1 className="inspector--menu--title">Effection Inspector</h1>
           <div className="inspector--menu--toolbar">
-            <SettingsMenu/>
+            <SettingsMenu />
           </div>
         </div>
-        <div className="inspector--main">
-          <Switch>
-            <Route exact path="/" component={AllTasksPage}/>
-            <Route path="/tasks/:id" component={TaskPage}/>
-          </Switch>
-        </div>
+        <div className="inspector--main">{element}</div>
       </div>
     </SettingsContext.Provider>
   );

--- a/packages/inspect-ui/app/task-page.tsx
+++ b/packages/inspect-ui/app/task-page.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import { useParams, Link, Navigate } from "react-router-dom";
+import { InspectStateSlice } from "./app";
+import { TaskTreeRoot } from "./task-tree-root";
+
+export function TaskPage({ slice }: { slice: InspectStateSlice }): JSX.Element {
+  let { id } = useParams();
+
+  let targetSlice = findSliceById(slice, Number(id));
+  if (targetSlice) {
+    return (
+      <div>
+        <p>
+          <Link to="/" className="inspector--main--return">
+            ← Show all
+          </Link>
+        </p>
+
+        <TaskTreeRoot slice={targetSlice} />
+      </div>
+    );
+  } else {
+    return <Navigate to="/" />;
+  }
+}
+
+function findSliceById(
+  slice: InspectStateSlice,
+  targetId: number
+): InspectStateSlice | undefined {
+  let task = slice.get();
+
+  if (task.id === targetId) {
+    return slice;
+  }
+
+  if (task.yieldingTo) {
+    let result = findSliceById(
+      slice.slice("yieldingTo") as InspectStateSlice,
+      targetId
+    );
+    if (result) {
+      return result;
+    }
+  }
+
+  for (let [index] of task.children.entries()) {
+    let result = findSliceById(slice.slice("children", index), targetId);
+    if (result) {
+      return result;
+    }
+  }
+
+  return undefined;
+}

--- a/packages/inspect-ui/app/task-page.tsx
+++ b/packages/inspect-ui/app/task-page.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useParams, Link, Navigate } from "react-router-dom";
 import { InspectStateSlice } from "./app";
-import { TaskTreeRoot } from "./task-tree-root";
+import { TaskTreePage } from "./task-tree-page";
 
 export function TaskPage({ slice }: { slice: InspectStateSlice }): JSX.Element {
   let { id } = useParams();
@@ -16,7 +16,7 @@ export function TaskPage({ slice }: { slice: InspectStateSlice }): JSX.Element {
           </Link>
         </p>
 
-        <TaskTreeRoot slice={targetSlice} />
+        <TaskTreePage slice={targetSlice} />
       </div>
     );
   } else {

--- a/packages/inspect-ui/app/task-tree-page.tsx
+++ b/packages/inspect-ui/app/task-tree-page.tsx
@@ -4,7 +4,7 @@ import { Navigate } from 'react-router-dom';
 import { InspectStateSlice } from './app';
 import { TaskTree } from './task-tree';
 
-export function TaskTreeRoot({ slice }: { slice: InspectStateSlice }): JSX.Element {
+export function TaskTreePage({ slice }: { slice: InspectStateSlice }): JSX.Element {
   let task = useSlice(slice);
 
   if (task) {

--- a/packages/inspect-ui/app/task-tree-root.tsx
+++ b/packages/inspect-ui/app/task-tree-root.tsx
@@ -1,0 +1,15 @@
+import { useSlice } from '@effection/react';
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+import { InspectStateSlice } from './app';
+import { TaskTree } from './task-tree';
+
+export function TaskTreeRoot({ slice }: { slice: InspectStateSlice }): JSX.Element {
+  let task = useSlice(slice);
+
+  if (task) {
+    return <TaskTree task={task} />;
+  } else {
+    return <Navigate to="/" />;
+  }
+}

--- a/packages/inspect-ui/package.json
+++ b/packages/inspect-ui/package.json
@@ -30,6 +30,12 @@
     "docs": "echo noop",
     "mocha": "mocha -r ts-node/register --timeout 5000"
   },
+  "peerDependencies": {
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
+    "react-router": "^6.3.0",
+    "react-router-dom": "^6.3.0"
+  },
   "devDependencies": {
     "@interactors/html": "^1.0.0-rc1.2",
     "@effection/inspect-utils": "2.1.4",
@@ -53,8 +59,8 @@
     "parcel": "^2.5.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-router": "^5.2.1",
-    "react-router-dom": "^5.3.0",
+    "react-router": "^6.3.0",
+    "react-router-dom": "^6.3.0",
     "ts-node": "^10.4.0",
     "typescript": "^4.3.5"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -437,14 +437,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.16.7"
 
-"@babel/runtime@^7.1.2", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.13":
-  version "7.15.4"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.15.4.tgz#fd17d16bfdf878e6dd02d19753a39fa8a8d9c84a"
-  integrity sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==
-  dependencies:
-    regenerator-runtime "^0.13.4"
-
-"@babel/runtime@^7.12.5":
+"@babel/runtime@^7.12.5", "@babel/runtime@^7.7.6":
   version "7.17.9"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.9.tgz#d19fbf802d01a8cb6cf053a64e472d42c434ba72"
   integrity sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==
@@ -4765,24 +4758,12 @@ header-case@^2.0.4:
     capital-case "^1.0.4"
     tslib "^2.0.3"
 
-history@^4.9.0:
-  version "4.10.1"
-  resolved "https://registry.yarnpkg.com/history/-/history-4.10.1.tgz#33371a65e3a83b267434e2b3f3b1b4c58aad4cf3"
-  integrity sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==
+history@^5.2.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/history/-/history-5.3.0.tgz#1548abaa245ba47992f063a0783db91ef201c73b"
+  integrity sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==
   dependencies:
-    "@babel/runtime" "^7.1.2"
-    loose-envify "^1.2.0"
-    resolve-pathname "^3.0.0"
-    tiny-invariant "^1.0.2"
-    tiny-warning "^1.0.0"
-    value-equal "^1.0.1"
-
-hoist-non-react-statics@^3.1.0:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
-  integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
-  dependencies:
-    react-is "^16.7.0"
+    "@babel/runtime" "^7.7.6"
 
 hosted-git-info@^2.1.4, hosted-git-info@^2.7.1:
   version "2.8.9"
@@ -6112,7 +6093,7 @@ longest-streak@^2.0.0:
   resolved "https://registry.yarnpkg.com/longest-streak/-/longest-streak-2.0.4.tgz#b8599957da5b5dab64dee3fe316fa774597d90e4"
   integrity sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg==
 
-loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
+loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -6344,14 +6325,6 @@ min-indent@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
   integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
-
-mini-create-react-context@^0.4.0:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/mini-create-react-context/-/mini-create-react-context-0.4.1.tgz#072171561bfdc922da08a60c2197a497cc2d1d5e"
-  integrity sha512-YWCYEmd5CQeHGSAKrYvXgmzzkrvssZcuuQDDeqkT+PziKGMgE+0MCCtcKbROzocGBG1meBLl2FotlRwf4gAzbQ==
-  dependencies:
-    "@babel/runtime" "^7.12.1"
-    tiny-warning "^1.0.3"
 
 minimatch@3.0.4:
   version "3.0.4"
@@ -7112,13 +7085,6 @@ path-parse@^1.0.6, path-parse@^1.0.7:
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
-path-to-regexp@^1.7.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.8.0.tgz#887b3ba9d84393e87a0a0b9f4cb756198b53548a"
-  integrity sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==
-  dependencies:
-    isarray "0.0.1"
-
 path-type@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-3.0.0.tgz#cef31dc8e0a1a3bb0d105c0cd97cf3bf47f4e36f"
@@ -7283,7 +7249,7 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -7333,7 +7299,7 @@ react-dom@^17.0.2:
     object-assign "^4.1.1"
     scheduler "^0.20.2"
 
-react-is@^16.12.0, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1:
+react-is@^16.12.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -7353,34 +7319,20 @@ react-refresh@^0.9.0:
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.9.0.tgz#71863337adc3e5c2f8a6bfddd12ae3bfe32aafbf"
   integrity sha512-Gvzk7OZpiqKSkxsQvO/mbTN1poglhmAV7gR/DdIrRrSMXraRQQlfikRJOr3Nb9GTMPC5kof948Zy6jJZIFtDvQ==
 
-react-router-dom@^5.3.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-5.3.0.tgz#da1bfb535a0e89a712a93b97dd76f47ad1f32363"
-  integrity sha512-ObVBLjUZsphUUMVycibxgMdh5jJ1e3o+KpAZBVeHcNQZ4W+uUGGWsokurzlF4YOldQYRQL4y6yFRWM4m3svmuQ==
+react-router-dom@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.3.0.tgz#a0216da813454e521905b5fa55e0e5176123f43d"
+  integrity sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==
   dependencies:
-    "@babel/runtime" "^7.12.13"
-    history "^4.9.0"
-    loose-envify "^1.3.1"
-    prop-types "^15.6.2"
-    react-router "5.2.1"
-    tiny-invariant "^1.0.2"
-    tiny-warning "^1.0.0"
+    history "^5.2.0"
+    react-router "6.3.0"
 
-react-router@5.2.1, react-router@^5.2.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-5.2.1.tgz#4d2e4e9d5ae9425091845b8dbc6d9d276239774d"
-  integrity sha512-lIboRiOtDLFdg1VTemMwud9vRVuOCZmUIT/7lUoZiSpPODiiH1UQlfXy+vPLC/7IWdFYnhRwAyNqA/+I7wnvKQ==
+react-router@6.3.0, react-router@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.3.0.tgz#3970cc64b4cb4eae0c1ea5203a80334fdd175557"
+  integrity sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==
   dependencies:
-    "@babel/runtime" "^7.12.13"
-    history "^4.9.0"
-    hoist-non-react-statics "^3.1.0"
-    loose-envify "^1.3.1"
-    mini-create-react-context "^0.4.0"
-    path-to-regexp "^1.7.0"
-    prop-types "^15.6.2"
-    react-is "^16.6.0"
-    tiny-invariant "^1.0.2"
-    tiny-warning "^1.0.0"
+    history "^5.2.0"
 
 react-shallow-renderer@^16.13.1:
   version "16.14.1"
@@ -7604,11 +7556,6 @@ resolve-from@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
-
-resolve-pathname@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/resolve-pathname/-/resolve-pathname-3.0.0.tgz#99d02224d3cf263689becbb393bc560313025dcd"
-  integrity sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==
 
 resolve-url@^0.2.1:
   version "0.2.1"
@@ -8365,16 +8312,6 @@ timsort@^0.3.0:
   resolved "https://registry.yarnpkg.com/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4"
   integrity sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=
 
-tiny-invariant@^1.0.2:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.1.0.tgz#634c5f8efdc27714b7f386c35e6760991d230875"
-  integrity sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw==
-
-tiny-warning@^1.0.0, tiny-warning@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
-  integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
-
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
@@ -8832,11 +8769,6 @@ validate-npm-package-name@^3.0.0:
   integrity sha1-X6kS2B630MdK/BQN5zF/DKffQ34=
   dependencies:
     builtins "^1.0.3"
-
-value-equal@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-1.0.1.tgz#1e0b794c734c5c0cade179c437d356d931a34d6c"
-  integrity sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==
 
 verror@1.10.0:
   version "1.10.0"


### PR DESCRIPTION
## Motivation

I'm in the process of upgrading inspector-ui to make it embeddable into Backstage. One of the problems that we observed in our integration is that navigating to index page caused the browser to go to root. For example, going from `/inspector/tasks/1`, navigated to `/` instead of `/inspector`. This was caused by the fact that routing was not scoped within the route. We can fix that with relative navigation and nested routes introduced in React Router 6.0.

## Approach

1. Upgraded to react-router@6.3.0. 
2. Defined one root route with 2 child routes as a route object
3. Replaced `<Switch>` with `useRoutes`
4. Refactored to use `element` which allow to eliminate unnecessary wrapper components
5. Refactored to use `Navigate` instead of `Redirect`
6. Created TaskTreePage & TaskPage 

### Possible Drawbacks or Risks

[React Router 6.3 compatibility](https://github.com/backstage/backstage/pull/10450) hasn't been merged yet. It maybe problematic, but I think it should be ok. 

## Learning

[Upgrading from React Router 5](https://reactrouter.com/docs/en/v6/upgrading/v5)