### PR TITLE
Add useResource hook.

### DIFF
--- a/.changes/react-use-resource.md
+++ b/.changes/react-use-resource.md
@@ -1,0 +1,4 @@
+---
+"@effection/react": minor
+---
+introduce the `useResource()` hook for working directly with resources.

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -2,4 +2,5 @@ export { useStream } from './use-stream';
 export { useSubscription } from './use-subscription';
 export { useOperation } from './use-operation';
 export { useSlice } from './use-slice';
+export { ResourceHandle, useResource } from './use-resource';
 export { EffectionContext } from './context';

--- a/packages/react/src/use-resource.ts
+++ b/packages/react/src/use-resource.ts
@@ -1,0 +1,31 @@
+import type { DependencyList } from "react";
+import type { Operation } from "effection";
+import { useState } from "react";
+import { useOperation } from "./use-operation";
+
+export type ResourceHandle<T> = {
+  type: 'pending';
+} | {
+  type: 'resolved';
+  value: T;
+} | {
+  type: 'rejected';
+  error: Error;
+}
+
+export function useResource<T>(resource: Operation<T>, deps: DependencyList = []): ResourceHandle<T> {
+  let [state, setState] = useState<ResourceHandle<T>>({ type: 'pending' });
+
+  useOperation(function*() {
+    try {
+      yield function* ErrorBoundary() {
+        setState({ type: 'resolved', value: yield resource });
+        yield;
+      }
+    } catch (error: any) {
+      setState({ type: 'rejected', error });
+    }
+  }, deps as unknown[]);
+
+  return state;
+}

--- a/packages/react/src/use-resource.ts
+++ b/packages/react/src/use-resource.ts
@@ -21,9 +21,9 @@ export function useResource<T>(resource: Operation<T>, deps: DependencyList = []
       yield function* ErrorBoundary() {
         setState({ type: 'resolved', value: yield resource });
         yield;
-      }
-    } catch (error: any) {
-      setState({ type: 'rejected', error });
+      };
+    } catch (error: unknown) {
+      setState({ type: 'rejected', error: error as Error });
     }
   }, deps as unknown[]);
 

--- a/packages/react/test/use-resource.test.tsx
+++ b/packages/react/test/use-resource.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it } from '@effection/mocha';
+import expect from 'expect';
+
+import React from 'react';
+import type { ReactTestRenderer } from 'react-test-renderer';
+import { render } from './helpers';
+import { useResource } from '../src/';
+
+import { sleep, spawn, createFuture } from 'effection';
+
+describe("use-resource", () => {
+
+  it('is loading while the resource is initializing', function*() {
+    function Test() {
+      let handle = useResource(new Promise(() => {}));
+      return <h1>{handle.type}</h1>
+    }
+
+    let renderer: ReactTestRenderer = yield render(<Test/>);
+    expect(renderer.toJSON()).toMatchObject({ type: 'h1', children: ['pending'] });
+  });
+
+  it('provides a handle to the resource when initialization succeeds', function*() {
+    let resolve = Promise.resolve('hello');
+
+    function Test() {
+      let handle = useResource(resolve);
+      return <h1>{handle.type === 'resolved' ? handle.value : null }</h1>
+    }
+
+    let renderer: ReactTestRenderer = yield render(<Test/>);
+    yield resolve;
+    yield tick();
+
+    expect(renderer.toJSON()).toMatchObject({ type: 'h1', children: ['hello'] });
+  });
+
+  it('marks the resource state as rejected when initialization fails', function*() {
+    let explode = Promise.reject(new Error('boom!'));
+    function Test() {
+      let handle = useResource(explode);
+      return <h1>{handle.type === 'rejected' ? handle.error.message: null }</h1>
+    }
+
+    let renderer: ReactTestRenderer = yield render(<Test/>);
+    yield explode.catch(() => {});
+    yield tick();
+    expect(renderer.toJSON()).toMatchObject({ type: 'h1', children: ['boom!'] });
+  });
+
+  it('marks the resource state as rejected when initialization succeeds, but resource subsequently fails', function*() {
+
+    let { resolve, future } = createFuture<void>();
+
+    function Test() {
+      let handle = useResource({
+        name: 'Test',
+        *init() {
+          yield spawn(function* Box() {
+            yield future;
+            throw new Error('boom!');
+          });
+          return 'hello';
+        }
+      });
+
+      if (handle.type === 'resolved') {
+        return <h1>{handle.value}</h1>;
+      } else if (handle.type === 'rejected') {
+        return <h1>{handle.error.message}</h1>;
+      } else {
+        return <h1>pending</h1>
+      }
+    }
+
+    let renderer: ReactTestRenderer = yield render(<Test/>);
+
+    yield tick();
+    expect(renderer.toJSON()).toMatchObject({ type: 'h1', children: ['hello']});
+
+    resolve();
+    yield tick();
+    expect(renderer.toJSON()).toMatchObject({ type: 'h1', children: ['boom!']});
+  });
+});
+
+const tick = () => sleep(0);


### PR DESCRIPTION
## Motivation

When embedding the inspector into another react app, we need to load a slice of data that is continuously updated from the server. This data is loaded from either a `WebSocket` or an `EventSource` and so it takes some time to become available as the server and client negotiate could fail at any point. Once this has been negotiated, and only then, is the stream set up and the subscription can be used to drive the inspector. It turns out that it is helpful to model this very Effectionate process directly in the state

## Approach
This adds a hook callled `useResource()` that can be used to consume a resource directly from within a React Component. Resources can either be `pending`, `resolved`, or `rejected` and as a result, the handle returned by a resource does not let you access the resource directly, but via a `Maybe`-like interface called `ResourceHandle`.

```tsx
  const handle = useResource(operation, [dep1, dep2]);

  if (handle.type === 'pending') {
    return <p>Loading</p>;
  } else if (handle.type === 'rejected') {
    return <p>{handle.error.toString()}</p>;
  } else {
    return <MyComponent value={handle.value}/>
  }
```

It's interestig to note that `useResource` can be used with _any_ `Operation` type, and _not_ just `Resource`. This is because normal operations also provide a value asynchronously. The only difference is that they are completely done and do not have any on-going computation associated with them. The following is totaly valid:

```tsx
  const handle = useResource(Promise.resolve('hello'), [dep1, dep2]);

  if (handle.type === 'pending') {
    return <p>Loading</p>;
  } else if (handle.type === 'rejected') {
    return <p>{handle.error.toString()}</p>;
  } else {
    return <MyComponent value={handle.value}/>
  }
```