### PR TITLE
migrate events

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -32,5 +32,12 @@
         "packages"
       ]
     }
+  },
+  "compilerOptions": {
+    "lib": [
+      "esnext",
+      "dom",
+      "dom.iterable"
+    ]
   }
 }

--- a/deno.lock
+++ b/deno.lock
@@ -15,19 +15,8 @@
     "https://deno.land/x/expect@v0.3.0/matchers.ts": "a37ef4577739247af77a852cdcd69484f999a41ad86ec16bb63a88a7a47a2372",
     "https://deno.land/x/expect@v0.3.0/mock.ts": "562d4b1d735d15b0b8e935f342679096b64fe452f86e96714fe8616c0c884914",
     "https://deno.land/x/expect@v0.3.0/mod.ts": "0304d2430e1e96ba669a8495e24ba606dcc3d152e1f81aaa8da898cea24e36c2",
-    "https://esm.sh/ts-expect@1.3.0": "c5a28d141915c0a7722ef2a1bb807f469b395c3485f9626d7deeffb71989f055",
-    "https://esm.sh/v119/ts-expect@1.3.0/deno/ts-expect.mjs": "c7b69ca5c89607901c927026c39c44c322733cf2081ab44cc3b46a75edb7d43a",
-    "https://esm.sh/v119/ts-expect@1.3.0/dist/index.d.ts": "d3b5df65f830ba8273665821d1f59946cd92acef455339a0ab53f5fd4c36d09e"
-  },
-  "npm": {
-    "specifiers": {
-      "@types/node": "@types/node@18.11.18"
-    },
-    "packages": {
-      "@types/node@18.11.18": {
-        "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==",
-        "dependencies": {}
-      }
-    }
+    "https://esm.sh/ts-expect@1.3.0": "a8e541153b7fc969864df0f2dbdda761ea2bbc1adde46fb67519bebcdd93a922",
+    "https://esm.sh/v124/ts-expect@1.3.0/deno/ts-expect.mjs": "c7b69ca5c89607901c927026c39c44c322733cf2081ab44cc3b46a75edb7d43a",
+    "https://esm.sh/v124/ts-expect@1.3.0/dist/index.d.ts": "d3b5df65f830ba8273665821d1f59946cd92acef455339a0ab53f5fd4c36d09e"
   }
 }

--- a/deno.lock
+++ b/deno.lock
@@ -18,5 +18,16 @@
     "https://esm.sh/ts-expect@1.3.0": "c5a28d141915c0a7722ef2a1bb807f469b395c3485f9626d7deeffb71989f055",
     "https://esm.sh/v119/ts-expect@1.3.0/deno/ts-expect.mjs": "c7b69ca5c89607901c927026c39c44c322733cf2081ab44cc3b46a75edb7d43a",
     "https://esm.sh/v119/ts-expect@1.3.0/dist/index.d.ts": "d3b5df65f830ba8273665821d1f59946cd92acef455339a0ab53f5fd4c36d09e"
+  },
+  "npm": {
+    "specifiers": {
+      "@types/node": "@types/node@18.11.18"
+    },
+    "packages": {
+      "@types/node@18.11.18": {
+        "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==",
+        "dependencies": {}
+      }
+    }
   }
 }

--- a/lib/deps.ts
+++ b/lib/deps.ts
@@ -1,3 +1,2 @@
 export { assert } from "https://deno.land/std@0.158.0/testing/asserts.ts";
 export * from "https://deno.land/x/continuation@0.1.5/mod.ts";
-export { expectType } from "https://esm.sh/ts-expect@1.3.0";

--- a/lib/deps.ts
+++ b/lib/deps.ts
@@ -1,2 +1,3 @@
 export { assert } from "https://deno.land/std@0.158.0/testing/asserts.ts";
 export * from "https://deno.land/x/continuation@0.1.5/mod.ts";
+export { expectType } from "https://esm.sh/ts-expect@1.3.0";

--- a/lib/events.ts
+++ b/lib/events.ts
@@ -1,8 +1,10 @@
 // deno-lint-ignore-file no-explicit-any ban-types
 import { createChannel } from "./channel.ts";
-import { action, resource, suspend } from "./instructions.ts";
+import { resource } from "./instructions.ts";
+import { first } from "./mod.ts";
 import { useScope } from "./run/scope.ts";
 import type { Operation, Stream } from "./types.ts";
+import { EventEmitter } from "node:events";
 
 type FN = (...any: any[]) => any;
 
@@ -17,91 +19,38 @@ export type EventList<T> = T extends {
 } ? P & string
   : never;
 
-/**
- * Takes an event source and event name and returns an
- * {@link effection:Operation} that produces the value emitted by that
- * event. Both {@link EventTarget} and {@link EventEmitter} are
- * supported.
- *
- * ### Example
- *
- * ``` javascript
- * let start = yield once(document, 'dragstart');
- * console.log(`drag started at (${start.pageX}, ${start.pageY})`);
- *
- * let end = yield once(document, 'dragend');
- * console.log(`drag ended at (${end.pageX}, ${end.pageY})`);
- * ```
- *
- * ### Example
- *
- * ``` javascript
- * let src = yield once(stream, 'pipe');
- * ```
- *
- * @param source an object which emits events
- * @param eventName the name of the event to subscribe to
- * @typeParam T the type of the argument to the emitted event
- */
 export function once<
-  T extends EventTarget,
+  T extends EventTarget | EventEmitter,
   K extends EventList<T> | (string & {}),
 >(target: T, name: K): Operation<EventTypeFromEventTarget<T, K>> {
-  return action(function* (resolve) {
-    target.addEventListener(
-      name,
-      resolve as EventListenerOrEventListenerObject,
-    );
+  return resource(function* (provide) {
+    let { input, output } = createChannel<Event, never>();
+    let scope = yield* useScope();
+
+    let listener = (event: Event) => scope.run(() => input.send(event));
+
+    if ("addEventListener" in target) {
+      target.addEventListener(name, listener);
+    } else if ("addListener" in target) {
+      target.addListener(name, listener);
+    }
+
     try {
-      yield* suspend();
-    } finally {
-      target.removeEventListener(
-        name,
-        resolve as EventListenerOrEventListenerObject,
+      yield* provide(
+        yield* first(output as Stream<EventTypeFromEventTarget<T, K>, never>),
       );
+    } finally {
+      if ("removeEventListener" in target) {
+        target.removeEventListener(name, listener);
+      } else {
+        target.removeListener(name, listener);
+      }
     }
   });
 }
 
-/**
- * Creates a `Stream` from an event source and event name that
- * produces the event as its next value every time that the source
- * raises it. Streams created in this way are infinite.
- *
- * Both
- * [`EventTarget`](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget)
- * from the browser DOM and
- * [`EventEmitter`](https://nodejs.org/api/events.html#events_class_eventemitter)
- * from node are supported.
- *
- * ### Example
- *
- * log every click in a web page:
- *
- * ```javascript
- * yield spawn(on(document, 'click').forEach(event => {
- *   console.log(`click at (${event.pageX}, ${event.pageY})`);
- * }));
- * ```
- *
- * ### Example
- *
- * buffer a node process's stdin into a single string:
- *
- * ```javascript
- * let buffer = '';
- * yield spawn(on(process.stdin, 'data').forEach(data => {
- *   buffer += data;
- * }));
- * ```
- *
- * @param source an object which emits events
- * @param name the name of the event to subscribe to
- * @param streamName the name of the returned stream, useful for debugging
- * @typeParam T the type of the argument to the emitted event
- */
 export function on<
-  T extends EventTarget,
+  T extends EventTarget | EventEmitter,
   K extends EventList<T> | (string & {}),
 >(target: T, name: K): Stream<EventTypeFromEventTarget<T, K>, never> {
   return resource(function* (provide) {
@@ -109,14 +58,22 @@ export function on<
     let scope = yield* useScope();
     let listener = (event: Event) => scope.run(() => input.send(event));
 
-    target.addEventListener(name, listener);
+    if ("addEventListener" in target) {
+      target.addEventListener(name, listener);
+    } else if ("addListener" in target) {
+      target.addListener(name, listener);
+    }
 
     try {
       yield* provide(
         yield* output as Stream<EventTypeFromEventTarget<T, K>, never>,
       );
     } finally {
-      target.removeEventListener(name, listener);
+      if ("removeEventListener" in target) {
+        target.removeEventListener(name, listener);
+      } else {
+        target.removeListener(name, listener);
+      }
     }
   });
 }

--- a/lib/events.ts
+++ b/lib/events.ts
@@ -4,7 +4,6 @@ import { resource } from "./instructions.ts";
 import { first } from "./mod.ts";
 import { useScope } from "./run/scope.ts";
 import type { Operation, Stream } from "./types.ts";
-import { assert } from "./deps.ts";
 
 type FN = (...any: any[]) => any;
 
@@ -19,40 +18,14 @@ export type EventList<T> = T extends {
 } ? P & string
   : never;
 
-function _once<
+export function once<
   T extends EventTarget,
   K extends EventList<T> | (string & {}),
 >(target: T, name: K): Operation<EventTypeFromEventTarget<T, K>> {
   return first(on(target, name));
 }
 
-export function once<
-  T extends EventTarget,
-  K extends EventList<T> | (string & {}),
->(target: T, name: K): Operation<EventTypeFromEventTarget<T, K>> {
-  return _once(target, name);
-}
-
-export function onceFP<
-  T extends EventTarget,
-  K extends EventList<T> | (string & {}),
->(name: K): (target: T) => Operation<EventTypeFromEventTarget<T, K>>;
-export function onceFP<
-  T extends EventTarget,
-  K extends EventList<T> | (string & {}),
->(this: unknown, name: K, target?: T): unknown {
-  const fn = onceFP<T, K>;
-
-  if (arguments.length < 2) {
-    return fn.bind(this, name);
-  }
-
-  assert(target, `once target undefined`);
-
-  return _once(target, name);
-}
-
-function _on<
+export function on<
   T extends EventTarget,
   K extends EventList<T> | (string & {}),
 >(target: T, name: K): Stream<EventTypeFromEventTarget<T, K>, never> {
@@ -71,30 +44,4 @@ function _on<
       target.removeEventListener(name, listener);
     }
   });
-}
-
-export function on<
-  T extends EventTarget,
-  K extends EventList<T> | (string & {}),
->(target: T, name: K): Stream<EventTypeFromEventTarget<T, K>, never> {
-  return _on(target, name);
-}
-
-export function onFP<
-  T extends EventTarget,
-  K extends EventList<T> | (string & {}),
->(name: K): (target: T) => Stream<EventTypeFromEventTarget<T, K>, never>;
-export function onFP<
-  T extends EventTarget,
-  K extends EventList<T> | (string & {}),
->(this: unknown, name: K, target?: T): unknown {
-  const fn = onFP<T, K>;
-
-  if (arguments.length < 2) {
-    return fn.bind(this, name);
-  }
-
-  assert(target, `on target undefined`);
-
-  return _on(target, name);
 }

--- a/lib/events.ts
+++ b/lib/events.ts
@@ -1,10 +1,10 @@
 // deno-lint-ignore-file no-explicit-any ban-types
 import { createChannel } from "./channel.ts";
-import { assert } from "./deps.ts";
 import { resource } from "./instructions.ts";
 import { first } from "./mod.ts";
 import { useScope } from "./run/scope.ts";
 import type { Operation, Stream } from "./types.ts";
+import { assert } from "./deps.ts";
 
 type FN = (...any: any[]) => any;
 
@@ -19,19 +19,29 @@ export type EventList<T> = T extends {
 } ? P & string
   : never;
 
+function _once<
+  T extends EventTarget,
+  K extends EventList<T> | (string & {}),
+>(target: T, name: K): Operation<EventTypeFromEventTarget<T, K>> {
+  return first(on(target, name));
+}
+
 export function once<
+  T extends EventTarget,
+  K extends EventList<T> | (string & {}),
+>(target: T, name: K): Operation<EventTypeFromEventTarget<T, K>> {
+  return _once(target, name);
+}
+
+export function onceFP<
   T extends EventTarget,
   K extends EventList<T> | (string & {}),
 >(name: K): (target: T) => Operation<EventTypeFromEventTarget<T, K>>;
-export function once<
-  T extends EventTarget,
-  K extends EventList<T> | (string & {}),
->(name: K, target: T): Operation<EventTypeFromEventTarget<T, K>>;
-export function once<
+export function onceFP<
   T extends EventTarget,
   K extends EventList<T> | (string & {}),
 >(this: unknown, name: K, target?: T): unknown {
-  const fn = once<T, K>;
+  const fn = onceFP<T, K>;
 
   if (arguments.length < 2) {
     return fn.bind(this, name);
@@ -39,29 +49,13 @@ export function once<
 
   assert(target, `once target undefined`);
 
-  return first(on(name, target));
+  return _once(target, name);
 }
 
-export function on<
+function _on<
   T extends EventTarget,
   K extends EventList<T> | (string & {}),
->(name: K): (target: T) => Stream<EventTypeFromEventTarget<T, K>, never>;
-export function on<
-  T extends EventTarget,
-  K extends EventList<T> | (string & {}),
->(name: K, target: T): Stream<EventTypeFromEventTarget<T, K>, never>;
-export function on<
-  T extends EventTarget,
-  K extends EventList<T> | (string & {}),
->(this: unknown, name: K, target?: T): unknown {
-  const fn = on<T, K>;
-
-  if (arguments.length < 2) {
-    return fn.bind(this, name);
-  }
-
-  assert(target, `on target undefined`);
-
+>(target: T, name: K): Stream<EventTypeFromEventTarget<T, K>, never> {
   return resource(function* (provide) {
     let { input, output } = createChannel<Event, never>();
     let scope = yield* useScope();
@@ -77,4 +71,30 @@ export function on<
       target.removeEventListener(name, listener);
     }
   });
+}
+
+export function on<
+  T extends EventTarget,
+  K extends EventList<T> | (string & {}),
+>(target: T, name: K): Stream<EventTypeFromEventTarget<T, K>, never> {
+  return _on(target, name);
+}
+
+export function onFP<
+  T extends EventTarget,
+  K extends EventList<T> | (string & {}),
+>(name: K): (target: T) => Stream<EventTypeFromEventTarget<T, K>, never>;
+export function onFP<
+  T extends EventTarget,
+  K extends EventList<T> | (string & {}),
+>(this: unknown, name: K, target?: T): unknown {
+  const fn = onFP<T, K>;
+
+  if (arguments.length < 2) {
+    return fn.bind(this, name);
+  }
+
+  assert(target, `on target undefined`);
+
+  return _on(target, name);
 }

--- a/lib/events.ts
+++ b/lib/events.ts
@@ -22,22 +22,7 @@ export function once<
   T extends EventTarget,
   K extends EventList<T> | (string & {}),
 >(target: T, name: K): Operation<EventTypeFromEventTarget<T, K>> {
-  return resource(function* (provide) {
-    let { input, output } = createChannel<Event, never>();
-    let scope = yield* useScope();
-
-    let listener = (event: Event) => scope.run(() => input.send(event));
-
-    target.addEventListener(name, listener);
-
-    try {
-      yield* provide(
-        yield* first(output as Stream<EventTypeFromEventTarget<T, K>, never>),
-      );
-    } finally {
-      target.removeEventListener(name, listener);
-    }
-  });
+  return first(on(target, name));
 }
 
 export function on<

--- a/lib/events.ts
+++ b/lib/events.ts
@@ -1,0 +1,122 @@
+// deno-lint-ignore-file no-explicit-any ban-types
+import { createChannel } from "./channel.ts";
+import { action, resource, suspend } from "./instructions.ts";
+import { useScope } from "./run/scope.ts";
+import type { Operation, Stream } from "./types.ts";
+
+type FN = (...any: any[]) => any;
+
+type EventTypeFromEventTarget<T, K extends string> = `on${K}` extends keyof T
+  ? Parameters<Extract<T[`on${K}`], FN>>[0]
+  : Event;
+
+export type EventList<T> = T extends {
+  addEventListener(type: infer P, ...args: any): void;
+  // we basically ignore this but we need it so we always get the first override of addEventListener
+  addEventListener(type: infer P2, ...args: any): void;
+} ? P & string
+  : never;
+
+/**
+ * Takes an event source and event name and returns an
+ * {@link effection:Operation} that produces the value emitted by that
+ * event. Both {@link EventTarget} and {@link EventEmitter} are
+ * supported.
+ *
+ * ### Example
+ *
+ * ``` javascript
+ * let start = yield once(document, 'dragstart');
+ * console.log(`drag started at (${start.pageX}, ${start.pageY})`);
+ *
+ * let end = yield once(document, 'dragend');
+ * console.log(`drag ended at (${end.pageX}, ${end.pageY})`);
+ * ```
+ *
+ * ### Example
+ *
+ * ``` javascript
+ * let src = yield once(stream, 'pipe');
+ * ```
+ *
+ * @param source an object which emits events
+ * @param eventName the name of the event to subscribe to
+ * @typeParam T the type of the argument to the emitted event
+ */
+export function once<
+  T extends EventTarget,
+  K extends EventList<T> | (string & {}),
+>(target: T, name: K): Operation<EventTypeFromEventTarget<T, K>> {
+  return action(function* (resolve) {
+    target.addEventListener(
+      name,
+      resolve as EventListenerOrEventListenerObject,
+    );
+    try {
+      yield* suspend();
+    } finally {
+      target.removeEventListener(
+        name,
+        resolve as EventListenerOrEventListenerObject,
+      );
+    }
+  });
+}
+
+/**
+ * Creates a `Stream` from an event source and event name that
+ * produces the event as its next value every time that the source
+ * raises it. Streams created in this way are infinite.
+ *
+ * Both
+ * [`EventTarget`](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget)
+ * from the browser DOM and
+ * [`EventEmitter`](https://nodejs.org/api/events.html#events_class_eventemitter)
+ * from node are supported.
+ *
+ * ### Example
+ *
+ * log every click in a web page:
+ *
+ * ```javascript
+ * yield spawn(on(document, 'click').forEach(event => {
+ *   console.log(`click at (${event.pageX}, ${event.pageY})`);
+ * }));
+ * ```
+ *
+ * ### Example
+ *
+ * buffer a node process's stdin into a single string:
+ *
+ * ```javascript
+ * let buffer = '';
+ * yield spawn(on(process.stdin, 'data').forEach(data => {
+ *   buffer += data;
+ * }));
+ * ```
+ *
+ * @param source an object which emits events
+ * @param name the name of the event to subscribe to
+ * @param streamName the name of the returned stream, useful for debugging
+ * @typeParam T the type of the argument to the emitted event
+ */
+export function on<
+  T extends EventTarget,
+  K extends EventList<T> | (string & {}),
+>(target: T, name: K): Stream<EventTypeFromEventTarget<T, K>, never> {
+  return resource(function* (provide) {
+    let { input, output } = createChannel<Event, never>();
+    let scope = yield* useScope();
+    let listener = (event: Event) => scope.run(() => input.send(event));
+
+    target.addEventListener(name, listener);
+
+    try {
+      yield* provide(
+        yield* output as Stream<EventTypeFromEventTarget<T, K>, never>,
+      );
+    } finally {
+      target.removeEventListener(name, listener);
+    }
+  });
+}

--- a/lib/mod.ts
+++ b/lib/mod.ts
@@ -14,3 +14,4 @@ export * from "./map.ts";
 export * from "./filter.ts";
 export * from "./pipe.ts";
 export * from "./op.ts";
+export * from "./events.ts";

--- a/test/events.test.ts
+++ b/test/events.test.ts
@@ -1,4 +1,4 @@
-import { on, once } from "../mod.ts";
+import { on, once, pipe } from "../mod.ts";
 import type { Operation, Stream } from "../mod.ts";
 import { describe, expectType, it } from "./suite.ts";
 
@@ -7,18 +7,40 @@ describe("events", () => {
     const domElement = {} as HTMLElement;
     const socket = {} as WebSocket;
 
-    it("should find event from eventTarget", () => {
-      expectType<Operation<CloseEvent>>(once(socket, "close"));
-      expectType<Operation<MouseEvent>>(once(domElement, "click"));
+    describe("once", () => {
+      it("should find event from eventTarget", () => {
+        expectType<Operation<CloseEvent>>(pipe(socket, once("close")));
 
-      // deno-lint-ignore no-explicit-any
-      expectType<Stream<MessageEvent<any>, never>>(on(socket, "message"));
+        expectType<Operation<MouseEvent>>(once("click", domElement));
+      });
+
+      it("should fall back to event", () => {
+        expectType<Operation<Event>>(
+          pipe(domElement, once("anothercustomevent")),
+        );
+
+        expectType<Operation<Event>>(once("anothercustomevent", domElement));
+      });
     });
 
-    it("should fall back to event", () => {
-      expectType<Operation<Event>>(once(domElement, "mycustomevent"));
+    describe("on", () => {
+      it("should find event from eventTarget", () => {
+        // deno-lint-ignore no-explicit-any
+        expectType<Stream<MessageEvent<any>, never>>(
+          pipe(socket, on("message")),
+        );
 
-      expectType<Stream<Event, never>>(on(domElement, "anothercustomevent"));
+        // deno-lint-ignore no-explicit-any
+        expectType<Stream<MessageEvent<any>, never>>(on("message", socket));
+      });
+
+      it("should fall back to event", () => {
+        expectType<Stream<Event, never>>(
+          pipe(domElement, on("anothercustomevent")),
+        );
+
+        expectType<Stream<Event, never>>(on("anothercustomevent", domElement));
+      });
     });
   });
 });

--- a/test/events.test.ts
+++ b/test/events.test.ts
@@ -1,0 +1,23 @@
+import { expectType } from "../lib/deps.ts";
+import { on, once } from "../mod.ts";
+import type { Operation, Stream } from "../mod.ts";
+import { describe, it } from "./suite.ts";
+
+describe("events", () => {
+  const domElement = {} as HTMLElement;
+  let socket = {} as WebSocket;
+
+  it("should find event from eventTarget", () => {
+    expectType<Operation<CloseEvent>>(once(socket, "close"));
+    expectType<Operation<MouseEvent>>(once(domElement, "click"));
+
+    // deno-lint-ignore no-explicit-any
+    expectType<Stream<MessageEvent<any>, never>>(on(socket, "message"));
+  });
+
+  it("should fall back to event", () => {
+    expectType<Operation<Event>>(once(domElement, "mycustomevent"));
+
+    expectType<Stream<Event, never>>(on(domElement, "anothercustomevent"));
+  });
+});

--- a/test/events.test.ts
+++ b/test/events.test.ts
@@ -1,22 +1,56 @@
-import { on, once } from "../mod.ts";
+import { on, once, run } from "../mod.ts";
 import type { Operation, Stream } from "../mod.ts";
-import { describe, expectType, it } from "./suite.ts";
+import { describe, expect, expectType, it } from "./suite.ts";
+import { EventEmitter } from "node:events";
 
 describe("events", () => {
-  const domElement = {} as HTMLElement;
-  let socket = {} as WebSocket;
+  describe("eventEmitter", () => {
+    it("on", () =>
+      run(function* () {
+        let eventEmitter = new EventEmitter();
+        let subscription = yield* on(eventEmitter, "event");
 
-  it("should find event from eventTarget", () => {
-    expectType<Operation<CloseEvent>>(once(socket, "close"));
-    expectType<Operation<MouseEvent>>(once(domElement, "click"));
+        eventEmitter.emit("event", 1);
 
-    // deno-lint-ignore no-explicit-any
-    expectType<Stream<MessageEvent<any>, never>>(on(socket, "message"));
+        let next = yield* subscription.next();
+
+        expect(next).toEqual({ done: false, value: 1 });
+      }));
+
+    it("once", () =>
+      run(function* () {
+        let eventEmitter = new EventEmitter();
+        let subscription = yield* on(eventEmitter, "event");
+
+        eventEmitter.emit("event", 1);
+
+        let next = yield* subscription.next();
+
+        expect(next).toEqual({ done: false, value: 1 });
+      }));
   });
 
-  it("should fall back to event", () => {
-    expectType<Operation<Event>>(once(domElement, "mycustomevent"));
+  describe("types", () => {
+    const domElement = {} as HTMLElement;
+    const socket = {} as WebSocket;
 
-    expectType<Stream<Event, never>>(on(domElement, "anothercustomevent"));
+    it("should find event from eventTarget", () => {
+      expectType<Operation<CloseEvent>>(once(socket, "close"));
+      expectType<Operation<MouseEvent>>(once(domElement, "click"));
+
+      // deno-lint-ignore no-explicit-any
+      expectType<Stream<MessageEvent<any>, never>>(on(socket, "message"));
+    });
+
+    it("should fall back to event", () => {
+      expectType<Operation<Event>>(once(domElement, "mycustomevent"));
+
+      expectType<Stream<Event, never>>(on(domElement, "anothercustomevent"));
+    });
+
+    it("should type eventEmitter", () => {
+      let eventEmitter = new EventEmitter();
+      expectType<Stream<Event, never>>(on(eventEmitter, "event"));
+    });
   });
 });

--- a/test/events.test.ts
+++ b/test/events.test.ts
@@ -1,4 +1,4 @@
-import { on, once, onceFP, onFP, pipe } from "../mod.ts";
+import { on, once } from "../mod.ts";
 import type { Operation, Stream } from "../mod.ts";
 import { describe, expectType, it } from "./suite.ts";
 
@@ -7,40 +7,18 @@ describe("events", () => {
     const domElement = {} as HTMLElement;
     const socket = {} as WebSocket;
 
-    describe("once", () => {
-      it("should find event from eventTarget", () => {
-        expectType<Operation<CloseEvent>>(pipe(socket, onceFP("close")));
+    it("should find event from eventTarget", () => {
+      expectType<Operation<CloseEvent>>(once(socket, "close"));
+      expectType<Operation<MouseEvent>>(once(domElement, "click"));
 
-        expectType<Operation<MouseEvent>>(once(domElement, "click"));
-      });
-
-      it("should fall back to event", () => {
-        expectType<Operation<Event>>(
-          pipe(domElement, onceFP("anothercustomevent")),
-        );
-
-        expectType<Operation<Event>>(once(domElement, "anothercustomevent"));
-      });
+      // deno-lint-ignore no-explicit-any
+      expectType<Stream<MessageEvent<any>, never>>(on(socket, "message"));
     });
 
-    describe("on", () => {
-      it("should find event from eventTarget", () => {
-        // deno-lint-ignore no-explicit-any
-        expectType<Stream<MessageEvent<any>, never>>(
-          pipe(socket, onFP("message")),
-        );
+    it("should fall back to event", () => {
+      expectType<Operation<Event>>(once(domElement, "mycustomevent"));
 
-        // deno-lint-ignore no-explicit-any
-        expectType<Stream<MessageEvent<any>, never>>(on(socket, "message"));
-      });
-
-      it("should fall back to event", () => {
-        expectType<Stream<Event, never>>(
-          pipe(domElement, onFP("anothercustomevent")),
-        );
-
-        expectType<Stream<Event, never>>(on(domElement, "anothercustomevent"));
-      });
+      expectType<Stream<Event, never>>(on(domElement, "anothercustomevent"));
     });
   });
 });

--- a/test/events.test.ts
+++ b/test/events.test.ts
@@ -1,7 +1,6 @@
-import { expectType } from "../lib/deps.ts";
 import { on, once } from "../mod.ts";
 import type { Operation, Stream } from "../mod.ts";
-import { describe, it } from "./suite.ts";
+import { describe, expectType, it } from "./suite.ts";
 
 describe("events", () => {
   const domElement = {} as HTMLElement;

--- a/test/events.test.ts
+++ b/test/events.test.ts
@@ -1,4 +1,4 @@
-import { on, once, pipe } from "../mod.ts";
+import { on, once, onceFP, onFP, pipe } from "../mod.ts";
 import type { Operation, Stream } from "../mod.ts";
 import { describe, expectType, it } from "./suite.ts";
 
@@ -9,17 +9,17 @@ describe("events", () => {
 
     describe("once", () => {
       it("should find event from eventTarget", () => {
-        expectType<Operation<CloseEvent>>(pipe(socket, once("close")));
+        expectType<Operation<CloseEvent>>(pipe(socket, onceFP("close")));
 
-        expectType<Operation<MouseEvent>>(once("click", domElement));
+        expectType<Operation<MouseEvent>>(once(domElement, "click"));
       });
 
       it("should fall back to event", () => {
         expectType<Operation<Event>>(
-          pipe(domElement, once("anothercustomevent")),
+          pipe(domElement, onceFP("anothercustomevent")),
         );
 
-        expectType<Operation<Event>>(once("anothercustomevent", domElement));
+        expectType<Operation<Event>>(once(domElement, "anothercustomevent"));
       });
     });
 
@@ -27,19 +27,19 @@ describe("events", () => {
       it("should find event from eventTarget", () => {
         // deno-lint-ignore no-explicit-any
         expectType<Stream<MessageEvent<any>, never>>(
-          pipe(socket, on("message")),
+          pipe(socket, onFP("message")),
         );
 
         // deno-lint-ignore no-explicit-any
-        expectType<Stream<MessageEvent<any>, never>>(on("message", socket));
+        expectType<Stream<MessageEvent<any>, never>>(on(socket, "message"));
       });
 
       it("should fall back to event", () => {
         expectType<Stream<Event, never>>(
-          pipe(domElement, on("anothercustomevent")),
+          pipe(domElement, onFP("anothercustomevent")),
         );
 
-        expectType<Stream<Event, never>>(on("anothercustomevent", domElement));
+        expectType<Stream<Event, never>>(on(domElement, "anothercustomevent"));
       });
     });
   });

--- a/test/events.test.ts
+++ b/test/events.test.ts
@@ -1,35 +1,8 @@
-import { on, once, run } from "../mod.ts";
+import { on, once } from "../mod.ts";
 import type { Operation, Stream } from "../mod.ts";
-import { describe, expect, expectType, it } from "./suite.ts";
-import { EventEmitter } from "node:events";
+import { describe, expectType, it } from "./suite.ts";
 
 describe("events", () => {
-  describe("eventEmitter", () => {
-    it("on", () =>
-      run(function* () {
-        let eventEmitter = new EventEmitter();
-        let subscription = yield* on(eventEmitter, "event");
-
-        eventEmitter.emit("event", 1);
-
-        let next = yield* subscription.next();
-
-        expect(next).toEqual({ done: false, value: 1 });
-      }));
-
-    it("once", () =>
-      run(function* () {
-        let eventEmitter = new EventEmitter();
-        let subscription = yield* on(eventEmitter, "event");
-
-        eventEmitter.emit("event", 1);
-
-        let next = yield* subscription.next();
-
-        expect(next).toEqual({ done: false, value: 1 });
-      }));
-  });
-
   describe("types", () => {
     const domElement = {} as HTMLElement;
     const socket = {} as WebSocket;
@@ -46,11 +19,6 @@ describe("events", () => {
       expectType<Operation<Event>>(once(domElement, "mycustomevent"));
 
       expectType<Stream<Event, never>>(on(domElement, "anothercustomevent"));
-    });
-
-    it("should type eventEmitter", () => {
-      let eventEmitter = new EventEmitter();
-      expectType<Stream<Event, never>>(on(eventEmitter, "event"));
     });
   });
 });


### PR DESCRIPTION
## Motivation

Migrate `on` and `once` to v3 and add better typing around the event type.

## Approach

Extract all the `onXXX` events from the event target and allow a fallback to string if none is found.