### PR TITLE
Add Erlang style supervisor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,6 +115,7 @@ workflows:
                 - events
                 - channel
                 - duplex-channel
+                - supervisor
                 - dispatch
                 - fetch
                 - process

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
       "packages/mocha",
       "packages/jest",
       "packages/dispatch",
+      "packages/supervisor",
       "packages/duplex-channel",
       "packages/atom",
       "packages/process",

--- a/packages/supervisor/.gitignore
+++ b/packages/supervisor/.gitignore
@@ -1,0 +1,4 @@
+/node_modules
+/yarn-error.log
+.node-version
+.cache

--- a/packages/supervisor/README.md
+++ b/packages/supervisor/README.md
@@ -1,0 +1,79 @@
+# @effection/supervisor
+
+A task supervisor similar to Erlang's OTP supervisor module. Supervisors can
+monitor other tasks and restart them as needed.
+
+The functionality and options of the Effection supervisor are broadly similar
+to Erlang's.
+
+## Known limitations:
+
+Some functionality from Erlang's supervisors is as of yet still missing:
+
+- `simple_one_for_one` supervision strategy
+- the `intensity` and `period` options, which prevent restart loops
+
+Contributions for these are very welcome!
+
+## Usage
+
+This packages exposes two methods `runSupervisor` and `createSupervisor`.
+
+With `runSupervisor`, the supervisor runs in the foreground as a task, which
+makes it easy to start and keep it running, for example with `main`:
+
+```typescript
+import { main } from 'effection';
+import { runSupervisor } from '@effection/supervisor';
+import { fobrulator, phaseInverter } from './operations';
+
+main(runSupervisor([
+  { name: 'fobrulator', run: fobrulator, args: ['fob'] },
+  { name: 'phaseInverter', run: phaseInverter, args: [true] },
+]);
+```
+
+With `createSupervisor`, the supervisor runs in the background as a resource,
+which makes it possible to dynamically control the supervisor:
+
+```typescript
+import { main } from 'effection';
+import { runSupervisor } from '@effection/supervisor';
+import { fobrulator, phaseInverter } from './operations';
+
+main(function*() {
+  let supervisor = yield createSupervisor();
+
+  supervisor.addChild({ name: 'fobrulator', run: fobrulator, args: ['fob'] });
+  supervisor.addChild({ name: 'phaseInverter', run: phaseInverter, args: [true] });
+
+  yield;
+]);
+```
+
+## Options
+
+The supervisor can currently take the following options:
+
+- `strategy`, one of:
+  - `oneForOne`: If one child task terminates and is to be restarted, only that child process is affected. This is the default restart strategy.
+  - `oneForAll`: If one child task terminates and is to be restarted, all other child processes are terminated and then all child processes are restarted.
+  - `restForOne`: If one child task terminates and is to be restarted, the 'rest' of the child tasks (that is, the child tasks after the terminated child task in the start order) are terminated. Then the terminated child task and all child tasks after it are restarted.
+- `shutdown`, one of:
+  - `never`: Automic shutdown is disabled. This is the default setting.
+  - `anySignificant`: The supervisor will shut itself down when **any** significant child terminates, that is, when a transient significant child terminates normally or when a temporary significant child terminates normally or abnormally.
+  - `allSignificant`: The supervisor will shut itself down when **all** significant children have terminated, that is, when the **last active** significant child terminates.
+
+## Child specs
+
+The child specification can contain the following options:
+
+- `name` *required*: A name which identifies the child.
+- `run` *required*: A function which returns an operation.
+- `args`: a list of arguments to pass to the `run` function.
+- `type`: one of:
+  - `permanent`: The child is always restart when it terminates, regardless of the reason. Note that children explicitly halted through `haltChild` are not restarted.
+  - `transient`: The child is restarted when it errors. It is not restarted when it completes successfully or is halted.
+  - `temporary`: The child is never restarted.
+- `significant`: See the `shutdown` option for the supervisor.
+- `labels`: A set of labels to apply to the child task, which can be helpful when debugging

--- a/packages/supervisor/examples/tick.ts
+++ b/packages/supervisor/examples/tick.ts
@@ -1,0 +1,16 @@
+import { main, sleep } from 'effection';
+import { runSupervisor } from '../src/index';
+
+function *tick(name: string, value: number) {
+  for(; value >= 0; value--) {
+    console.log(name, value);
+    yield sleep(1000);
+  }
+
+  throw new Error('boom');
+}
+
+main(runSupervisor([
+  { name: 'foo', run: tick, args: ['foo', 5] },
+  { name: 'bar', run: tick, args: ['bar', 3] },
+], { logErrors: true }));

--- a/packages/supervisor/package.json
+++ b/packages/supervisor/package.json
@@ -37,7 +37,7 @@
     "typescript": "^4.3.5"
   },
   "dependencies": {
-    "effection": "2.0.4"
+    "effection": "^2.0.4"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/supervisor/package.json
+++ b/packages/supervisor/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@effection/supervisor",
+  "version": "2.0.0",
+  "description": "Supervisors for Effection in the spirit of OTP supervisors",
+  "main": "dist-cjs/index.js",
+  "module": "dist-esm/index.js",
+  "types": "dist-esm/index.d.ts",
+  "typeDocEntry": "src/index.ts",
+  "sideEffects": false,
+  "homepage": "https://frontside.com/effection",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/thefrontside/effection.git",
+    "directory": "packages/supervisor"
+  },
+  "author": "Frontside Engineering <engineering@frontside.io>",
+  "license": "MIT",
+  "files": [
+    "README.md",
+    "CHANGELOG.md",
+    "dist-*/**/*",
+    "src/**/*"
+  ],
+  "scripts": {
+    "lint": "eslint '{src,tests}/**/*.ts'",
+    "test": "mocha -r ts-node/register test/**/*.test.ts",
+    "prepack": "tsc --build tsconfig.esm.json && tsc --build tsconfig.esm.json && tsc --build tsconfig.cjs.json",
+    "mocha": "mocha -r ts-node/register"
+  },
+  "devDependencies": {
+    "@frontside/tsconfig": "^1.2.0",
+    "@types/mocha": "^7.0.1",
+    "@types/node": "^13.13.4",
+    "expect": "^25.4.0",
+    "mocha": "^8.3.1",
+    "ts-node": "^10.4.0",
+    "typescript": "^4.3.5"
+  },
+  "dependencies": {
+    "effection": "2.0.4"
+  },
+  "volta": {
+    "extends": "../../package.json"
+  }
+}

--- a/packages/supervisor/src/index.ts
+++ b/packages/supervisor/src/index.ts
@@ -1,0 +1,162 @@
+/* eslint-disable @typescript-eslint/no-explicit-any, prefer-let/prefer-let */
+
+import type { Operation, Resource, Task, Labels } from 'effection';
+import { createFuture } from 'effection';
+
+type ChildName = string;
+type ChildTask = Task;
+
+export type Strategy = 'oneForOne' | 'oneForAll' | 'restForOne';
+export type Shutdown = 'never' | 'anySignificant' | 'allSignificant';
+
+export type SupervisorOptions = {
+  strategy?: Strategy;
+  shutdown?: Shutdown;
+};
+
+export type ChildType = 'permanent' | 'transient' | 'temporary';
+
+export type ChildSpecification<TArgs extends any[]> = {
+  name: ChildName;
+  run: (...args: TArgs) => Operation<any>;
+  args?: TArgs;
+  type?: ChildType;
+  significant?: boolean;
+  labels?: Labels;
+}
+
+export interface Supervisor {
+  specs: ChildSpecification<any[]>[],
+  children: Task[],
+  getSpec(name: ChildName): ChildSpecification<any[]> | undefined;
+  getChild(name: ChildName): ChildTask | undefined;
+  addChild(child: ChildSpecification<any[]>): ChildTask;
+  startChild(name: ChildName): ChildTask;
+  haltChild(name: ChildName): Task<void>;
+  haltAndRemoveChild(name: ChildName): Task<void>;
+  restartChild(name: ChildName): Task<ChildTask>;
+  halt(): Promise<void>;
+  resourceTask: Task;
+}
+
+function isLive(task?: Task): boolean {
+  return task ? (task.state === 'running' || task.state === 'pending') : false;
+}
+
+export function createSupervisor(specs: ChildSpecification<any[]>[] = [], options: SupervisorOptions = {}): Resource<Supervisor> {
+  return {
+    *init(resourceTask) {
+      let children: Map<ChildName, { task?: Task, spec: ChildSpecification<any[]>, reaped: boolean }> = new Map(specs.map((spec) => [spec.name, { spec, reaped: false }]));
+
+      function addChild(spec: ChildSpecification<any[]>) {
+        if(!children.has(spec.name)) {
+          children.set(spec.name, { spec, reaped: false });
+          return startChild(spec.name);
+        } else {
+          throw new Error(`child with name ${spec.name} already exists, ids must be unique within a supervisor`);
+        }
+      }
+
+      function startChild(name: ChildName) {
+        const child = children.get(name);
+        if(!child) {
+          throw new Error(`child with name ${name} does not exist`);
+        }
+        if(isLive(child?.task)) {
+          throw new Error(`child with name ${name} has already been started`);
+        }
+        let childTask = resourceTask.run(child.spec.run(...(child.spec.args || [])), { ignoreError: true, labels: { name, ...child.spec.labels } });
+
+        resourceTask.run(function*() {
+          let { resolve, future } = createFuture();
+          childTask.consume(resolve);
+          let result = yield future;
+
+          if(options.shutdown === 'anySignificant' && child.spec.significant) {
+            resourceTask.halt();
+          } else if(options.shutdown === 'allSignificant' && !Array.from(children.values()).filter((c) => c.spec.significant).map((c) => c.task).some(isLive)) {
+            resourceTask.halt();
+          } else {
+            if(child.reaped) return; // this task is already marked for termination and will be handled by the supervisor
+            let restart = Array.from(children.values());
+            if(options.strategy !== 'oneForAll') {
+              restart = restart.slice(restart.indexOf(child));
+            }
+            if(options.strategy !== 'oneForAll' && options.strategy !== 'restForOne') {
+              restart = restart.slice(0, 1);
+            }
+            for(let sibling of restart.slice().reverse()) {
+              sibling.reaped = true;
+              yield haltChild(sibling.spec.name);
+            }
+            for(let sibling of restart) {
+              if(result.state === 'errored' && (sibling.spec.type !== 'temporary')) {
+                startChild(sibling.spec.name);
+              }
+              if((result.state === 'completed' || result.state === 'halted') && (sibling.spec.type !== 'temporary' && sibling.spec.type !== 'transient')) {
+                startChild(sibling.spec.name);
+              }
+            }
+          }
+        });
+        child.task = childTask;
+        return childTask;
+      }
+
+      function haltChild(name: ChildName) {
+        return resourceTask.run(function*() {
+          let child = children.get(name);
+          if(child && child.task) {
+            child.reaped = true;
+            return yield child.task.halt();
+          } else {
+            throw new Error(`child with name ${name} does not exist`);
+          }
+        });
+      }
+
+      function haltAndRemoveChild(name: ChildName) {
+        return resourceTask.run(function*() {
+          yield haltChild(name);
+          children.delete(name);
+        });
+      }
+
+      function restartChild(name: ChildName) {
+        return resourceTask.run(function*() {
+          yield haltChild(name);
+          return startChild(name);
+        });
+      }
+
+      for(let name of children.keys()) {
+        startChild(name);
+      }
+
+      return {
+        get specs() {
+          return Array.from(children.values()).map((c) => c.spec);
+        },
+        get children() {
+          return Array.from(children.values()).map((c) => c.task).filter(Boolean) as Task[];
+        },
+        getSpec(name) { return children.get(name)?.spec },
+        getChild(name) { return children.get(name)?.task },
+        addChild,
+        startChild,
+        haltChild,
+        haltAndRemoveChild,
+        restartChild,
+        halt() {
+          return resourceTask.halt();
+        },
+        resourceTask,
+      };
+    }
+  };
+}
+
+export function* runSupervisor(specs: ChildSpecification<any[]>[] = [], options: SupervisorOptions = {}): Operation<void> {
+  yield createSupervisor(specs, options);
+  yield;
+}

--- a/packages/supervisor/src/rotate-buffer.ts
+++ b/packages/supervisor/src/rotate-buffer.ts
@@ -1,0 +1,16 @@
+export class RotateBuffer<T> {
+  private buffer: T[];
+  private current: number;
+
+  constructor(public size: number) {
+    this.buffer = new Array(size);
+    this.current = 0;
+  }
+
+  push(value: T): T | undefined {
+    let oldValue = this.buffer[this.current];
+    this.buffer[this.current] = value;
+    this.current = (this.current + 1) % this.size;
+    return oldValue;
+  }
+}

--- a/packages/supervisor/test/rotate-buffer.test.ts
+++ b/packages/supervisor/test/rotate-buffer.test.ts
@@ -1,0 +1,19 @@
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-non-null-assertion */
+import { describe, it } from "@effection/mocha";
+import expect from "expect";
+
+import { RotateBuffer } from "../src/rotate-buffer";
+
+describe("RotateBuffer", () => {
+  it("can push in new children and rotate out old ones", function* () {
+    let buffer = new RotateBuffer<string>(3);
+
+    expect(buffer.push("foo")).toEqual(undefined);
+    expect(buffer.push("bar")).toEqual(undefined);
+    expect(buffer.push("baz")).toEqual(undefined);
+    expect(buffer.push("quox")).toEqual("foo");
+    expect(buffer.push("mox")).toEqual("bar");
+    expect(buffer.push("tox")).toEqual("baz");
+    expect(buffer.push("blorb")).toEqual("quox");
+  });
+});

--- a/packages/supervisor/test/supervisor.test.ts
+++ b/packages/supervisor/test/supervisor.test.ts
@@ -1,0 +1,433 @@
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-non-null-assertion */
+import { describe, beforeEach, it } from '@effection/mocha';
+import { Operation, run, sleep, createFuture } from 'effection';
+import expect from 'expect';
+
+import { createSupervisor, Supervisor } from '../src/index';
+
+function *crash() {
+  throw new Error('boom');
+}
+
+const Live: Map<string, boolean> = new Map();
+const Wait: Map<string, Promise<unknown>> = new Map();
+const Complete: Map<string, (value: any) => void> = new Map();
+
+function* track(name: string): Operation<void> {
+  let semaphore = run();
+  let { future, resolve } = createFuture();
+  Live.set(name, true);
+  Wait.set(name, semaphore);
+  Complete.set(name, resolve);
+  try {
+    return yield future;
+  } finally {
+    Live.set(name, false);
+    yield semaphore.halt();
+  }
+}
+
+describe('createSupervisor', () => {
+  it('starts given children', function*() {
+    let supervisor = yield createSupervisor([
+      { name: 'foo', run: track, args: ['foo'] },
+      { name: 'bar', run: track, args: ['bar'] }
+    ]);
+
+    expect(Live.get('foo')).toEqual(true);
+    expect(Live.get('bar')).toEqual(true);
+
+    yield supervisor.halt();
+
+    expect(Live.get('foo')).toEqual(false);
+    expect(Live.get('bar')).toEqual(false);
+  });
+
+  describe('addChild', () => {
+    it('can dynamically start a child', function*() {
+      let supervisor = yield createSupervisor([]);
+
+      supervisor.addChild({ name: 'foo', run: track, args: ['foo'] });
+
+      expect(Live.get('foo')).toEqual(true);
+
+      yield supervisor.halt();
+
+      expect(Live.get('foo')).toEqual(false);
+    });
+  });
+
+  describe('startChild', () => {
+    it('starts a halted child', function*() {
+      let supervisor = yield createSupervisor([
+        { name: 'foo', run: track, args: ['foo'] },
+        { name: 'bar', run: track, args: ['bar'] },
+      ]);
+
+      expect(Live.get('foo')).toEqual(true);
+      expect(Live.get('bar')).toEqual(true);
+
+      yield supervisor.haltChild('foo');
+
+      expect(Live.get('foo')).toEqual(false);
+      expect(Live.get('bar')).toEqual(true);
+
+      supervisor.startChild('foo');
+
+      expect(Live.get('foo')).toEqual(true);
+      expect(Live.get('bar')).toEqual(true);
+    });
+  });
+
+  describe('haltChild', () => {
+    it('stops child', function*() {
+      let supervisor = yield createSupervisor([
+        { name: 'foo', run: track, args: ['foo'] },
+        { name: 'bar', run: track, args: ['bar'] }
+      ]);
+
+      expect(Live.get('foo')).toEqual(true);
+      expect(Live.get('bar')).toEqual(true);
+
+      yield supervisor.haltChild('foo');
+
+      expect(Live.get('foo')).toEqual(false);
+      expect(Live.get('bar')).toEqual(true);
+    });
+  });
+
+  describe('restartChild', () => {
+    it('stops child', function*() {
+      let supervisor = yield createSupervisor([]);
+
+      let original = supervisor.addChild({ name: 'foo', run: track, args: ['foo'] });
+
+      expect(Live.get('foo')).toEqual(true);
+
+      let restarted = yield supervisor.restartChild('foo');
+
+      expect(Live.get('foo')).toEqual(true);
+
+      expect(original.id).not.toEqual(restarted.id);
+    });
+  });
+
+  describe('haltAndRemoveChild', () => {
+    it('stops child and removes specification', function*() {
+      let supervisor = yield createSupervisor([{
+        name: 'foo',
+        run: track, args: ['foo'],
+      }]);
+
+      expect(Live.get('foo')).toEqual(true);
+
+      yield supervisor.haltAndRemoveChild('foo');
+
+      expect(Live.get('foo')).toEqual(false);
+
+      expect(supervisor.specs).toEqual([]);
+    });
+  });
+
+  describe('restart: oneForOne', () => {
+    let supervisor: Supervisor;
+
+    describe('with permanent child', () => {
+      beforeEach(function*() {
+        supervisor = yield createSupervisor([
+          { name: 'child1', run: track, args: ['child1'] },
+          { name: 'child2', run: track, args: ['child2'] },
+        ]);
+      });
+
+      it('restarts crashed child when it crashes', function*() {
+        let child1 = supervisor.getChild('child1')!;
+        let child2 = supervisor.getChild('child2')!;
+
+        child2.run(crash);
+
+        yield sleep(5);
+
+        expect(Live.get('child1')).toEqual(true);
+        expect(Live.get('child2')).toEqual(true);
+
+        expect(supervisor.getChild('child1')!.id).toEqual(child1.id);
+        expect(supervisor.getChild('child2')!.id).not.toEqual(child2.id);
+      });
+
+      it('restarts halted child when it halts', function*() {
+        let child1 = supervisor.getChild('child1')!;
+        let child2 = supervisor.getChild('child2')!;
+
+        child2.halt();
+
+        yield sleep(5);
+
+        expect(Live.get('child1')).toEqual(true);
+        expect(Live.get('child2')).toEqual(true);
+
+        expect(supervisor.getChild('child1')!.id).toEqual(child1.id);
+        expect(supervisor.getChild('child2')!.id).not.toEqual(child2.id);
+      });
+
+      it('restarts completed child when it completes', function*() {
+        let child1 = supervisor.getChild('child1')!;
+        let child2 = supervisor.getChild('child2')!;
+
+        Complete.get('child2')!('done');
+
+        yield sleep(5);
+
+        expect(Live.get('child1')).toEqual(true);
+        expect(Live.get('child2')).toEqual(true);
+
+        expect(supervisor.getChild('child1')!.id).toEqual(child1.id);
+        expect(supervisor.getChild('child2')!.id).not.toEqual(child2.id);
+      });
+    });
+
+    describe('with transient child', () => {
+      beforeEach(function*() {
+        supervisor = yield createSupervisor([
+          { name: 'child1', run: track, args: ['child1'] },
+          { name: 'child2', run: track, args: ['child2'], type: 'transient' },
+        ]);
+      });
+
+      it('restarts crashed child when it crashes', function*() {
+        let child1 = supervisor.getChild('child1')!;
+        let child2 = supervisor.getChild('child2')!;
+
+        child2.run(crash);
+
+        yield sleep(5);
+
+        expect(Live.get('child1')).toEqual(true);
+        expect(Live.get('child2')).toEqual(true);
+
+        expect(supervisor.getChild('child1')!.id).toEqual(child1.id);
+        expect(supervisor.getChild('child2')!.id).not.toEqual(child2.id);
+      });
+
+      it('does not restart halted child when it halts', function*() {
+        let child1 = supervisor.getChild('child1')!;
+        let child2 = supervisor.getChild('child2')!;
+
+        child2.halt();
+
+        yield sleep(5);
+
+        expect(Live.get('child1')).toEqual(true);
+        expect(Live.get('child2')).toEqual(false);
+
+        expect(supervisor.getChild('child1')!.id).toEqual(child1.id);
+      });
+
+      it('does not restart completed child when it completes', function*() {
+        let child1 = supervisor.getChild('child1')!;
+
+        Complete.get('child2')!('done');
+
+        yield sleep(5);
+
+        expect(Live.get('child1')).toEqual(true);
+        expect(Live.get('child2')).toEqual(false);
+
+        expect(supervisor.getChild('child1')!.id).toEqual(child1.id);
+      });
+    });
+
+    describe('with temporary child', () => {
+      beforeEach(function*() {
+        supervisor = yield createSupervisor([
+          { name: 'child1', run: track, args: ['child1'] },
+          { name: 'child2', run: track, args: ['child2'], type: 'temporary' },
+        ]);
+      });
+
+      it('does not restart crashed child when it crashes', function*() {
+        let child1 = supervisor.getChild('child1')!;
+        let child2 = supervisor.getChild('child2')!;
+
+        child2.run(crash);
+
+        yield sleep(5);
+
+        expect(Live.get('child1')).toEqual(true);
+        expect(Live.get('child2')).toEqual(false);
+
+        expect(supervisor.getChild('child1')!.id).toEqual(child1.id);
+      });
+
+      it('does not restart halted child when it halts', function*() {
+        let child1 = supervisor.getChild('child1')!;
+        let child2 = supervisor.getChild('child2')!;
+
+        child2.halt();
+
+        yield sleep(5);
+
+        expect(Live.get('child1')).toEqual(true);
+        expect(Live.get('child2')).toEqual(false);
+
+        expect(supervisor.getChild('child1')!.id).toEqual(child1.id);
+      });
+
+      it('does not restart halted child when it halts', function*() {
+        let child1 = supervisor.getChild('child1')!;
+
+        Complete.get('child2')!('done');
+
+        yield sleep(5);
+
+        expect(Live.get('child1')).toEqual(true);
+        expect(Live.get('child2')).toEqual(false);
+
+        expect(supervisor.getChild('child1')!.id).toEqual(child1.id);
+      });
+    });
+  });
+
+  describe('restart: oneForAll', () => {
+    let supervisor: Supervisor;
+
+    beforeEach(function*() {
+      supervisor = yield createSupervisor([
+        { name: 'child1', run: track, args: ['child1'] },
+        { name: 'child2', run: track, args: ['child2'] },
+        { name: 'child3', run: track, args: ['child3'] },
+        { name: 'child4', run: track, args: ['child4'], type: 'temporary' },
+      ], { strategy: 'oneForAll' });
+    });
+
+    it('restarts all permanent children when it crashes', function*() {
+      let child1 = supervisor.getChild('child1')!;
+      let child2 = supervisor.getChild('child2')!;
+      let child3 = supervisor.getChild('child3')!;
+
+      child2.run(crash);
+
+      yield sleep(5);
+
+      expect(Live.get('child1')).toEqual(true);
+      expect(Live.get('child2')).toEqual(true);
+      expect(Live.get('child3')).toEqual(true);
+      expect(Live.get('child4')).toEqual(false);
+
+      expect(supervisor.getChild('child1')!.id).not.toEqual(child1.id);
+      expect(supervisor.getChild('child2')!.id).not.toEqual(child2.id);
+      expect(supervisor.getChild('child3')!.id).not.toEqual(child3.id);
+    });
+  });
+
+  describe('restart: restForOne', () => {
+    let supervisor: Supervisor;
+
+    beforeEach(function*() {
+      supervisor = yield createSupervisor([
+        { name: 'child1', run: track, args: ['child1'] },
+        { name: 'child2', run: track, args: ['child2'] },
+        { name: 'child3', run: track, args: ['child3'] },
+        { name: 'child4', run: track, args: ['child4'], type: 'temporary' },
+      ], { strategy: 'restForOne' });
+    });
+
+    it('restarts children that come after crashed child', function*() {
+      let child1 = supervisor.getChild('child1')!;
+      let child2 = supervisor.getChild('child2')!;
+      let child3 = supervisor.getChild('child3')!;
+
+      child2.run(crash);
+
+      yield sleep(5);
+
+      expect(Live.get('child1')).toEqual(true);
+      expect(Live.get('child2')).toEqual(true);
+      expect(Live.get('child3')).toEqual(true);
+      expect(Live.get('child4')).toEqual(false);
+
+      expect(supervisor.getChild('child1')!.id).toEqual(child1.id);
+      expect(supervisor.getChild('child2')!.id).not.toEqual(child2.id);
+      expect(supervisor.getChild('child3')!.id).not.toEqual(child3.id);
+    });
+  });
+
+  describe('autoShutdown: never', () => {
+    let supervisor: Supervisor;
+
+    beforeEach(function*() {
+      supervisor = yield createSupervisor([
+        { name: 'child1', run: track, args: ['child1'], type: 'temporary', significant: true },
+        { name: 'child2', run: track, args: ['child2'], type: 'temporary', significant: true },
+        { name: 'child3', run: track, args: ['child3'], type: 'temporary' },
+      ], { shutdown: 'never' });
+    });
+
+    it('does not shut down supervisor as children are halted', function*() {
+      let child1 = supervisor.getChild('child1')!;
+      let child2 = supervisor.getChild('child2')!;
+
+      child1.halt();
+
+      yield sleep(5);
+      expect(Live.get('child3')).toEqual(true);
+
+      child2.halt();
+
+      yield sleep(5);
+      expect(Live.get('child3')).toEqual(true);
+    });
+  });
+
+  describe('autoShutdown: anySignificant', () => {
+    let supervisor: Supervisor;
+
+    beforeEach(function*() {
+      supervisor = yield createSupervisor([
+        { name: 'child1', run: track, args: ['child1'], type: 'temporary', significant: true },
+        { name: 'child2', run: track, args: ['child2'], type: 'temporary', significant: true },
+        { name: 'child3', run: track, args: ['child3'], type: 'temporary' },
+      ], { shutdown: 'anySignificant' });
+    });
+
+    it('shuts down supervisor when any significant task is halted', function*() {
+      let child2 = supervisor.getChild('child2')!;
+
+      child2.halt();
+
+      yield sleep(5);
+      expect(Live.get('child3')).toEqual(false);
+
+      yield supervisor.resourceTask;
+    });
+  });
+
+  describe('autoShutdown: allSignificant', () => {
+    let supervisor: Supervisor;
+
+    beforeEach(function*() {
+      supervisor = yield createSupervisor([
+        { name: 'child1', run: track, args: ['child1'], type: 'temporary', significant: true },
+        { name: 'child2', run: track, args: ['child2'], type: 'temporary', significant: true },
+        { name: 'child3', run: track, args: ['child3'], type: 'temporary' },
+      ], { shutdown: 'allSignificant' });
+    });
+
+    it('shuts down supervisor when all significant tasks are halted', function*() {
+      let child1 = supervisor.getChild('child1')!;
+      let child2 = supervisor.getChild('child2')!;
+
+      child1.halt();
+
+      yield sleep(5);
+      expect(Live.get('child3')).toEqual(true);
+
+      child2.halt();
+
+      yield sleep(5);
+      expect(Live.get('child3')).toEqual(false);
+
+      yield supervisor.resourceTask;
+    });
+  });
+});

--- a/packages/supervisor/test/supervisor.test.ts
+++ b/packages/supervisor/test/supervisor.test.ts
@@ -1,12 +1,13 @@
 /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-non-null-assertion */
-import { describe, beforeEach, it } from '@effection/mocha';
-import { Operation, run, sleep, createFuture } from 'effection';
-import expect from 'expect';
+import { describe, beforeEach, it } from "@effection/mocha";
+import type { Operation, Subscription, Task } from "effection";
+import { run, sleep, createFuture } from "effection";
+import expect from "expect";
 
-import { createSupervisor, Supervisor } from '../src/index';
+import { createSupervisor, Supervisor } from "../src/index";
 
-function *crash() {
-  throw new Error('boom');
+function* crash() {
+  throw new Error("boom");
 }
 
 const Live: Map<string, boolean> = new Map();
@@ -27,407 +28,492 @@ function* track(name: string): Operation<void> {
   }
 }
 
-describe('createSupervisor', () => {
-  it('starts given children', function*() {
+describe("createSupervisor", () => {
+  it("starts given children", function* () {
     let supervisor = yield createSupervisor([
-      { name: 'foo', run: track, args: ['foo'] },
-      { name: 'bar', run: track, args: ['bar'] }
+      { name: "foo", run: () => track("foo") },
+      { name: "bar", run: () => track("bar") },
     ]);
 
-    expect(Live.get('foo')).toEqual(true);
-    expect(Live.get('bar')).toEqual(true);
+    expect(Live.get("foo")).toEqual(true);
+    expect(Live.get("bar")).toEqual(true);
 
     yield supervisor.halt();
 
-    expect(Live.get('foo')).toEqual(false);
-    expect(Live.get('bar')).toEqual(false);
+    expect(Live.get("foo")).toEqual(false);
+    expect(Live.get("bar")).toEqual(false);
   });
 
-  describe('addChild', () => {
-    it('can dynamically start a child', function*() {
+  describe("addChild", () => {
+    it("can dynamically start a child", function* () {
       let supervisor = yield createSupervisor([]);
 
-      supervisor.addChild({ name: 'foo', run: track, args: ['foo'] });
+      supervisor.addChild({ name: "foo", run: () => track("foo") });
 
-      expect(Live.get('foo')).toEqual(true);
+      expect(Live.get("foo")).toEqual(true);
 
       yield supervisor.halt();
 
-      expect(Live.get('foo')).toEqual(false);
+      expect(Live.get("foo")).toEqual(false);
     });
   });
 
-  describe('startChild', () => {
-    it('starts a halted child', function*() {
+  describe("startChild", () => {
+    it("starts a halted child", function* () {
       let supervisor = yield createSupervisor([
-        { name: 'foo', run: track, args: ['foo'] },
-        { name: 'bar', run: track, args: ['bar'] },
+        { name: "foo", run: () => track("foo") },
+        { name: "bar", run: () => track("bar") },
       ]);
 
-      expect(Live.get('foo')).toEqual(true);
-      expect(Live.get('bar')).toEqual(true);
+      expect(Live.get("foo")).toEqual(true);
+      expect(Live.get("bar")).toEqual(true);
 
-      yield supervisor.haltChild('foo');
+      yield supervisor.haltChild("foo");
 
-      expect(Live.get('foo')).toEqual(false);
-      expect(Live.get('bar')).toEqual(true);
+      expect(Live.get("foo")).toEqual(false);
+      expect(Live.get("bar")).toEqual(true);
 
-      supervisor.startChild('foo');
+      supervisor.startChild("foo");
 
-      expect(Live.get('foo')).toEqual(true);
-      expect(Live.get('bar')).toEqual(true);
+      expect(Live.get("foo")).toEqual(true);
+      expect(Live.get("bar")).toEqual(true);
     });
   });
 
-  describe('haltChild', () => {
-    it('stops child', function*() {
+  describe("haltChild", () => {
+    it("stops child", function* () {
       let supervisor = yield createSupervisor([
-        { name: 'foo', run: track, args: ['foo'] },
-        { name: 'bar', run: track, args: ['bar'] }
+        { name: "foo", run: () => track("foo") },
+        { name: "bar", run: () => track("bar") },
       ]);
 
-      expect(Live.get('foo')).toEqual(true);
-      expect(Live.get('bar')).toEqual(true);
+      expect(Live.get("foo")).toEqual(true);
+      expect(Live.get("bar")).toEqual(true);
 
-      yield supervisor.haltChild('foo');
+      yield supervisor.haltChild("foo");
 
-      expect(Live.get('foo')).toEqual(false);
-      expect(Live.get('bar')).toEqual(true);
+      expect(Live.get("foo")).toEqual(false);
+      expect(Live.get("bar")).toEqual(true);
     });
   });
 
-  describe('restartChild', () => {
-    it('stops child', function*() {
+  describe("restartChild", () => {
+    it("stops child", function* () {
       let supervisor = yield createSupervisor([]);
 
-      let original = supervisor.addChild({ name: 'foo', run: track, args: ['foo'] });
+      let original = supervisor.addChild({
+        name: "foo",
+        run: () => track("foo"),
+      });
 
-      expect(Live.get('foo')).toEqual(true);
+      expect(Live.get("foo")).toEqual(true);
 
-      let restarted = yield supervisor.restartChild('foo');
+      let restarted = yield supervisor.restartChild("foo");
 
-      expect(Live.get('foo')).toEqual(true);
+      expect(Live.get("foo")).toEqual(true);
 
       expect(original.id).not.toEqual(restarted.id);
     });
   });
 
-  describe('haltAndRemoveChild', () => {
-    it('stops child and removes specification', function*() {
-      let supervisor = yield createSupervisor([{
-        name: 'foo',
-        run: track, args: ['foo'],
-      }]);
+  describe("haltAndRemoveChild", () => {
+    it("stops child and removes specification", function* () {
+      let supervisor = yield createSupervisor([
+        {
+          name: "foo",
+          run: () => track("foo"),
+        },
+      ]);
 
-      expect(Live.get('foo')).toEqual(true);
+      expect(Live.get("foo")).toEqual(true);
 
-      yield supervisor.haltAndRemoveChild('foo');
+      yield supervisor.haltAndRemoveChild("foo");
 
-      expect(Live.get('foo')).toEqual(false);
+      expect(Live.get("foo")).toEqual(false);
 
       expect(supervisor.specs).toEqual([]);
     });
   });
 
-  describe('restart: oneForOne', () => {
+  describe("restart: oneForOne", () => {
     let supervisor: Supervisor;
 
-    describe('with permanent child', () => {
-      beforeEach(function*() {
+    describe("with permanent child", () => {
+      beforeEach(function* () {
         supervisor = yield createSupervisor([
-          { name: 'child1', run: track, args: ['child1'] },
-          { name: 'child2', run: track, args: ['child2'] },
+          { name: "child1", run: () => track("child1") },
+          { name: "child2", run: () => track("child2") },
         ]);
       });
 
-      it('restarts crashed child when it crashes', function*() {
-        let child1 = supervisor.getChild('child1')!;
-        let child2 = supervisor.getChild('child2')!;
+      it("restarts crashed child when it crashes", function* () {
+        let child1 = supervisor.getChild("child1")!;
+        let child2 = supervisor.getChild("child2")!;
 
         child2.run(crash);
 
         yield sleep(5);
 
-        expect(Live.get('child1')).toEqual(true);
-        expect(Live.get('child2')).toEqual(true);
+        expect(Live.get("child1")).toEqual(true);
+        expect(Live.get("child2")).toEqual(true);
 
-        expect(supervisor.getChild('child1')!.id).toEqual(child1.id);
-        expect(supervisor.getChild('child2')!.id).not.toEqual(child2.id);
+        expect(supervisor.getChild("child1")!.id).toEqual(child1.id);
+        expect(supervisor.getChild("child2")!.id).not.toEqual(child2.id);
       });
 
-      it('restarts halted child when it halts', function*() {
-        let child1 = supervisor.getChild('child1')!;
-        let child2 = supervisor.getChild('child2')!;
+      it("restarts halted child when it halts", function* () {
+        let child1 = supervisor.getChild("child1")!;
+        let child2 = supervisor.getChild("child2")!;
 
         child2.halt();
 
         yield sleep(5);
 
-        expect(Live.get('child1')).toEqual(true);
-        expect(Live.get('child2')).toEqual(true);
+        expect(Live.get("child1")).toEqual(true);
+        expect(Live.get("child2")).toEqual(true);
 
-        expect(supervisor.getChild('child1')!.id).toEqual(child1.id);
-        expect(supervisor.getChild('child2')!.id).not.toEqual(child2.id);
+        expect(supervisor.getChild("child1")!.id).toEqual(child1.id);
+        expect(supervisor.getChild("child2")!.id).not.toEqual(child2.id);
       });
 
-      it('restarts completed child when it completes', function*() {
-        let child1 = supervisor.getChild('child1')!;
-        let child2 = supervisor.getChild('child2')!;
+      it("restarts completed child when it completes", function* () {
+        let child1 = supervisor.getChild("child1")!;
+        let child2 = supervisor.getChild("child2")!;
 
-        Complete.get('child2')!('done');
+        Complete.get("child2")!("done");
 
         yield sleep(5);
 
-        expect(Live.get('child1')).toEqual(true);
-        expect(Live.get('child2')).toEqual(true);
+        expect(Live.get("child1")).toEqual(true);
+        expect(Live.get("child2")).toEqual(true);
 
-        expect(supervisor.getChild('child1')!.id).toEqual(child1.id);
-        expect(supervisor.getChild('child2')!.id).not.toEqual(child2.id);
+        expect(supervisor.getChild("child1")!.id).toEqual(child1.id);
+        expect(supervisor.getChild("child2")!.id).not.toEqual(child2.id);
       });
     });
 
-    describe('with transient child', () => {
-      beforeEach(function*() {
+    describe("with transient child", () => {
+      beforeEach(function* () {
         supervisor = yield createSupervisor([
-          { name: 'child1', run: track, args: ['child1'] },
-          { name: 'child2', run: track, args: ['child2'], type: 'transient' },
+          { name: "child1", run: () => track("child1") },
+          { name: "child2", run: () => track("child2"), type: "transient" },
         ]);
       });
 
-      it('restarts crashed child when it crashes', function*() {
-        let child1 = supervisor.getChild('child1')!;
-        let child2 = supervisor.getChild('child2')!;
+      it("restarts crashed child when it crashes", function* () {
+        let child1 = supervisor.getChild("child1")!;
+        let child2 = supervisor.getChild("child2")!;
 
         child2.run(crash);
 
         yield sleep(5);
 
-        expect(Live.get('child1')).toEqual(true);
-        expect(Live.get('child2')).toEqual(true);
+        expect(Live.get("child1")).toEqual(true);
+        expect(Live.get("child2")).toEqual(true);
 
-        expect(supervisor.getChild('child1')!.id).toEqual(child1.id);
-        expect(supervisor.getChild('child2')!.id).not.toEqual(child2.id);
+        expect(supervisor.getChild("child1")!.id).toEqual(child1.id);
+        expect(supervisor.getChild("child2")!.id).not.toEqual(child2.id);
       });
 
-      it('does not restart halted child when it halts', function*() {
-        let child1 = supervisor.getChild('child1')!;
-        let child2 = supervisor.getChild('child2')!;
+      it("does not restart halted child when it halts", function* () {
+        let child1 = supervisor.getChild("child1")!;
+        let child2 = supervisor.getChild("child2")!;
 
         child2.halt();
 
         yield sleep(5);
 
-        expect(Live.get('child1')).toEqual(true);
-        expect(Live.get('child2')).toEqual(false);
+        expect(Live.get("child1")).toEqual(true);
+        expect(Live.get("child2")).toEqual(false);
 
-        expect(supervisor.getChild('child1')!.id).toEqual(child1.id);
+        expect(supervisor.getChild("child1")!.id).toEqual(child1.id);
       });
 
-      it('does not restart completed child when it completes', function*() {
-        let child1 = supervisor.getChild('child1')!;
+      it("does not restart completed child when it completes", function* () {
+        let child1 = supervisor.getChild("child1")!;
 
-        Complete.get('child2')!('done');
+        Complete.get("child2")!("done");
 
         yield sleep(5);
 
-        expect(Live.get('child1')).toEqual(true);
-        expect(Live.get('child2')).toEqual(false);
+        expect(Live.get("child1")).toEqual(true);
+        expect(Live.get("child2")).toEqual(false);
 
-        expect(supervisor.getChild('child1')!.id).toEqual(child1.id);
+        expect(supervisor.getChild("child1")!.id).toEqual(child1.id);
       });
     });
 
-    describe('with temporary child', () => {
-      beforeEach(function*() {
+    describe("with temporary child", () => {
+      beforeEach(function* () {
         supervisor = yield createSupervisor([
-          { name: 'child1', run: track, args: ['child1'] },
-          { name: 'child2', run: track, args: ['child2'], type: 'temporary' },
+          { name: "child1", run: () => track("child1") },
+          { name: "child2", run: () => track("child2"), type: "temporary" },
         ]);
       });
 
-      it('does not restart crashed child when it crashes', function*() {
-        let child1 = supervisor.getChild('child1')!;
-        let child2 = supervisor.getChild('child2')!;
+      it("does not restart crashed child when it crashes", function* () {
+        let child1 = supervisor.getChild("child1")!;
+        let child2 = supervisor.getChild("child2")!;
 
         child2.run(crash);
 
         yield sleep(5);
 
-        expect(Live.get('child1')).toEqual(true);
-        expect(Live.get('child2')).toEqual(false);
+        expect(Live.get("child1")).toEqual(true);
+        expect(Live.get("child2")).toEqual(false);
 
-        expect(supervisor.getChild('child1')!.id).toEqual(child1.id);
+        expect(supervisor.getChild("child1")!.id).toEqual(child1.id);
       });
 
-      it('does not restart halted child when it halts', function*() {
-        let child1 = supervisor.getChild('child1')!;
-        let child2 = supervisor.getChild('child2')!;
+      it("does not restart halted child when it halts", function* () {
+        let child1 = supervisor.getChild("child1")!;
+        let child2 = supervisor.getChild("child2")!;
 
         child2.halt();
 
         yield sleep(5);
 
-        expect(Live.get('child1')).toEqual(true);
-        expect(Live.get('child2')).toEqual(false);
+        expect(Live.get("child1")).toEqual(true);
+        expect(Live.get("child2")).toEqual(false);
 
-        expect(supervisor.getChild('child1')!.id).toEqual(child1.id);
+        expect(supervisor.getChild("child1")!.id).toEqual(child1.id);
       });
 
-      it('does not restart halted child when it halts', function*() {
-        let child1 = supervisor.getChild('child1')!;
+      it("does not restart halted child when it halts", function* () {
+        let child1 = supervisor.getChild("child1")!;
 
-        Complete.get('child2')!('done');
+        Complete.get("child2")!("done");
 
         yield sleep(5);
 
-        expect(Live.get('child1')).toEqual(true);
-        expect(Live.get('child2')).toEqual(false);
+        expect(Live.get("child1")).toEqual(true);
+        expect(Live.get("child2")).toEqual(false);
 
-        expect(supervisor.getChild('child1')!.id).toEqual(child1.id);
+        expect(supervisor.getChild("child1")!.id).toEqual(child1.id);
       });
     });
   });
 
-  describe('restart: oneForAll', () => {
+  describe("restart: oneForAll", () => {
     let supervisor: Supervisor;
 
-    beforeEach(function*() {
-      supervisor = yield createSupervisor([
-        { name: 'child1', run: track, args: ['child1'] },
-        { name: 'child2', run: track, args: ['child2'] },
-        { name: 'child3', run: track, args: ['child3'] },
-        { name: 'child4', run: track, args: ['child4'], type: 'temporary' },
-      ], { strategy: 'oneForAll' });
+    beforeEach(function* () {
+      supervisor = yield createSupervisor(
+        [
+          { name: "child1", run: () => track("child1") },
+          { name: "child2", run: () => track("child2") },
+          { name: "child3", run: () => track("child3") },
+          { name: "child4", run: () => track("child4"), type: "temporary" },
+        ],
+        { strategy: "oneForAll" }
+      );
     });
 
-    it('restarts all permanent children when it crashes', function*() {
-      let child1 = supervisor.getChild('child1')!;
-      let child2 = supervisor.getChild('child2')!;
-      let child3 = supervisor.getChild('child3')!;
+    it("restarts all permanent children when it crashes", function* () {
+      let child1 = supervisor.getChild("child1")!;
+      let child2 = supervisor.getChild("child2")!;
+      let child3 = supervisor.getChild("child3")!;
 
       child2.run(crash);
 
       yield sleep(5);
 
-      expect(Live.get('child1')).toEqual(true);
-      expect(Live.get('child2')).toEqual(true);
-      expect(Live.get('child3')).toEqual(true);
-      expect(Live.get('child4')).toEqual(false);
+      expect(Live.get("child1")).toEqual(true);
+      expect(Live.get("child2")).toEqual(true);
+      expect(Live.get("child3")).toEqual(true);
+      expect(Live.get("child4")).toEqual(false);
 
-      expect(supervisor.getChild('child1')!.id).not.toEqual(child1.id);
-      expect(supervisor.getChild('child2')!.id).not.toEqual(child2.id);
-      expect(supervisor.getChild('child3')!.id).not.toEqual(child3.id);
+      expect(supervisor.getChild("child1")!.id).not.toEqual(child1.id);
+      expect(supervisor.getChild("child2")!.id).not.toEqual(child2.id);
+      expect(supervisor.getChild("child3")!.id).not.toEqual(child3.id);
     });
   });
 
-  describe('restart: restForOne', () => {
+  describe("restart: restForOne", () => {
     let supervisor: Supervisor;
 
-    beforeEach(function*() {
-      supervisor = yield createSupervisor([
-        { name: 'child1', run: track, args: ['child1'] },
-        { name: 'child2', run: track, args: ['child2'] },
-        { name: 'child3', run: track, args: ['child3'] },
-        { name: 'child4', run: track, args: ['child4'], type: 'temporary' },
-      ], { strategy: 'restForOne' });
+    beforeEach(function* () {
+      supervisor = yield createSupervisor(
+        [
+          { name: "child1", run: () => track("child1") },
+          { name: "child2", run: () => track("child2") },
+          { name: "child3", run: () => track("child3") },
+          { name: "child4", run: () => track("child4"), type: "temporary" },
+        ],
+        { strategy: "restForOne" }
+      );
     });
 
-    it('restarts children that come after crashed child', function*() {
-      let child1 = supervisor.getChild('child1')!;
-      let child2 = supervisor.getChild('child2')!;
-      let child3 = supervisor.getChild('child3')!;
+    it("restarts children that come after crashed child", function* () {
+      let child1 = supervisor.getChild("child1")!;
+      let child2 = supervisor.getChild("child2")!;
+      let child3 = supervisor.getChild("child3")!;
 
       child2.run(crash);
 
       yield sleep(5);
 
-      expect(Live.get('child1')).toEqual(true);
-      expect(Live.get('child2')).toEqual(true);
-      expect(Live.get('child3')).toEqual(true);
-      expect(Live.get('child4')).toEqual(false);
+      expect(Live.get("child1")).toEqual(true);
+      expect(Live.get("child2")).toEqual(true);
+      expect(Live.get("child3")).toEqual(true);
+      expect(Live.get("child4")).toEqual(false);
 
-      expect(supervisor.getChild('child1')!.id).toEqual(child1.id);
-      expect(supervisor.getChild('child2')!.id).not.toEqual(child2.id);
-      expect(supervisor.getChild('child3')!.id).not.toEqual(child3.id);
+      expect(supervisor.getChild("child1")!.id).toEqual(child1.id);
+      expect(supervisor.getChild("child2")!.id).not.toEqual(child2.id);
+      expect(supervisor.getChild("child3")!.id).not.toEqual(child3.id);
     });
   });
 
-  describe('autoShutdown: never', () => {
+  describe("autoShutdown: never", () => {
     let supervisor: Supervisor;
 
-    beforeEach(function*() {
-      supervisor = yield createSupervisor([
-        { name: 'child1', run: track, args: ['child1'], type: 'temporary', significant: true },
-        { name: 'child2', run: track, args: ['child2'], type: 'temporary', significant: true },
-        { name: 'child3', run: track, args: ['child3'], type: 'temporary' },
-      ], { shutdown: 'never' });
+    beforeEach(function* () {
+      supervisor = yield createSupervisor(
+        [
+          {
+            name: "child1",
+            run: () => track("child1"),
+            type: "temporary",
+            significant: true,
+          },
+          {
+            name: "child2",
+            run: () => track("child2"),
+            type: "temporary",
+            significant: true,
+          },
+          { name: "child3", run: () => track("child3"), type: "temporary" },
+        ],
+        { shutdown: "never" }
+      );
     });
 
-    it('does not shut down supervisor as children are halted', function*() {
-      let child1 = supervisor.getChild('child1')!;
-      let child2 = supervisor.getChild('child2')!;
+    it("does not shut down supervisor as children are halted", function* () {
+      let child1 = supervisor.getChild("child1")!;
+      let child2 = supervisor.getChild("child2")!;
 
       child1.halt();
 
       yield sleep(5);
-      expect(Live.get('child3')).toEqual(true);
+      expect(Live.get("child3")).toEqual(true);
 
       child2.halt();
 
       yield sleep(5);
-      expect(Live.get('child3')).toEqual(true);
+      expect(Live.get("child3")).toEqual(true);
     });
   });
 
-  describe('autoShutdown: anySignificant', () => {
+  describe("autoShutdown: anySignificant", () => {
     let supervisor: Supervisor;
 
-    beforeEach(function*() {
-      supervisor = yield createSupervisor([
-        { name: 'child1', run: track, args: ['child1'], type: 'temporary', significant: true },
-        { name: 'child2', run: track, args: ['child2'], type: 'temporary', significant: true },
-        { name: 'child3', run: track, args: ['child3'], type: 'temporary' },
-      ], { shutdown: 'anySignificant' });
+    beforeEach(function* () {
+      supervisor = yield createSupervisor(
+        [
+          {
+            name: "child1",
+            run: () => track("child1"),
+            type: "temporary",
+            significant: true,
+          },
+          {
+            name: "child2",
+            run: () => track("child2"),
+            type: "temporary",
+            significant: true,
+          },
+          { name: "child3", run: () => track("child3"), type: "temporary" },
+        ],
+        { shutdown: "anySignificant" }
+      );
     });
 
-    it('shuts down supervisor when any significant task is halted', function*() {
-      let child2 = supervisor.getChild('child2')!;
+    it("shuts down supervisor when any significant task is halted", function* () {
+      let child2 = supervisor.getChild("child2")!;
 
       child2.halt();
 
       yield sleep(5);
-      expect(Live.get('child3')).toEqual(false);
+      expect(Live.get("child3")).toEqual(false);
 
       yield supervisor.resourceTask;
     });
   });
 
-  describe('autoShutdown: allSignificant', () => {
+  describe("autoShutdown: allSignificant", () => {
     let supervisor: Supervisor;
 
-    beforeEach(function*() {
-      supervisor = yield createSupervisor([
-        { name: 'child1', run: track, args: ['child1'], type: 'temporary', significant: true },
-        { name: 'child2', run: track, args: ['child2'], type: 'temporary', significant: true },
-        { name: 'child3', run: track, args: ['child3'], type: 'temporary' },
-      ], { shutdown: 'allSignificant' });
+    beforeEach(function* () {
+      supervisor = yield createSupervisor(
+        [
+          {
+            name: "child1",
+            run: () => track("child1"),
+            type: "temporary",
+            significant: true,
+          },
+          {
+            name: "child2",
+            run: () => track("child2"),
+            type: "temporary",
+            significant: true,
+          },
+          { name: "child3", run: () => track("child3"), type: "temporary" },
+        ],
+        { shutdown: "allSignificant" }
+      );
     });
 
-    it('shuts down supervisor when all significant tasks are halted', function*() {
-      let child1 = supervisor.getChild('child1')!;
-      let child2 = supervisor.getChild('child2')!;
+    it("shuts down supervisor when all significant tasks are halted", function* () {
+      let child1 = supervisor.getChild("child1")!;
+      let child2 = supervisor.getChild("child2")!;
 
       child1.halt();
 
       yield sleep(5);
-      expect(Live.get('child3')).toEqual(true);
+      expect(Live.get("child3")).toEqual(true);
 
       child2.halt();
 
       yield sleep(5);
-      expect(Live.get('child3')).toEqual(false);
+      expect(Live.get("child3")).toEqual(false);
 
       yield supervisor.resourceTask;
+    });
+  });
+
+  describe("onExit", () => {
+    let supervisor: Supervisor;
+
+    beforeEach(function* () {
+      supervisor = yield createSupervisor([
+        { name: "child1", run: () => track("child1") },
+        { name: "child2", run: () => track("child2") },
+        { name: "child3", run: () => track("child3") },
+      ]);
+    });
+
+    it("can listen for exited children", function* () {
+      let child1 = supervisor.getChild("child1")!;
+      let child2 = supervisor.getChild("child2")!;
+      supervisor.getChild("child3")!;
+
+      let subscription: Subscription<Task> = yield supervisor.onExit;
+
+      child2.run(crash);
+
+      let [task1, value1] = yield subscription.first();
+      expect(task1.state).toEqual("errored");
+      expect(task1.id).toEqual(child2.id);
+      expect(value1.error.message).toEqual("boom");
+
+      child1.halt();
+
+      let [task2, value2] = yield subscription.first();
+
+      expect(task2.state).toEqual("halted");
+      expect(task2.id).toEqual(child1.id);
+      expect(value2.state).toEqual("halted");
     });
   });
 });

--- a/packages/supervisor/test/supervisor.test.ts
+++ b/packages/supervisor/test/supervisor.test.ts
@@ -530,7 +530,7 @@ describe("createSupervisor", () => {
             { name: "child2", run: () => track("child2") },
             { name: "child3", run: () => track("child3") },
           ],
-          { period: 50, intensity: 2 }
+          { period: 100, intensity: 2 }
         )
       );
     });
@@ -551,18 +551,22 @@ describe("createSupervisor", () => {
       expect(supervisorTask.state).toEqual("errored");
       yield expect(supervisorTask).rejects.toHaveProperty(
         "message",
-        "child task restarted more than 2 times within 50ms"
+        "child task restarted more than 2 times within 100ms"
       );
     });
 
     it("does not shut down if restart intensity is not exceeded", function* () {
       supervisor.getChild("child2")!.run(crash);
 
-      yield sleep(30);
+      yield sleep(80);
 
       supervisor.getChild("child2")!.run(crash);
 
-      yield sleep(30);
+      yield sleep(80);
+
+      supervisor.getChild("child2")!.run(crash);
+
+      yield sleep(80);
 
       supervisor.getChild("child2")!.run(crash);
 

--- a/packages/supervisor/tsconfig.cjs.json
+++ b/packages/supervisor/tsconfig.cjs.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist-cjs",
+    "noEmit": false
+  },
+  "references": [
+    { "path": "../core/tsconfig.cjs.json" }
+  ],
+  "exclude": ["./test/*"]
+}

--- a/packages/supervisor/tsconfig.esm.json
+++ b/packages/supervisor/tsconfig.esm.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.cjs.json",
+  "compilerOptions": {
+    "outDir": "./dist-esm",
+    "module": "ESNext"
+  },
+  "references": [
+    { "path": "../core/tsconfig.esm.json" }
+  ],
+  "exclude": ["./test/*"]
+}

--- a/packages/supervisor/tsconfig.json
+++ b/packages/supervisor/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "noEmit": true
+  },
+  "references": [
+    { "path": "../core/tsconfig.cjs.json" }
+  ],
+  "include": [
+    "src/**/*.ts",
+    "test/**/*.ts"
+  ]
+}


### PR DESCRIPTION
Depends on #649 

## Motivation

One of the visions for Effection was to recreate part of the brilliant OTP system for Erlang, by enabling the easy creation of supervision trees. Supervision trees enable fault tolerance through the "just let it crash" philosophy. While Effection code is very good at surfacing errors, actually dealing with those errors has been tricky. With supervision trees, parts of the system or the whole system can be kept running and restarted easily.

## Approach

Why reinvent the wheel? OTPs supervisors are good and battle tested. This basically copies most of the functionality of OTP supervisors.

For more information, see the [README](https://github.com/thefrontside/effection/blob/supervisor/packages/supervisor/README.md)

### Alternate Designs

There are millions of other ways of doing the same thing.

### Possible Drawbacks or Risks

The code is complicated, and there are probably a ton of nasty edge cases.

### TODOs and Open Questions

- [ ] This interacts somewhat poorly with resources. Is there something we can do about that?
- [x] Missing `simple_one_for_one` strategy. IMO this should probably be a completely separate thing, since the external interface for `simple_one_for_one` should be quite different. It feels like Erlang sort of shoehorned this into one module, but it really shouldn't be.
- [x] The `period` and `intensity` options are not yet implemented. I think this is a very necessary part of the supervision system, but it's tricky to implement. Also, I think having some kind of backoff would be nice.
- [x] Type safety for the `args` option could be improved. I think the only nice way of doing this is by using the multiple-overloads trick.

## Learning

https://www.erlang.org/doc/man/supervisor.html