### PR TITLE
Publish New Versions

### DIFF
--- a/.changes/vitest.md
+++ b/.changes/vitest.md
@@ -1,5 +1,0 @@
----
-"@effection/vitest": patch
----
-
-Make @effection/vitest esm only.

--- a/packages/vitest/CHANGELOG.md
+++ b/packages/vitest/CHANGELOG.md
@@ -1,5 +1,10 @@
 # @effection/vitest
 
+## \[2.0.2]
+
+- Make @effection/vitest esm only.
+  - [a5350c4](https://github.com/thefrontside/effection/commit/a5350c4613306747322580c63ce471141ec63872) remove all cjs from @effection/vitest ([#678](https://github.com/thefrontside/effection/pull/678)) on 2022-11-08
+
 ## \[2.0.1]
 
 - delegate `error` and `name` properties to underlying `Error`. fixes  https://github.com/thefrontside/effection/issues/675)

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/vitest",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Effection Integration for the Vitest framework",
   "types": "dist-esm/index.d.ts",
   "type": "module",


### PR DESCRIPTION
# Version Updates

Merging this PR will release new versions of the following packages based on your change files.




# @effection/vitest

## [2.0.2]
- Make @effection/vitest esm only.
  - [a5350c4](https://github.com/thefrontside/effection/commit/a5350c4613306747322580c63ce471141ec63872) remove all cjs from @effection/vitest ([#678](https://github.com/thefrontside/effection/pull/678)) on 2022-11-08