### PR TITLE
Embrace "structured concurrency" in tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 # Effection
 
-A JavaScript framework that makes building concurrent systems easy to get right.
+Structured concurrency and effects for JavaScript.
 
 ## Why use Effection?
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "effection-monorepo",
   "version": "0.0.0-monorepo",
-  "description": "Effortlessly composable structured concurrency primitive for JavaScript",
+  "description": "Structured concurrency and effects for JavaScript",
   "repository": "git@github.com:thefrontside/effection.git",
   "author": "Frontside Engineering <engineering@frontside.com>",
   "license": "MIT",

--- a/packages/effection/package.json
+++ b/packages/effection/package.json
@@ -1,7 +1,7 @@
 {
   "name": "effection",
   "version": "2.0.4",
-  "description": "Effortlessly composable structured concurrency primitive for JavaScript",
+  "description": "Structured concurrency and effects for JavaScript",
   "homepage": "https://frontside.com/effection",
   "repository": {
     "type": "git",

--- a/website/docs/guides/introduction.md
+++ b/website/docs/guides/introduction.md
@@ -3,8 +3,7 @@ id: introduction
 title: Introduction
 ---
 
-Effection is a JavaScript framework that makes building
-concurrent systems easy to get right.
+Effection is a structured concurrency and effects framework for JavaScript.
 
 ## Why use Effection?
 


### PR DESCRIPTION
## Motivation
Originally, we had shied away from using the term "structured concurrency" directly since it was not that well known, a bit academic sounding and we wanted to appeal to a practical audience. However, now that it is becoming more mainstream with the advent of structured concurrent systems in Java and Swift, it is much more recognizable and people will be explicitly shopping for structured concurrency. 

We should state explicitly that yes, this is structured concurrency (and effects) so that folks searching for  those things will find us and know that it's what we're looking for.