### PR TITLE
covector publish when package doesn't exist

### DIFF
--- a/.changes/config.json
+++ b/.changes/config.json
@@ -3,7 +3,7 @@
   "pkgManagers": {
     "javascript": {
       "version": true,
-      "getPublishedVersion": "npm view ${ pkgFile.pkg.name } version",
+      "getPublishedVersion": "node ../../.scripts/checkIfPublished.mjs ${ pkgFile.pkg.name } ${ pkg.tag ? pkg.tag : 'latest' }",
       "publish": [
         "npm publish --access public ${ pkg.tag ? '--tag ' + pkg.tag : '' }"
       ]

--- a/.scripts/checkIfPublished.mjs
+++ b/.scripts/checkIfPublished.mjs
@@ -1,0 +1,22 @@
+import { main } from 'effection';
+import { fetch } from '@effection/fetch';
+
+const pkgName = process.argv[2];
+const tag = process.argv[3];
+
+main(function* () {
+  const pkg = yield packageExists(pkgName, tag);
+  console.log(pkg);
+});
+
+function* packageExists(name, tag) {
+  let request = yield fetch(`https://registry.npmjs.com/${name}`);
+  if (request.status === 404) {
+    return 'not published';
+  } else if (request.status < 400) {
+    let response = yield request.json();
+    return response['dist-tags'][tag];
+  } else {
+    throw new Error('request error');
+  }
+}


### PR DESCRIPTION
## Motivation

The existing command for the covector checks if a package has been published and the version. If the package has yet to be published, this command throws an error which breaks the publish sequence. This changes adjust the command not to throw an error and attempt to publish.

## Approach

A little extra bash.

### Alternate Designs

We want to make this more robust, and fetch via the API. This way we could check specifically for a 404 error. This likely makes sense after an effection upgrade and implementing presets. I can work on that next week, but have been focusing on simulacrum this week and haven't gotten to it. Don't want to hold up our publishing.
