### PR TITLE
✨Mark as side-effect free so that bundlers can tree-shake

### DIFF
--- a/tasks/build-npm.ts
+++ b/tasks/build-npm.ts
@@ -39,6 +39,7 @@ await build({
     engines: {
       node: ">= 16",
     },
+    sideEffects: false,
   },
 });
 


### PR DESCRIPTION
## Motivation
If anybody is bundling Effection, they might want want to [tree-shake][] it and only bundle those functions and constants that are used.

## Approach
This marks the NPM package built by DNT as "side-effect" free. In other words, no modules are imported purely for their side-effects like mutating a global variable or doing something els.

[tree-shake]: https://webpack.js.org/guides/tree-shaking/
