### PR TITLE
assert that vitest test fails as either 1 or 100

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
 executors:
   linux:
     docker:
-      - image: cimg/node:18.8.0-browsers
+      - image: cimg/node:18.9.0-browsers
   macos:
     macos:
       xcode: "13.4.1"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "docs:preview": "yarn parcel docs/api/v2/index.html"
   },
   "volta": {
-    "node": "14.20.0",
+    "node": "18.9.0",
     "yarn": "1.22.19"
   },
   "devDependencies": {

--- a/packages/vitest/test/vitest.test.ts
+++ b/packages/vitest/test/vitest.test.ts
@@ -43,7 +43,7 @@ describe('@effection/vitest', () => {
         'yarn vitest run spawned-error.failure.ts --no-color --config vite.test.config.ts',
         { cwd }
       ).join();
-      expect(code).toEqual(1);
+      expect(code).toMatch(/1|100/);
       expect(stderr).toContain('boom');
     },
     process.env.CI ? 30000 : undefined


### PR DESCRIPTION
## Motivation

The vitest tests where testing that a separate script exploded, and it did. However, on some versions of node+OS it was actually v8 itself exploding which would return a `code: 100`. This is a bug upstream in node and will eventually be fixed, but regardless _our_ tests pass in seeing that error and properly throwing. Consider this case and check for both `code: 1` and `code: 100` instead.

## Approach

Added an "or" check for `code: 100`. Also including the bump to v18 for volta so local work matches what we are running in CI which also supscedes #664.
