### PR TITLE
Delegate error properties to original error

### DIFF
--- a/.changes/delegate-error-properties.md
+++ b/.changes/delegate-error-properties.md
@@ -1,0 +1,4 @@
+---
+"@effection/core": patch
+---
+delegate `error` and `name` properties to underlying `Error`. fixes  https://github.com/thefrontside/effection/issues/675)

--- a/packages/core/src/error.ts
+++ b/packages/core/src/error.ts
@@ -16,6 +16,14 @@ export function addTrace(error: Error & Partial<HasEffectionTrace>, task: Task):
   };
 
   return Object.create(error, {
+    name: {
+      get: () => error.name,
+      enumerable: true,
+    },
+    message: {
+      get: () => error.message,
+      enumerable: true,
+    },
     effectionTrace: {
       value: [...(error.effectionTrace || []), info],
       enumerable: true,


### PR DESCRIPTION
## Motivation
Because effection is "stackless", the actual JavaScript backtrace of an exception is less useful more often than not. Instead what is more often of use is the trace of operations that got you to the point where you are. To accomplish this, we augment caught errors with the `effectionTrace` property which contains the stack of operations. We don't actually mutate the underlying `Error` object in order to be minimally invasive, and instead create a new object with the original error as the prototype. That way, it will have all the original error's properties, but won't change it in place and risk unknown side-effects.

However, this does not work for native DOMExceptions (see https://github.com/thefrontside/effection/issues/675)



## Approach
This explicitly delegates the `name` and `message` properties of the underlying `Error` object rather than using normal prototype dispatch. The `code` property which is deprecated, is not delegated since it will likely be removed in the future.

As further work, we may look into adding `cause` property to point to the original error.

fixes #675

## Learning
- https://developer.mozilla.org/en-US/docs/Web/API/DOMException/code

