### PR TITLE
Publish New Versions

### DIFF
--- a/.changes/fix-typings-path.md
+++ b/.changes/fix-typings-path.md
@@ -1,8 +1,0 @@
----
-"@effection/inspect-ui": minor
-"@effection/inspect-server": minor
----
-
-`@effection/inspect-server` is now responsible for resolving the path of `@effection/inspect-ui/dist-app/index.html`.
-This allows us to remove Node.js specific code from the `@effection/inspect-ui` package and make sure that exports only
-include the code that will be used in the browser.

--- a/.changes/react-use-resource.md
+++ b/.changes/react-use-resource.md
@@ -1,4 +1,0 @@
----
-"@effection/react": minor
----
-introduce the `useResource()` hook for working directly with resources.

--- a/packages/inspect-server/CHANGELOG.md
+++ b/packages/inspect-server/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @effection/inspect-server
 
+## \[2.2.0]
+
+- `@effection/inspect-server` is now responsible for resolving the path of `@effection/inspect-ui/dist-app/index.html`.
+  This allows us to remove Node.js specific code from the `@effection/inspect-ui` package and make sure that exports only
+  include the code that will be used in the browser.
+  - [3b40df0](https://github.com/thefrontside/effection/commit/3b40df0f660987ec782d3d4ab9674b595cf5b019) Added changeset on 2022-05-10
+
 ## \[2.1.5]
 
 - Add ESM build of react components so that they can be embedded into any

--- a/packages/inspect-server/package.json
+++ b/packages/inspect-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/inspect-server",
-  "version": "2.1.5",
+  "version": "2.2.0",
   "description": "Inspect server for inspecting effection processes",
   "main": "dist-cjs/index.js",
   "types": "dist-esm/index.d.ts",
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@effection/atom": "2.0.4",
-    "@effection/inspect-ui": "2.1.5",
+    "@effection/inspect-ui": "2.2.0",
     "@effection/inspect-utils": "2.1.4",
     "@effection/websocket-server": "2.0.4",
     "effection": "2.0.4",

--- a/packages/inspect-ui/CHANGELOG.md
+++ b/packages/inspect-ui/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @effection/inspect-ui
 
+## \[2.2.0]
+
+- `@effection/inspect-server` is now responsible for resolving the path of `@effection/inspect-ui/dist-app/index.html`.
+  This allows us to remove Node.js specific code from the `@effection/inspect-ui` package and make sure that exports only
+  include the code that will be used in the browser.
+  - [3b40df0](https://github.com/thefrontside/effection/commit/3b40df0f660987ec782d3d4ab9674b595cf5b019) Added changeset on 2022-05-10
+
 ## \[2.1.5]
 
 - Add ESM build of react components so that they can be embedded into any

--- a/packages/inspect-ui/package.json
+++ b/packages/inspect-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/inspect-ui",
-  "version": "2.1.5",
+  "version": "2.2.0",
   "description": "Web interface for inspecting effection applications",
   "main": "app/index.ts",
   "types": "dist-esm/index.d.ts",
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@interactors/html": "^1.0.0-rc1.2",
     "@effection/inspect-utils": "2.1.4",
-    "@effection/react": "2.1.4",
+    "@effection/react": "2.2.0",
     "@effection/websocket-client": "2.0.4",
     "@frontside/tsconfig": "^1.2.0",
     "@types/jsdom-global": "^3.0.2",

--- a/packages/inspect/CHANGELOG.md
+++ b/packages/inspect/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @effection/inspect
 
+## \[2.1.6]
+
+- `@effection/inspect-server` is now responsible for resolving the path of `@effection/inspect-ui/dist-app/index.html`.
+  This allows us to remove Node.js specific code from the `@effection/inspect-ui` package and make sure that exports only
+  include the code that will be used in the browser.
+  - Bumped due to a bump in @effection/inspect-server.
+  - [3b40df0](https://github.com/thefrontside/effection/commit/3b40df0f660987ec782d3d4ab9674b595cf5b019) Added changeset on 2022-05-10
+
 ## \[2.1.5]
 
 - Add ESM build of react components so that they can be embedded into any

--- a/packages/inspect/package.json
+++ b/packages/inspect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/inspect",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "description": "Injects an inspector into an Effection application",
   "main": "index.cjs.js",
   "module": "index.esm.js",
@@ -23,7 +23,7 @@
     "docs": "echo noop"
   },
   "dependencies": {
-    "@effection/inspect-server": "2.1.5"
+    "@effection/inspect-server": "2.2.0"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,10 @@
 # @effection/react
 
+## \[2.2.0]
+
+- introduce the `useResource()` hook for working directly with resources.
+  - [47f9c9e](https://github.com/thefrontside/effection/commit/47f9c9ee4092d8f05b21372f9300e4f9cd530c2a) Add useResource hook. on 2022-05-09
+
 ## \[2.1.4]
 
 - make react a flexible peer dependency for 16,17

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/react",
-  "version": "2.1.4",
+  "version": "2.2.0",
   "description": "Hooks for integrating effection into react applications",
   "main": "dist-cjs/index.js",
   "module": "dist-esm/index.js",


### PR DESCRIPTION
# Version Updates

Merging this PR will release new versions of the following packages based on your change files.




# @effection/inspect

## [2.1.6]
- `@effection/inspect-server` is now responsible for resolving the path of `@effection/inspect-ui/dist-app/index.html`.
This allows us to remove Node.js specific code from the `@effection/inspect-ui` package and make sure that exports only
include the code that will be used in the browser.
  - Bumped due to a bump in @effection/inspect-server.
  - [3b40df0](https://github.com/thefrontside/effection/commit/3b40df0f660987ec782d3d4ab9674b595cf5b019) Added changeset on 2022-05-10



# @effection/inspect-server

## [2.2.0]
- `@effection/inspect-server` is now responsible for resolving the path of `@effection/inspect-ui/dist-app/index.html`.
This allows us to remove Node.js specific code from the `@effection/inspect-ui` package and make sure that exports only
include the code that will be used in the browser.
  - [3b40df0](https://github.com/thefrontside/effection/commit/3b40df0f660987ec782d3d4ab9674b595cf5b019) Added changeset on 2022-05-10



# @effection/react

## [2.2.0]
- introduce the `useResource()` hook for working directly with resources.
  - [47f9c9e](https://github.com/thefrontside/effection/commit/47f9c9ee4092d8f05b21372f9300e4f9cd530c2a) Add useResource hook. on 2022-05-09



# @effection/inspect-ui

## [2.2.0]
- `@effection/inspect-server` is now responsible for resolving the path of `@effection/inspect-ui/dist-app/index.html`.
This allows us to remove Node.js specific code from the `@effection/inspect-ui` package and make sure that exports only
include the code that will be used in the browser.
  - [3b40df0](https://github.com/thefrontside/effection/commit/3b40df0f660987ec782d3d4ab9674b595cf5b019) Added changeset on 2022-05-10