### PR TITLE
sync @effection/react dep on effection to latest

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -28,7 +28,7 @@
     "mocha": "mocha -r ts-node/register"
   },
   "dependencies": {
-    "effection": "^2.0.0"
+    "effection": "2.0.4"
   },
   "devDependencies": {
     "@frontside/tsconfig": "^1.2.0",


### PR DESCRIPTION
## Motivation

As it sits currently, `covector` only runs the dependency bumps as a patch. The `@effection/react` dep on `effection` was behind so it was doing a patch bump, but not to the latest.

## Approach

Set the dep to the current latest and then covector will pick it up and bump it correctly.

I didn't add a change file since the existing change files will take care of the bump and notes.

