### PR TITLE
Publish New Versions

### DIFF
--- a/.changes/ctrlc-windows-2.1.0.md
+++ b/.changes/ctrlc-windows-2.1.0.md
@@ -1,5 +1,0 @@
----
-'@effection/process': patch
----
-
-Bump the `ctrlc-windows` package to include the new build process and remove all dependencies.

--- a/.changes/expose-format-error.md
+++ b/.changes/expose-format-error.md
@@ -1,4 +1,0 @@
----
-'@effection/main': minor
----
-Expose `formatError` so other packages can format errors the same way as `main`

--- a/.changes/inspect-utils-dispatch-dep.md
+++ b/.changes/inspect-utils-dispatch-dep.md
@@ -1,5 +1,0 @@
----
-"@effection/inspect-utils": patch
----
-
-`@effection/dispatch` was not listed as a dependency which led to it becoming out of sync with the latest.

--- a/.changes/material-ui-inspector.md
+++ b/.changes/material-ui-inspector.md
@@ -1,4 +1,0 @@
----
-'@effection/inspect-ui': minor
----
-Refactored the UI to use Material UI

--- a/packages/atom/CHANGELOG.md
+++ b/packages/atom/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @effection/atom
 
+## \[2.0.5]
+
+- Expose `formatError` so other packages can format errors the same way as `main`
+  - Bumped due to a bump in effection.
+  - [6b2077f](https://github.com/thefrontside/effection/commit/6b2077f6217883630e20df4569e22d2ebce3a6ce) Expose  so packages other than  can make nice errors on 2022-05-27
+
 ## \[2.0.4]
 
 - Allow pass object with `Symbol.operation` as an operation

--- a/packages/atom/package.json
+++ b/packages/atom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/atom",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "State atom implementation for effection",
   "main": "dist-cjs/index.js",
   "types": "dist-esm/index.d.ts",
@@ -41,7 +41,7 @@
     "extends": "../../package.json"
   },
   "dependencies": {
-    "effection": "2.0.4",
+    "effection": "2.0.5",
     "assert-ts": "^0.2.2",
     "fp-ts": "^2.8.2",
     "monocle-ts": "^2.3.3"

--- a/packages/dispatch/CHANGELOG.md
+++ b/packages/dispatch/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## \[2.0.5]
+
+- Expose `formatError` so other packages can format errors the same way as `main`
+  - Bumped due to a bump in effection.
+  - [6b2077f](https://github.com/thefrontside/effection/commit/6b2077f6217883630e20df4569e22d2ebce3a6ce) Expose  so packages other than  can make nice errors on 2022-05-27
+
 ## \[2.0.4]
 
 - Allow pass object with `Symbol.operation` as an operation

--- a/packages/dispatch/package.json
+++ b/packages/dispatch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/dispatch",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Splits a subscription into multiple subscriptions",
   "main": "dist-cjs/index.js",
   "module": "dist-esm/index.js",
@@ -39,6 +39,6 @@
     "extends": "../../package.json"
   },
   "dependencies": {
-    "effection": "2.0.4"
+    "effection": "2.0.5"
   }
 }

--- a/packages/duplex-channel/CHANGELOG.md
+++ b/packages/duplex-channel/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## \[2.0.5]
+
+- Expose `formatError` so other packages can format errors the same way as `main`
+  - Bumped due to a bump in effection.
+  - [6b2077f](https://github.com/thefrontside/effection/commit/6b2077f6217883630e20df4569e22d2ebce3a6ce) Expose  so packages other than  can make nice errors on 2022-05-27
+
 ## \[2.0.4]
 
 - Allow pass object with `Symbol.operation` as an operation

--- a/packages/duplex-channel/package.json
+++ b/packages/duplex-channel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/duplex-channel",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "A bidirectional channel for effection",
   "main": "dist-cjs/index.js",
   "module": "dist-esm/index.js",
@@ -37,7 +37,7 @@
     "typescript": "^4.3.5"
   },
   "dependencies": {
-    "effection": "2.0.4"
+    "effection": "2.0.5"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/effection/CHANGELOG.md
+++ b/packages/effection/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## \[2.0.5]
+
+- Expose `formatError` so other packages can format errors the same way as `main`
+  - Bumped due to a bump in @effection/main.
+  - [6b2077f](https://github.com/thefrontside/effection/commit/6b2077f6217883630e20df4569e22d2ebce3a6ce) Expose  so packages other than  can make nice errors on 2022-05-27
+
 ## \[2.0.4]
 
 - Allow pass object with `Symbol.operation` as an operation

--- a/packages/effection/package.json
+++ b/packages/effection/package.json
@@ -1,6 +1,6 @@
 {
   "name": "effection",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Structured concurrency and effects for JavaScript",
   "homepage": "https://frontside.com/effection",
   "repository": {
@@ -32,7 +32,7 @@
     "@effection/core": "2.2.0",
     "@effection/events": "2.0.3",
     "@effection/fetch": "2.0.4",
-    "@effection/main": "2.0.3",
+    "@effection/main": "2.1.0",
     "@effection/subscription": "2.0.3",
     "@effection/stream": "2.0.3"
   },

--- a/packages/inspect-server/CHANGELOG.md
+++ b/packages/inspect-server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @effection/inspect-server
 
+## \[2.2.1]
+
+- `@effection/dispatch` was not listed as a dependency which led to it becoming out of sync with the latest.
+  - Bumped due to a bump in @effection/inspect-utils.
+  - [ee76b1f](https://github.com/thefrontside/effection/commit/ee76b1f67568bf0cf7790a7fbd19d145852520e0) adjust inspect-utils dep on dispatch to latest on 2022-09-23
+
 ## \[2.2.0]
 
 - `@effection/inspect-server` is now responsible for resolving the path of `@effection/inspect-ui/dist-app/index.html`.

--- a/packages/inspect-server/package.json
+++ b/packages/inspect-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/inspect-server",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Inspect server for inspecting effection processes",
   "main": "dist-cjs/index.js",
   "types": "dist-esm/index.d.ts",
@@ -29,11 +29,11 @@
     "examples:basic": "ts-node ./examples/basic.ts"
   },
   "dependencies": {
-    "@effection/atom": "2.0.4",
-    "@effection/inspect-ui": "2.2.0",
-    "@effection/inspect-utils": "2.1.4",
-    "@effection/websocket-server": "2.0.4",
-    "effection": "2.0.4",
+    "@effection/atom": "2.0.5",
+    "@effection/inspect-ui": "2.3.0",
+    "@effection/inspect-utils": "2.1.5",
+    "@effection/websocket-server": "2.0.5",
+    "effection": "2.0.5",
     "node-static": "^0.7.11",
     "websocket": "^1.0.34"
   },

--- a/packages/inspect-ui/CHANGELOG.md
+++ b/packages/inspect-ui/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @effection/inspect-ui
 
+## \[2.3.0]
+
+- Refactored the UI to use Material UI
+  - [65260ac](https://github.com/thefrontside/effection/commit/65260ac0cbab594ec581326a6d4cdc83142f605d) Add covector change file on 2022-05-10
+  - [c174eae](https://github.com/thefrontside/effection/commit/c174eae2e86a51d23bc78296c053df235b320d45) Fix formatting on 2022-05-10
+
 ## \[2.2.0]
 
 - `@effection/inspect-server` is now responsible for resolving the path of `@effection/inspect-ui/dist-app/index.html`.

--- a/packages/inspect-ui/package.json
+++ b/packages/inspect-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/inspect-ui",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Web interface for inspecting effection applications",
   "main": "app/index.ts",
   "types": "dist-esm/index.d.ts",
@@ -31,7 +31,7 @@
     "mocha": "mocha -r ts-node/register --timeout 5000"
   },
   "dependencies": {
-    "@effection/react": "^2.2.0",
+    "@effection/react": "2.2.1",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.57",
@@ -45,8 +45,8 @@
     "react-router-dom": "^6.3.0"
   },
   "devDependencies": {
-    "@effection/inspect-utils": "2.1.4",
-    "@effection/websocket-client": "2.0.4",
+    "@effection/inspect-utils": "2.1.5",
+    "@effection/websocket-client": "2.0.5",
     "@frontside/tsconfig": "^1.2.0",
     "@interactors/material-ui": "^4.1.0",
     "@types/jsdom-global": "^3.0.2",
@@ -56,7 +56,7 @@
     "@types/react-router": "^5.1.17",
     "@types/react-router-dom": "^5.3.1",
     "copyfiles": "^2.4.1",
-    "effection": "2.0.4",
+    "effection": "2.0.5",
     "eslint-plugin-react": "^7.31.8",
     "eslint-plugin-react-hooks": "^4.6.0",
     "events": "^3.3.0",

--- a/packages/inspect-utils/CHANGELOG.md
+++ b/packages/inspect-utils/CHANGELOG.md
@@ -1,5 +1,10 @@
 # @effection/inspect-utils
 
+## \[2.1.5]
+
+- `@effection/dispatch` was not listed as a dependency which led to it becoming out of sync with the latest.
+  - [ee76b1f](https://github.com/thefrontside/effection/commit/ee76b1f67568bf0cf7790a7fbd19d145852520e0) adjust inspect-utils dep on dispatch to latest on 2022-09-23
+
 ## \[2.1.4]
 
 - Allow pass object with `Symbol.operation` as an operation

--- a/packages/inspect-utils/package.json
+++ b/packages/inspect-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/inspect-utils",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "Helper functions and types for inspecting effection applications",
   "main": "dist-cjs/index.js",
   "types": "dist-esm/index.d.ts",
@@ -28,9 +28,9 @@
     "mocha": "mocha -r ts-node/register"
   },
   "dependencies": {
-    "@effection/atom": "2.0.4",
-    "@effection/dispatch": "2.0.4",
-    "effection": "2.0.4"
+    "@effection/atom": "2.0.5",
+    "@effection/dispatch": "2.0.5",
+    "effection": "2.0.5"
   },
   "devDependencies": {
     "@frontside/tsconfig": "^1.2.0",

--- a/packages/inspect/CHANGELOG.md
+++ b/packages/inspect/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @effection/inspect
 
+## \[2.1.7]
+
+- `@effection/dispatch` was not listed as a dependency which led to it becoming out of sync with the latest.
+  - Bumped due to a bump in @effection/inspect-server.
+  - [ee76b1f](https://github.com/thefrontside/effection/commit/ee76b1f67568bf0cf7790a7fbd19d145852520e0) adjust inspect-utils dep on dispatch to latest on 2022-09-23
+
 ## \[2.1.6]
 
 - `@effection/inspect-server` is now responsible for resolving the path of `@effection/inspect-ui/dist-app/index.html`.

--- a/packages/inspect/package.json
+++ b/packages/inspect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/inspect",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "description": "Injects an inspector into an Effection application",
   "main": "index.cjs.js",
   "module": "index.esm.js",
@@ -23,7 +23,7 @@
     "docs": "echo noop"
   },
   "dependencies": {
-    "@effection/inspect-server": "2.2.0"
+    "@effection/inspect-server": "2.2.1"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/jest/CHANGELOG.md
+++ b/packages/jest/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @effection/jest
 
+## \[2.0.3]
+
+- Expose `formatError` so other packages can format errors the same way as `main`
+  - Bumped due to a bump in effection.
+  - [6b2077f](https://github.com/thefrontside/effection/commit/6b2077f6217883630e20df4569e22d2ebce3a6ce) Expose  so packages other than  can make nice errors on 2022-05-27
+
 ## \[2.0.2]
 
 - Do not run each trial of it.eventually() in each scope

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/jest",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Effection Integration for the Jest framework",
   "main": "dist-cjs/index.js",
   "module": "dist-esm/index.js",
@@ -26,7 +26,7 @@
     "prepack": "tsc --build tsconfig.esm.json && tsc --build tsconfig.cjs.json"
   },
   "dependencies": {
-    "effection": "2.0.4",
+    "effection": "2.0.5",
     "assert-ts": "^0.3.4"
   },
   "peerDependencies": {

--- a/packages/main/CHANGELOG.md
+++ b/packages/main/CHANGELOG.md
@@ -1,5 +1,10 @@
 # @effection/main
 
+## \[2.1.0]
+
+- Expose `formatError` so other packages can format errors the same way as `main`
+  - [6b2077f](https://github.com/thefrontside/effection/commit/6b2077f6217883630e20df4569e22d2ebce3a6ce) Expose  so packages other than  can make nice errors on 2022-05-27
+
 ## \[2.0.3]
 
 - Allow pass object with `Symbol.operation` as an operation

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/main",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "description": "Main entry point for Effection applications",
   "main": "dist-cjs/node.js",
   "module": "dist-esm/node.js",

--- a/packages/mocha/CHANGELOG.md
+++ b/packages/mocha/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @effection/mocha
 
+## \[2.0.5]
+
+- Expose `formatError` so other packages can format errors the same way as `main`
+  - Bumped due to a bump in effection.
+  - [6b2077f](https://github.com/thefrontside/effection/commit/6b2077f6217883630e20df4569e22d2ebce3a6ce) Expose  so packages other than  can make nice errors on 2022-05-27
+
 ## \[2.0.4]
 
 - Allow pass object with `Symbol.operation` as an operation

--- a/packages/mocha/package.json
+++ b/packages/mocha/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/mocha",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Effection Subscriptions",
   "main": "dist-cjs/index.js",
   "module": "dist-esm/index.js",
@@ -27,7 +27,7 @@
     "mocha": "mocha -r ts-node/register"
   },
   "dependencies": {
-    "effection": "2.0.4"
+    "effection": "2.0.5"
   },
   "peerDependencies": {
     "mocha": "^8.0.0"

--- a/packages/process/CHANGELOG.md
+++ b/packages/process/CHANGELOG.md
@@ -1,5 +1,10 @@
 # @effection/process
 
+## \[2.1.1]
+
+- Bump the `ctrlc-windows` package to include the new build process and remove all dependencies.
+  - [4b7ca17](https://github.com/thefrontside/effection/commit/4b7ca1791a776bd1a7e4b8d100554aa683ebc49f) bump ctrlc-windows to 2.1.0 on 2022-09-21
+
 ## \[2.1.0]
 
 - The shell option now accepts a string which allows one to specify an exact shell to run a command. This is helpful on windows as the default generally doesn't handle bash-like syntax.

--- a/packages/process/package.json
+++ b/packages/process/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/process",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Spawn and manage external processes with Effection",
   "main": "dist-cjs/index.js",
   "module": "dist-esm/index.js",
@@ -40,7 +40,7 @@
   "dependencies": {
     "cross-spawn": "^7.0.3",
     "ctrlc-windows": "^2.1.0",
-    "effection": "2.0.4",
+    "effection": "2.0.5",
     "shellwords": "^0.1.1"
   },
   "volta": {

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @effection/react
 
+## \[2.2.1]
+
+- Expose `formatError` so other packages can format errors the same way as `main`
+  - Bumped due to a bump in effection.
+  - [6b2077f](https://github.com/thefrontside/effection/commit/6b2077f6217883630e20df4569e22d2ebce3a6ce) Expose  so packages other than  can make nice errors on 2022-05-27
+
 ## \[2.2.0]
 
 - introduce the `useResource()` hook for working directly with resources.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/react",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Hooks for integrating effection into react applications",
   "main": "dist-cjs/index.js",
   "module": "dist-esm/index.js",
@@ -28,7 +28,7 @@
     "mocha": "mocha -r ts-node/register"
   },
   "dependencies": {
-    "effection": "2.0.4"
+    "effection": "2.0.5"
   },
   "devDependencies": {
     "@frontside/tsconfig": "^1.2.0",

--- a/packages/vitest/CHANGELOG.md
+++ b/packages/vitest/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @effection/vitest
 
-## \[2.0.1]
-
-- Expose `formatError` so other packages can format errors the same way as `main`
-  - Bumped due to a bump in effection.
-  - [6b2077f](https://github.com/thefrontside/effection/commit/6b2077f6217883630e20df4569e22d2ebce3a6ce) Expose  so packages other than  can make nice errors on 2022-05-27
-
 ## \[2.0.0]
 
 - Release @effection/vitest@2.0.0

--- a/packages/vitest/CHANGELOG.md
+++ b/packages/vitest/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @effection/vitest
 
+## \[2.0.1]
+
+- Expose `formatError` so other packages can format errors the same way as `main`
+  - Bumped due to a bump in effection.
+  - [6b2077f](https://github.com/thefrontside/effection/commit/6b2077f6217883630e20df4569e22d2ebce3a6ce) Expose  so packages other than  can make nice errors on 2022-05-27
+
 ## \[2.0.0]
 
 - Release @effection/vitest@2.0.0

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/vitest",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Effection Integration for the Vitest framework",
   "main": "dist-cjs/index.js",
   "module": "dist-esm/index.js",
@@ -26,7 +26,7 @@
     "prepack": "tsc --build tsconfig.esm.json && tsc --build tsconfig.cjs.json"
   },
   "dependencies": {
-    "effection": "2.0.4",
+    "effection": "2.0.5",
     "assert-ts": "^0.3.4"
   },
   "peerDependencies": {

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/vitest",
-  "version": "2.0.1",
+  "version": "2.0.0",
   "description": "Effection Integration for the Vitest framework",
   "main": "dist-cjs/index.js",
   "module": "dist-esm/index.js",

--- a/packages/websocket-client/CHANGELOG.md
+++ b/packages/websocket-client/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @effection/websocket-client
 
+## \[2.0.5]
+
+- Expose `formatError` so other packages can format errors the same way as `main`
+  - Bumped due to a bump in effection.
+  - [6b2077f](https://github.com/thefrontside/effection/commit/6b2077f6217883630e20df4569e22d2ebce3a6ce) Expose  so packages other than  can make nice errors on 2022-05-27
+
 ## \[2.0.4]
 
 - Allow pass object with `Symbol.operation` as an operation

--- a/packages/websocket-client/package.json
+++ b/packages/websocket-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/websocket-client",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "A websocket client for Effection in node and browser",
   "main": "dist-cjs/index.js",
   "module": "dist-esm/index.js",
@@ -28,7 +28,7 @@
     "mocha": "mocha -r ts-node/register"
   },
   "dependencies": {
-    "effection": "2.0.4",
+    "effection": "2.0.5",
     "isomorphic-ws": "^4.0.1"
   },
   "devDependencies": {

--- a/packages/websocket-server/CHANGELOG.md
+++ b/packages/websocket-server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @effection/websocket-server
 
+## \[2.0.5]
+
+- Expose `formatError` so other packages can format errors the same way as `main`
+  - Bumped due to a bump in effection.
+  - [6b2077f](https://github.com/thefrontside/effection/commit/6b2077f6217883630e20df4569e22d2ebce3a6ce) Expose  so packages other than  can make nice errors on 2022-05-27
+
 ## \[2.0.4]
 
 - Allow pass object with `Symbol.operation` as an operation

--- a/packages/websocket-server/package.json
+++ b/packages/websocket-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/websocket-server",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "A simple websocket server for Effection",
   "main": "dist-cjs/index.js",
   "module": "dist-esm/index.js",
@@ -28,7 +28,7 @@
     "mocha": "mocha -r ts-node/register"
   },
   "dependencies": {
-    "effection": "2.0.4",
+    "effection": "2.0.5",
     "ws": "^7.4.6"
   },
   "devDependencies": {


### PR DESCRIPTION
# Version Updates

Merging this PR will release new versions of the following packages based on your change files.




# @effection/duplex-channel

## [2.0.5]
- Expose `formatError` so other packages can format errors the same way as `main`
  - Bumped due to a bump in effection.
  - [6b2077f](https://github.com/thefrontside/effection/commit/6b2077f6217883630e20df4569e22d2ebce3a6ce) Expose  so packages other than  can make nice errors on 2022-05-27



# @effection/dispatch

## [2.0.5]
- Expose `formatError` so other packages can format errors the same way as `main`
  - Bumped due to a bump in effection.
  - [6b2077f](https://github.com/thefrontside/effection/commit/6b2077f6217883630e20df4569e22d2ebce3a6ce) Expose  so packages other than  can make nice errors on 2022-05-27



# @effection/atom

## [2.0.5]
- Expose `formatError` so other packages can format errors the same way as `main`
  - Bumped due to a bump in effection.
  - [6b2077f](https://github.com/thefrontside/effection/commit/6b2077f6217883630e20df4569e22d2ebce3a6ce) Expose  so packages other than  can make nice errors on 2022-05-27



# effection

## [2.0.5]
- Expose `formatError` so other packages can format errors the same way as `main`
  - Bumped due to a bump in @effection/main.
  - [6b2077f](https://github.com/thefrontside/effection/commit/6b2077f6217883630e20df4569e22d2ebce3a6ce) Expose  so packages other than  can make nice errors on 2022-05-27



# @effection/inspect

## [2.1.7]
- `@effection/dispatch` was not listed as a dependency which led to it becoming out of sync with the latest.
  - Bumped due to a bump in @effection/inspect-server.
  - [ee76b1f](https://github.com/thefrontside/effection/commit/ee76b1f67568bf0cf7790a7fbd19d145852520e0) adjust inspect-utils dep on dispatch to latest on 2022-09-23



# @effection/inspect-server

## [2.2.1]
- `@effection/dispatch` was not listed as a dependency which led to it becoming out of sync with the latest.
  - Bumped due to a bump in @effection/inspect-utils.
  - [ee76b1f](https://github.com/thefrontside/effection/commit/ee76b1f67568bf0cf7790a7fbd19d145852520e0) adjust inspect-utils dep on dispatch to latest on 2022-09-23



# @effection/inspect-utils

## [2.1.5]
- `@effection/dispatch` was not listed as a dependency which led to it becoming out of sync with the latest.
  - [ee76b1f](https://github.com/thefrontside/effection/commit/ee76b1f67568bf0cf7790a7fbd19d145852520e0) adjust inspect-utils dep on dispatch to latest on 2022-09-23



# @effection/main

## [2.1.0]
- Expose `formatError` so other packages can format errors the same way as `main`
  - [6b2077f](https://github.com/thefrontside/effection/commit/6b2077f6217883630e20df4569e22d2ebce3a6ce) Expose  so packages other than  can make nice errors on 2022-05-27



# @effection/mocha

## [2.0.5]
- Expose `formatError` so other packages can format errors the same way as `main`
  - Bumped due to a bump in effection.
  - [6b2077f](https://github.com/thefrontside/effection/commit/6b2077f6217883630e20df4569e22d2ebce3a6ce) Expose  so packages other than  can make nice errors on 2022-05-27



# @effection/jest

## [2.0.3]
- Expose `formatError` so other packages can format errors the same way as `main`
  - Bumped due to a bump in effection.
  - [6b2077f](https://github.com/thefrontside/effection/commit/6b2077f6217883630e20df4569e22d2ebce3a6ce) Expose  so packages other than  can make nice errors on 2022-05-27



# @effection/process

## [2.1.1]
- Bump the `ctrlc-windows` package to include the new build process and remove all dependencies.
  - [4b7ca17](https://github.com/thefrontside/effection/commit/4b7ca1791a776bd1a7e4b8d100554aa683ebc49f) bump ctrlc-windows to 2.1.0 on 2022-09-21



# @effection/react

## [2.2.1]
- Expose `formatError` so other packages can format errors the same way as `main`
  - Bumped due to a bump in effection.
  - [6b2077f](https://github.com/thefrontside/effection/commit/6b2077f6217883630e20df4569e22d2ebce3a6ce) Expose  so packages other than  can make nice errors on 2022-05-27



# @effection/websocket-client

## [2.0.5]
- Expose `formatError` so other packages can format errors the same way as `main`
  - Bumped due to a bump in effection.
  - [6b2077f](https://github.com/thefrontside/effection/commit/6b2077f6217883630e20df4569e22d2ebce3a6ce) Expose  so packages other than  can make nice errors on 2022-05-27



# @effection/websocket-server

## [2.0.5]
- Expose `formatError` so other packages can format errors the same way as `main`
  - Bumped due to a bump in effection.
  - [6b2077f](https://github.com/thefrontside/effection/commit/6b2077f6217883630e20df4569e22d2ebce3a6ce) Expose  so packages other than  can make nice errors on 2022-05-27



# @effection/inspect-ui

## [2.3.0]
- Refactored the UI to use Material UI
  - [65260ac](https://github.com/thefrontside/effection/commit/65260ac0cbab594ec581326a6d4cdc83142f605d) Add covector change file on 2022-05-10
  - [c174eae](https://github.com/thefrontside/effection/commit/c174eae2e86a51d23bc78296c053df235b320d45) Fix formatting on 2022-05-10

