### PR TITLE
Expose formatError so packages other than  can make nice errors

### DIFF
--- a/.changes/expose-format-error.md
+++ b/.changes/expose-format-error.md
@@ -1,0 +1,4 @@
+---
+'@effection/main': minor
+---
+Expose `formatError` so other packages can format errors the same way as `main`

--- a/packages/main/src/browser.ts
+++ b/packages/main/src/browser.ts
@@ -3,6 +3,14 @@ import { isMainError } from './error';
 
 export * from './error';
 
+export function formatError(error: Error): string {
+  if(isMainError(error)) {
+    return error.message;
+  } else {
+    return error.toString();
+  }
+}
+
 export function main<T>(operation: Operation<T>): Task<T> {
   return run(function*(task) {
     let interrupt = () => { task.halt() };

--- a/packages/main/src/node.ts
+++ b/packages/main/src/node.ts
@@ -3,6 +3,7 @@ import { formatError } from './format-error-node';
 import { isMainError } from './error';
 
 export * from './error';
+export { formatError } from './format-error-node';
 
 /**
  * Runs the given operation in a task and returns that task. `main` functions


### PR DESCRIPTION
## Motivation

Other packages might want to format errors the same way that `main` does. See for example #648 

## Approach

Just make this public for both node and browser.