### PR TITLE
Publish New Versions

### DIFF
--- a/.changes/delegate-error-properties.md
+++ b/.changes/delegate-error-properties.md
@@ -1,4 +1,0 @@
----
-"@effection/core": patch
----
-delegate `error` and `name` properties to underlying `Error`. fixes  https://github.com/thefrontside/effection/issues/675)

--- a/packages/atom/CHANGELOG.md
+++ b/packages/atom/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @effection/atom
 
+## \[2.0.6]
+
+- delegate `error` and `name` properties to underlying `Error`. fixes  https://github.com/thefrontside/effection/issues/675)
+  - Bumped due to a bump in effection.
+  - [84a66d7](https://github.com/thefrontside/effection/commit/84a66d799060ba2292fff2482d87bf6abafa7937) Delegate error properties to original error on 2022-10-05
+
 ## \[2.0.5]
 
 - Expose `formatError` so other packages can format errors the same way as `main`

--- a/packages/atom/package.json
+++ b/packages/atom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/atom",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "State atom implementation for effection",
   "main": "dist-cjs/index.js",
   "types": "dist-esm/index.d.ts",
@@ -41,7 +41,7 @@
     "extends": "../../package.json"
   },
   "dependencies": {
-    "effection": "2.0.5",
+    "effection": "2.0.6",
     "assert-ts": "^0.2.2",
     "fp-ts": "^2.8.2",
     "monocle-ts": "^2.3.3"

--- a/packages/channel/CHANGELOG.md
+++ b/packages/channel/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## \[2.0.4]
+
+- delegate `error` and `name` properties to underlying `Error`. fixes  https://github.com/thefrontside/effection/issues/675)
+  - Bumped due to a bump in @effection/core.
+  - [84a66d7](https://github.com/thefrontside/effection/commit/84a66d799060ba2292fff2482d87bf6abafa7937) Delegate error properties to original error on 2022-10-05
+
 ## \[2.0.3]
 
 - Allow pass object with `Symbol.operation` as an operation

--- a/packages/channel/package.json
+++ b/packages/channel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/channel",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "MPMC Channel implementation for effection",
   "main": "dist-cjs/index.js",
   "module": "dist-esm/index.js",
@@ -39,8 +39,8 @@
     "extends": "../../package.json"
   },
   "dependencies": {
-    "@effection/core": "2.2.0",
-    "@effection/events": "2.0.3",
-    "@effection/stream": "2.0.3"
+    "@effection/core": "2.2.1",
+    "@effection/events": "2.0.4",
+    "@effection/stream": "2.0.4"
   }
 }

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,10 @@
 # @effection/core
 
+## \[2.2.1]
+
+- delegate `error` and `name` properties to underlying `Error`. fixes  https://github.com/thefrontside/effection/issues/675)
+  - [84a66d7](https://github.com/thefrontside/effection/commit/84a66d799060ba2292fff2482d87bf6abafa7937) Delegate error properties to original error on 2022-10-05
+
 ## \[2.2.0]
 
 - Allow pass object with `Symbol.operation` as an operation

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/core",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "main": "dist-cjs/index.js",
   "module": "dist-esm/index.js",
   "sideEffects": false,

--- a/packages/dispatch/CHANGELOG.md
+++ b/packages/dispatch/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## \[2.0.6]
+
+- delegate `error` and `name` properties to underlying `Error`. fixes  https://github.com/thefrontside/effection/issues/675)
+  - Bumped due to a bump in effection.
+  - [84a66d7](https://github.com/thefrontside/effection/commit/84a66d799060ba2292fff2482d87bf6abafa7937) Delegate error properties to original error on 2022-10-05
+
 ## \[2.0.5]
 
 - Expose `formatError` so other packages can format errors the same way as `main`

--- a/packages/dispatch/package.json
+++ b/packages/dispatch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/dispatch",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Splits a subscription into multiple subscriptions",
   "main": "dist-cjs/index.js",
   "module": "dist-esm/index.js",
@@ -39,6 +39,6 @@
     "extends": "../../package.json"
   },
   "dependencies": {
-    "effection": "2.0.5"
+    "effection": "2.0.6"
   }
 }

--- a/packages/duplex-channel/CHANGELOG.md
+++ b/packages/duplex-channel/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## \[2.0.6]
+
+- delegate `error` and `name` properties to underlying `Error`. fixes  https://github.com/thefrontside/effection/issues/675)
+  - Bumped due to a bump in effection.
+  - [84a66d7](https://github.com/thefrontside/effection/commit/84a66d799060ba2292fff2482d87bf6abafa7937) Delegate error properties to original error on 2022-10-05
+
 ## \[2.0.5]
 
 - Expose `formatError` so other packages can format errors the same way as `main`

--- a/packages/duplex-channel/package.json
+++ b/packages/duplex-channel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/duplex-channel",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "A bidirectional channel for effection",
   "main": "dist-cjs/index.js",
   "module": "dist-esm/index.js",
@@ -37,7 +37,7 @@
     "typescript": "^4.3.5"
   },
   "dependencies": {
-    "effection": "2.0.5"
+    "effection": "2.0.6"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/effection/CHANGELOG.md
+++ b/packages/effection/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## \[2.0.6]
+
+- delegate `error` and `name` properties to underlying `Error`. fixes  https://github.com/thefrontside/effection/issues/675)
+  - Bumped due to a bump in @effection/core.
+  - [84a66d7](https://github.com/thefrontside/effection/commit/84a66d799060ba2292fff2482d87bf6abafa7937) Delegate error properties to original error on 2022-10-05
+
 ## \[2.0.5]
 
 - Expose `formatError` so other packages can format errors the same way as `main`

--- a/packages/effection/package.json
+++ b/packages/effection/package.json
@@ -1,6 +1,6 @@
 {
   "name": "effection",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Structured concurrency and effects for JavaScript",
   "homepage": "https://frontside.com/effection",
   "repository": {
@@ -28,13 +28,13 @@
     "prepack": "tsc --build tsconfig.esm.json && tsc --build tsconfig.cjs.json && cpy ../../README.md ."
   },
   "dependencies": {
-    "@effection/channel": "2.0.3",
-    "@effection/core": "2.2.0",
-    "@effection/events": "2.0.3",
-    "@effection/fetch": "2.0.4",
-    "@effection/main": "2.1.0",
-    "@effection/subscription": "2.0.3",
-    "@effection/stream": "2.0.3"
+    "@effection/channel": "2.0.4",
+    "@effection/core": "2.2.1",
+    "@effection/events": "2.0.4",
+    "@effection/fetch": "2.0.5",
+    "@effection/main": "2.1.1",
+    "@effection/subscription": "2.0.4",
+    "@effection/stream": "2.0.4"
   },
   "devDependencies": {
     "@babel/core": "^7.14.8",

--- a/packages/events/CHANGELOG.md
+++ b/packages/events/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## \[2.0.4]
+
+- delegate `error` and `name` properties to underlying `Error`. fixes  https://github.com/thefrontside/effection/issues/675)
+  - Bumped due to a bump in @effection/core.
+  - [84a66d7](https://github.com/thefrontside/effection/commit/84a66d799060ba2292fff2482d87bf6abafa7937) Delegate error properties to original error on 2022-10-05
+
 ## \[2.0.3]
 
 - Allow pass object with `Symbol.operation` as an operation

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/events",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Helpers for listening to events with effection",
   "main": "dist-cjs/index.js",
   "module": "dist-esm/index.js",
@@ -28,8 +28,8 @@
     "mocha": "mocha -r ts-node/register"
   },
   "dependencies": {
-    "@effection/core": "2.2.0",
-    "@effection/stream": "2.0.3"
+    "@effection/core": "2.2.1",
+    "@effection/stream": "2.0.4"
   },
   "devDependencies": {
     "@frontside/tsconfig": "^1.2.0",

--- a/packages/fetch/CHANGELOG.md
+++ b/packages/fetch/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @effection/fetch
 
+## \[2.0.5]
+
+- delegate `error` and `name` properties to underlying `Error`. fixes  https://github.com/thefrontside/effection/issues/675)
+  - Bumped due to a bump in @effection/core.
+  - [84a66d7](https://github.com/thefrontside/effection/commit/84a66d799060ba2292fff2482d87bf6abafa7937) Delegate error properties to original error on 2022-10-05
+
 ## \[2.0.4]
 
 - Allow pass object with `Symbol.operation` as an operation

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/fetch",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Fetch operation for Effection",
   "main": "dist-cjs/index.js",
   "module": "dist-esm/index.js",
@@ -36,7 +36,7 @@
     "typescript": "^4.3.5"
   },
   "dependencies": {
-    "@effection/core": "2.2.0",
+    "@effection/core": "2.2.1",
     "cross-fetch": "3.1.5"
   },
   "volta": {

--- a/packages/inspect-server/CHANGELOG.md
+++ b/packages/inspect-server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @effection/inspect-server
 
+## \[2.2.3]
+
+- delegate `error` and `name` properties to underlying `Error`. fixes  https://github.com/thefrontside/effection/issues/675)
+  - Bumped due to a bump in effection.
+  - [84a66d7](https://github.com/thefrontside/effection/commit/84a66d799060ba2292fff2482d87bf6abafa7937) Delegate error properties to original error on 2022-10-05
+
 ## \[2.2.2]
 
 - These had unintentional preview publishes on a separate tag. Bumping and setting it to latest.

--- a/packages/inspect-server/package.json
+++ b/packages/inspect-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/inspect-server",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "Inspect server for inspecting effection processes",
   "main": "dist-cjs/index.js",
   "types": "dist-esm/index.d.ts",
@@ -29,11 +29,11 @@
     "examples:basic": "ts-node ./examples/basic.ts"
   },
   "dependencies": {
-    "@effection/atom": "2.0.5",
-    "@effection/inspect-ui": "2.3.1",
-    "@effection/inspect-utils": "2.1.5",
-    "@effection/websocket-server": "2.0.5",
-    "effection": "2.0.5",
+    "@effection/atom": "2.0.6",
+    "@effection/inspect-ui": "2.3.2",
+    "@effection/inspect-utils": "2.1.6",
+    "@effection/websocket-server": "2.0.6",
+    "effection": "2.0.6",
     "node-static": "^0.7.11",
     "websocket": "^1.0.34"
   },

--- a/packages/inspect-ui/CHANGELOG.md
+++ b/packages/inspect-ui/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @effection/inspect-ui
 
+## \[2.3.2]
+
+- delegate `error` and `name` properties to underlying `Error`. fixes  https://github.com/thefrontside/effection/issues/675)
+  - Bumped due to a bump in effection.
+  - [84a66d7](https://github.com/thefrontside/effection/commit/84a66d799060ba2292fff2482d87bf6abafa7937) Delegate error properties to original error on 2022-10-05
+
 ## \[2.3.1]
 
 - These had unintentional preview publishes on a separate tag. Bumping and setting it to latest.

--- a/packages/inspect-ui/package.json
+++ b/packages/inspect-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/inspect-ui",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Web interface for inspecting effection applications",
   "main": "app/index.ts",
   "types": "dist-esm/index.d.ts",
@@ -31,7 +31,7 @@
     "mocha": "mocha -r ts-node/register --timeout 5000"
   },
   "dependencies": {
-    "@effection/react": "2.2.1",
+    "@effection/react": "2.2.2",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.57",
@@ -45,8 +45,8 @@
     "react-router-dom": "^6.3.0"
   },
   "devDependencies": {
-    "@effection/inspect-utils": "2.1.5",
-    "@effection/websocket-client": "2.0.5",
+    "@effection/inspect-utils": "2.1.6",
+    "@effection/websocket-client": "2.0.6",
     "@frontside/tsconfig": "^1.2.0",
     "@interactors/material-ui": "^4.1.0",
     "@types/jsdom-global": "^3.0.2",
@@ -56,7 +56,7 @@
     "@types/react-router": "^5.1.17",
     "@types/react-router-dom": "^5.3.1",
     "copyfiles": "^2.4.1",
-    "effection": "2.0.5",
+    "effection": "2.0.6",
     "eslint-plugin-react": "^7.31.8",
     "eslint-plugin-react-hooks": "^4.6.0",
     "events": "^3.3.0",

--- a/packages/inspect-utils/CHANGELOG.md
+++ b/packages/inspect-utils/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @effection/inspect-utils
 
+## \[2.1.6]
+
+- delegate `error` and `name` properties to underlying `Error`. fixes  https://github.com/thefrontside/effection/issues/675)
+  - Bumped due to a bump in effection.
+  - [84a66d7](https://github.com/thefrontside/effection/commit/84a66d799060ba2292fff2482d87bf6abafa7937) Delegate error properties to original error on 2022-10-05
+
 ## \[2.1.5]
 
 - `@effection/dispatch` was not listed as a dependency which led to it becoming out of sync with the latest.

--- a/packages/inspect-utils/package.json
+++ b/packages/inspect-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/inspect-utils",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "description": "Helper functions and types for inspecting effection applications",
   "main": "dist-cjs/index.js",
   "types": "dist-esm/index.d.ts",
@@ -28,9 +28,9 @@
     "mocha": "mocha -r ts-node/register"
   },
   "dependencies": {
-    "@effection/atom": "2.0.5",
-    "@effection/dispatch": "2.0.5",
-    "effection": "2.0.5"
+    "@effection/atom": "2.0.6",
+    "@effection/dispatch": "2.0.6",
+    "effection": "2.0.6"
   },
   "devDependencies": {
     "@frontside/tsconfig": "^1.2.0",

--- a/packages/inspect/CHANGELOG.md
+++ b/packages/inspect/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @effection/inspect
 
+## \[2.1.9]
+
+- delegate `error` and `name` properties to underlying `Error`. fixes  https://github.com/thefrontside/effection/issues/675)
+  - Bumped due to a bump in @effection/inspect-server.
+  - [84a66d7](https://github.com/thefrontside/effection/commit/84a66d799060ba2292fff2482d87bf6abafa7937) Delegate error properties to original error on 2022-10-05
+
 ## \[2.1.8]
 
 - These had unintentional preview publishes on a separate tag. Bumping and setting it to latest.

--- a/packages/inspect/package.json
+++ b/packages/inspect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/inspect",
-  "version": "2.1.8",
+  "version": "2.1.9",
   "description": "Injects an inspector into an Effection application",
   "main": "index.cjs.js",
   "module": "index.esm.js",
@@ -23,7 +23,7 @@
     "docs": "echo noop"
   },
   "dependencies": {
-    "@effection/inspect-server": "2.2.2"
+    "@effection/inspect-server": "2.2.3"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/jest/CHANGELOG.md
+++ b/packages/jest/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @effection/jest
 
+## \[2.0.4]
+
+- delegate `error` and `name` properties to underlying `Error`. fixes  https://github.com/thefrontside/effection/issues/675)
+  - Bumped due to a bump in effection.
+  - [84a66d7](https://github.com/thefrontside/effection/commit/84a66d799060ba2292fff2482d87bf6abafa7937) Delegate error properties to original error on 2022-10-05
+
 ## \[2.0.3]
 
 - Expose `formatError` so other packages can format errors the same way as `main`

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/jest",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Effection Integration for the Jest framework",
   "main": "dist-cjs/index.js",
   "module": "dist-esm/index.js",
@@ -26,7 +26,7 @@
     "prepack": "tsc --build tsconfig.esm.json && tsc --build tsconfig.cjs.json"
   },
   "dependencies": {
-    "effection": "2.0.5",
+    "effection": "2.0.6",
     "assert-ts": "^0.3.4"
   },
   "peerDependencies": {

--- a/packages/main/CHANGELOG.md
+++ b/packages/main/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @effection/main
 
+## \[2.1.1]
+
+- delegate `error` and `name` properties to underlying `Error`. fixes  https://github.com/thefrontside/effection/issues/675)
+  - Bumped due to a bump in @effection/core.
+  - [84a66d7](https://github.com/thefrontside/effection/commit/84a66d799060ba2292fff2482d87bf6abafa7937) Delegate error properties to original error on 2022-10-05
+
 ## \[2.1.0]
 
 - Expose `formatError` so other packages can format errors the same way as `main`

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/main",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Main entry point for Effection applications",
   "main": "dist-cjs/node.js",
   "module": "dist-esm/node.js",
@@ -28,7 +28,7 @@
     "mocha": "mocha -r ts-node/register"
   },
   "dependencies": {
-    "@effection/core": "2.2.0",
+    "@effection/core": "2.2.1",
     "chalk": "^4.1.2",
     "stacktrace-parser": "^0.1.10"
   },

--- a/packages/mocha/CHANGELOG.md
+++ b/packages/mocha/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @effection/mocha
 
+## \[2.0.6]
+
+- delegate `error` and `name` properties to underlying `Error`. fixes  https://github.com/thefrontside/effection/issues/675)
+  - Bumped due to a bump in effection.
+  - [84a66d7](https://github.com/thefrontside/effection/commit/84a66d799060ba2292fff2482d87bf6abafa7937) Delegate error properties to original error on 2022-10-05
+
 ## \[2.0.5]
 
 - Expose `formatError` so other packages can format errors the same way as `main`

--- a/packages/mocha/package.json
+++ b/packages/mocha/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/mocha",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Effection Subscriptions",
   "main": "dist-cjs/index.js",
   "module": "dist-esm/index.js",
@@ -27,7 +27,7 @@
     "mocha": "mocha -r ts-node/register"
   },
   "dependencies": {
-    "effection": "2.0.5"
+    "effection": "2.0.6"
   },
   "peerDependencies": {
     "mocha": "^8.0.0"

--- a/packages/process/CHANGELOG.md
+++ b/packages/process/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @effection/process
 
+## \[2.1.2]
+
+- delegate `error` and `name` properties to underlying `Error`. fixes  https://github.com/thefrontside/effection/issues/675)
+  - Bumped due to a bump in effection.
+  - [84a66d7](https://github.com/thefrontside/effection/commit/84a66d799060ba2292fff2482d87bf6abafa7937) Delegate error properties to original error on 2022-10-05
+
 ## \[2.1.1]
 
 - Bump the `ctrlc-windows` package to include the new build process and remove all dependencies.

--- a/packages/process/package.json
+++ b/packages/process/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/process",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Spawn and manage external processes with Effection",
   "main": "dist-cjs/index.js",
   "module": "dist-esm/index.js",
@@ -40,7 +40,7 @@
   "dependencies": {
     "cross-spawn": "^7.0.3",
     "ctrlc-windows": "^2.1.0",
-    "effection": "2.0.5",
+    "effection": "2.0.6",
     "shellwords": "^0.1.1"
   },
   "volta": {

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @effection/react
 
+## \[2.2.2]
+
+- delegate `error` and `name` properties to underlying `Error`. fixes  https://github.com/thefrontside/effection/issues/675)
+  - Bumped due to a bump in effection.
+  - [84a66d7](https://github.com/thefrontside/effection/commit/84a66d799060ba2292fff2482d87bf6abafa7937) Delegate error properties to original error on 2022-10-05
+
 ## \[2.2.1]
 
 - Expose `formatError` so other packages can format errors the same way as `main`

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/react",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Hooks for integrating effection into react applications",
   "main": "dist-cjs/index.js",
   "module": "dist-esm/index.js",
@@ -28,7 +28,7 @@
     "mocha": "mocha -r ts-node/register"
   },
   "dependencies": {
-    "effection": "2.0.5"
+    "effection": "2.0.6"
   },
   "devDependencies": {
     "@frontside/tsconfig": "^1.2.0",

--- a/packages/stream/CHANGELOG.md
+++ b/packages/stream/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## \[2.0.4]
+
+- delegate `error` and `name` properties to underlying `Error`. fixes  https://github.com/thefrontside/effection/issues/675)
+  - Bumped due to a bump in @effection/core.
+  - [84a66d7](https://github.com/thefrontside/effection/commit/84a66d799060ba2292fff2482d87bf6abafa7937) Delegate error properties to original error on 2022-10-05
+
 ## \[2.0.3]
 
 - Allow pass object with `Symbol.operation` as an operation

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/stream",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Effection Stream",
   "main": "dist-cjs/index.js",
   "module": "dist-esm/index.js",
@@ -28,8 +28,8 @@
     "mocha": "mocha -r ts-node/register"
   },
   "dependencies": {
-    "@effection/core": "2.2.0",
-    "@effection/subscription": "2.0.3"
+    "@effection/core": "2.2.1",
+    "@effection/subscription": "2.0.4"
   },
   "devDependencies": {
     "@frontside/tsconfig": "^1.2.0",

--- a/packages/subscription/CHANGELOG.md
+++ b/packages/subscription/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @effection/subscription
 
+## \[2.0.4]
+
+- delegate `error` and `name` properties to underlying `Error`. fixes  https://github.com/thefrontside/effection/issues/675)
+  - Bumped due to a bump in @effection/core.
+  - [84a66d7](https://github.com/thefrontside/effection/commit/84a66d799060ba2292fff2482d87bf6abafa7937) Delegate error properties to original error on 2022-10-05
+
 ## \[2.0.3]
 
 - Allow pass object with `Symbol.operation` as an operation

--- a/packages/subscription/package.json
+++ b/packages/subscription/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/subscription",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Effection Subscriptions",
   "main": "dist-cjs/index.js",
   "module": "dist-esm/index.js",
@@ -28,7 +28,7 @@
     "mocha": "mocha -r ts-node/register"
   },
   "dependencies": {
-    "@effection/core": "2.2.0"
+    "@effection/core": "2.2.1"
   },
   "devDependencies": {
     "@frontside/tsconfig": "^1.2.0",

--- a/packages/vitest/CHANGELOG.md
+++ b/packages/vitest/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @effection/vitest
 
+## \[2.0.1]
+
+- delegate `error` and `name` properties to underlying `Error`. fixes  https://github.com/thefrontside/effection/issues/675)
+  - Bumped due to a bump in effection.
+  - [84a66d7](https://github.com/thefrontside/effection/commit/84a66d799060ba2292fff2482d87bf6abafa7937) Delegate error properties to original error on 2022-10-05
+
 ## \[2.0.0]
 
 - Release @effection/vitest@2.0.0

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/vitest",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Effection Integration for the Vitest framework",
   "main": "dist-cjs/index.js",
   "module": "dist-esm/index.js",
@@ -26,7 +26,7 @@
     "prepack": "tsc --build tsconfig.esm.json && tsc --build tsconfig.cjs.json"
   },
   "dependencies": {
-    "effection": "2.0.5",
+    "effection": "2.0.6",
     "assert-ts": "^0.3.4"
   },
   "peerDependencies": {

--- a/packages/websocket-client/CHANGELOG.md
+++ b/packages/websocket-client/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @effection/websocket-client
 
+## \[2.0.6]
+
+- delegate `error` and `name` properties to underlying `Error`. fixes  https://github.com/thefrontside/effection/issues/675)
+  - Bumped due to a bump in effection.
+  - [84a66d7](https://github.com/thefrontside/effection/commit/84a66d799060ba2292fff2482d87bf6abafa7937) Delegate error properties to original error on 2022-10-05
+
 ## \[2.0.5]
 
 - Expose `formatError` so other packages can format errors the same way as `main`

--- a/packages/websocket-client/package.json
+++ b/packages/websocket-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/websocket-client",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "A websocket client for Effection in node and browser",
   "main": "dist-cjs/index.js",
   "module": "dist-esm/index.js",
@@ -28,7 +28,7 @@
     "mocha": "mocha -r ts-node/register"
   },
   "dependencies": {
-    "effection": "2.0.5",
+    "effection": "2.0.6",
     "isomorphic-ws": "^4.0.1"
   },
   "devDependencies": {

--- a/packages/websocket-server/CHANGELOG.md
+++ b/packages/websocket-server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @effection/websocket-server
 
+## \[2.0.6]
+
+- delegate `error` and `name` properties to underlying `Error`. fixes  https://github.com/thefrontside/effection/issues/675)
+  - Bumped due to a bump in effection.
+  - [84a66d7](https://github.com/thefrontside/effection/commit/84a66d799060ba2292fff2482d87bf6abafa7937) Delegate error properties to original error on 2022-10-05
+
 ## \[2.0.5]
 
 - Expose `formatError` so other packages can format errors the same way as `main`

--- a/packages/websocket-server/package.json
+++ b/packages/websocket-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/websocket-server",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "A simple websocket server for Effection",
   "main": "dist-cjs/index.js",
   "module": "dist-esm/index.js",
@@ -28,7 +28,7 @@
     "mocha": "mocha -r ts-node/register"
   },
   "dependencies": {
-    "effection": "2.0.5",
+    "effection": "2.0.6",
     "ws": "^7.4.6"
   },
   "devDependencies": {


### PR DESCRIPTION
# Version Updates

Merging this PR will release new versions of the following packages based on your change files.




# @effection/channel

## [2.0.4]
- delegate `error` and `name` properties to underlying `Error`. fixes  https://github.com/thefrontside/effection/issues/675)
  - Bumped due to a bump in @effection/core.
  - [84a66d7](https://github.com/thefrontside/effection/commit/84a66d799060ba2292fff2482d87bf6abafa7937) Delegate error properties to original error on 2022-10-05



# @effection/duplex-channel

## [2.0.6]
- delegate `error` and `name` properties to underlying `Error`. fixes  https://github.com/thefrontside/effection/issues/675)
  - Bumped due to a bump in effection.
  - [84a66d7](https://github.com/thefrontside/effection/commit/84a66d799060ba2292fff2482d87bf6abafa7937) Delegate error properties to original error on 2022-10-05



# @effection/dispatch

## [2.0.6]
- delegate `error` and `name` properties to underlying `Error`. fixes  https://github.com/thefrontside/effection/issues/675)
  - Bumped due to a bump in effection.
  - [84a66d7](https://github.com/thefrontside/effection/commit/84a66d799060ba2292fff2482d87bf6abafa7937) Delegate error properties to original error on 2022-10-05



# @effection/atom

## [2.0.6]
- delegate `error` and `name` properties to underlying `Error`. fixes  https://github.com/thefrontside/effection/issues/675)
  - Bumped due to a bump in effection.
  - [84a66d7](https://github.com/thefrontside/effection/commit/84a66d799060ba2292fff2482d87bf6abafa7937) Delegate error properties to original error on 2022-10-05



# @effection/core

## [2.2.1]
- delegate `error` and `name` properties to underlying `Error`. fixes  https://github.com/thefrontside/effection/issues/675)
  - [84a66d7](https://github.com/thefrontside/effection/commit/84a66d799060ba2292fff2482d87bf6abafa7937) Delegate error properties to original error on 2022-10-05



# effection

## [2.0.6]
- delegate `error` and `name` properties to underlying `Error`. fixes  https://github.com/thefrontside/effection/issues/675)
  - Bumped due to a bump in @effection/core.
  - [84a66d7](https://github.com/thefrontside/effection/commit/84a66d799060ba2292fff2482d87bf6abafa7937) Delegate error properties to original error on 2022-10-05



# @effection/events

## [2.0.4]
- delegate `error` and `name` properties to underlying `Error`. fixes  https://github.com/thefrontside/effection/issues/675)
  - Bumped due to a bump in @effection/core.
  - [84a66d7](https://github.com/thefrontside/effection/commit/84a66d799060ba2292fff2482d87bf6abafa7937) Delegate error properties to original error on 2022-10-05



# @effection/fetch

## [2.0.5]
- delegate `error` and `name` properties to underlying `Error`. fixes  https://github.com/thefrontside/effection/issues/675)
  - Bumped due to a bump in @effection/core.
  - [84a66d7](https://github.com/thefrontside/effection/commit/84a66d799060ba2292fff2482d87bf6abafa7937) Delegate error properties to original error on 2022-10-05



# @effection/inspect

## [2.1.9]
- delegate `error` and `name` properties to underlying `Error`. fixes  https://github.com/thefrontside/effection/issues/675)
  - Bumped due to a bump in @effection/inspect-server.
  - [84a66d7](https://github.com/thefrontside/effection/commit/84a66d799060ba2292fff2482d87bf6abafa7937) Delegate error properties to original error on 2022-10-05



# @effection/inspect-server

## [2.2.3]
- delegate `error` and `name` properties to underlying `Error`. fixes  https://github.com/thefrontside/effection/issues/675)
  - Bumped due to a bump in effection.
  - [84a66d7](https://github.com/thefrontside/effection/commit/84a66d799060ba2292fff2482d87bf6abafa7937) Delegate error properties to original error on 2022-10-05



# @effection/inspect-utils

## [2.1.6]
- delegate `error` and `name` properties to underlying `Error`. fixes  https://github.com/thefrontside/effection/issues/675)
  - Bumped due to a bump in effection.
  - [84a66d7](https://github.com/thefrontside/effection/commit/84a66d799060ba2292fff2482d87bf6abafa7937) Delegate error properties to original error on 2022-10-05



# @effection/main

## [2.1.1]
- delegate `error` and `name` properties to underlying `Error`. fixes  https://github.com/thefrontside/effection/issues/675)
  - Bumped due to a bump in @effection/core.
  - [84a66d7](https://github.com/thefrontside/effection/commit/84a66d799060ba2292fff2482d87bf6abafa7937) Delegate error properties to original error on 2022-10-05



# @effection/mocha

## [2.0.6]
- delegate `error` and `name` properties to underlying `Error`. fixes  https://github.com/thefrontside/effection/issues/675)
  - Bumped due to a bump in effection.
  - [84a66d7](https://github.com/thefrontside/effection/commit/84a66d799060ba2292fff2482d87bf6abafa7937) Delegate error properties to original error on 2022-10-05



# @effection/jest

## [2.0.4]
- delegate `error` and `name` properties to underlying `Error`. fixes  https://github.com/thefrontside/effection/issues/675)
  - Bumped due to a bump in effection.
  - [84a66d7](https://github.com/thefrontside/effection/commit/84a66d799060ba2292fff2482d87bf6abafa7937) Delegate error properties to original error on 2022-10-05



# @effection/process

## [2.1.2]
- delegate `error` and `name` properties to underlying `Error`. fixes  https://github.com/thefrontside/effection/issues/675)
  - Bumped due to a bump in effection.
  - [84a66d7](https://github.com/thefrontside/effection/commit/84a66d799060ba2292fff2482d87bf6abafa7937) Delegate error properties to original error on 2022-10-05



# @effection/react

## [2.2.2]
- delegate `error` and `name` properties to underlying `Error`. fixes  https://github.com/thefrontside/effection/issues/675)
  - Bumped due to a bump in effection.
  - [84a66d7](https://github.com/thefrontside/effection/commit/84a66d799060ba2292fff2482d87bf6abafa7937) Delegate error properties to original error on 2022-10-05



# @effection/subscription

## [2.0.4]
- delegate `error` and `name` properties to underlying `Error`. fixes  https://github.com/thefrontside/effection/issues/675)
  - Bumped due to a bump in @effection/core.
  - [84a66d7](https://github.com/thefrontside/effection/commit/84a66d799060ba2292fff2482d87bf6abafa7937) Delegate error properties to original error on 2022-10-05



# @effection/stream

## [2.0.4]
- delegate `error` and `name` properties to underlying `Error`. fixes  https://github.com/thefrontside/effection/issues/675)
  - Bumped due to a bump in @effection/core.
  - [84a66d7](https://github.com/thefrontside/effection/commit/84a66d799060ba2292fff2482d87bf6abafa7937) Delegate error properties to original error on 2022-10-05



# @effection/websocket-client

## [2.0.6]
- delegate `error` and `name` properties to underlying `Error`. fixes  https://github.com/thefrontside/effection/issues/675)
  - Bumped due to a bump in effection.
  - [84a66d7](https://github.com/thefrontside/effection/commit/84a66d799060ba2292fff2482d87bf6abafa7937) Delegate error properties to original error on 2022-10-05



# @effection/websocket-server

## [2.0.6]
- delegate `error` and `name` properties to underlying `Error`. fixes  https://github.com/thefrontside/effection/issues/675)
  - Bumped due to a bump in effection.
  - [84a66d7](https://github.com/thefrontside/effection/commit/84a66d799060ba2292fff2482d87bf6abafa7937) Delegate error properties to original error on 2022-10-05



# @effection/inspect-ui

## [2.3.2]
- delegate `error` and `name` properties to underlying `Error`. fixes  https://github.com/thefrontside/effection/issues/675)
  - Bumped due to a bump in effection.
  - [84a66d7](https://github.com/thefrontside/effection/commit/84a66d799060ba2292fff2482d87bf6abafa7937) Delegate error properties to original error on 2022-10-05



# @effection/vitest

## [2.0.1]
- delegate `error` and `name` properties to underlying `Error`. fixes  https://github.com/thefrontside/effection/issues/675)
  - Bumped due to a bump in effection.
  - [84a66d7](https://github.com/thefrontside/effection/commit/84a66d799060ba2292fff2482d87bf6abafa7937) Delegate error properties to original error on 2022-10-05