### PR TITLE
`process.expect()` never returns stderr/stdout on exception

### DIFF
--- a/packages/process/test/exec.test.ts
+++ b/packages/process/test/exec.test.ts
@@ -42,6 +42,13 @@ describe('exec', () => {
       expect(error.name).toEqual('ExecError');
     });
 
+    it('allows to read output on exception', function* () {
+      let { stdout, stderr } = yield exec("node './test/fixtures/hello-world-failed.js'").expect();
+
+      expect(stdout).toEqual('hello world\n');
+      expect(stderr).toEqual('boom\n');
+    });
+
     it('applies labels', function*() {
       expect((exec("foo").expect()?.labels as Labels)?.name).toEqual('exec("foo").expect()');
     });


### PR DESCRIPTION
## Motivation

We encountered that `process.expect()` is not allowing to capture `stderr/stdout` because when it throws, it never actually returns a value. I'm not really sure if there is a solution to this other than maybe attaching stderr/stdout to error message.

## Approach

I just added failing test.
