### PR TITLE
add require to @effction/vitest package.json exports

### DIFF
--- a/.changes/add-require-to-vitest-exports.md
+++ b/.changes/add-require-to-vitest-exports.md
@@ -1,0 +1,5 @@
+---
+"@effection/vitest": minor
+---
+
+Add cjs support to @effection/vitest by adding require to package imports

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -3,10 +3,11 @@
   "version": "2.0.2",
   "description": "Effection Integration for the Vitest framework",
   "types": "dist-esm/index.d.ts",
-  "type": "module",
+  "main": "dist-cjs/index.js",
   "module": "dist-esm/index.js",
   "exports": {
-    "import": "./dist-esm/index.js"
+    "import": "./dist-esm/index.js",
+    "require": "./dist-cjs/index.js"
   },
   "typeDocEntry": "src/index.ts",
   "homepage": "https://frontside.com/effection",
@@ -26,7 +27,7 @@
   "scripts": {
     "lint": "eslint '{src,tests}/**/*.ts'",
     "test": "vitest",
-    "prepack": "tsc --build tsconfig.esm.json"
+    "prepack": "tsc --build tsconfig.esm.json && tsc --build tsconfig.cjs.json"
   },
   "dependencies": {
     "effection": "2.0.6",
@@ -42,5 +43,8 @@
     "vite": "^3.2.3",
     "vite-plugin-checker": "^0.5.1",
     "vitest": "^0.25.0"
+  },
+  "volta": {
+    "extends": "../../package.json"
   }
 }

--- a/packages/vitest/tsconfig.cjs.json
+++ b/packages/vitest/tsconfig.cjs.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist-cjs",
+    "noEmit": false
+  },
+  "references": [{ "path": "../core/tsconfig.cjs.json" }],
+  "exclude": ["./test/*"]
+}

--- a/packages/vitest/tsconfig.esm.json
+++ b/packages/vitest/tsconfig.esm.json
@@ -1,5 +1,5 @@
 {
-  "extends": "./tsconfig",
+  "extends": "./tsconfig.cjs.json",
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist-esm",


### PR DESCRIPTION
## Motivation

Not sure how this did not make it in the last release.  Maybe I did not push.

This PR is to stop us having to make everything esm with `"type": "module"` in the package.json etc. which might be hugely problematic in repos like backstage.

## Approach

add a `cjs` require to the `@effection/vitest` package.json exports.