### PR TITLE
convert `Subscription` from bare operation to iterator.

### DIFF
--- a/lib/async.ts
+++ b/lib/async.ts
@@ -10,7 +10,7 @@ export function expect<T>(promise: Promise<T>): Operation<T> {
 
 export function subscribe<T, R>(iter: AsyncIterator<T, R>): Subscription<T, R> {
   return {
-    [Symbol.iterator]: () => expect(iter.next())[Symbol.iterator](),
+    next: () => expect(iter.next()),
   };
 }
 

--- a/lib/channel.ts
+++ b/lib/channel.ts
@@ -52,7 +52,7 @@ function createSubscriber<T, TClose>(): ChannelSubscriber<T, TClose> {
       }
     },
     subscription: {
-      *[Symbol.iterator]() {
+      *next() {
         let message = items.pop();
         if (message) {
           return message;

--- a/lib/first.ts
+++ b/lib/first.ts
@@ -1,8 +1,13 @@
 import type { Operation, Stream } from "./types.ts";
 
-export function* first<T>(stream: Stream<T, void>): Operation<T | undefined> {
-  let events = yield* stream;
-  for (let next = yield* events; !next.done; next = yield* events) {
-    return next.value;
+export function first<T>(stream: Stream<T, never>): Operation<T>;
+export function* first<T>(
+  stream: Stream<T, unknown>,
+): Operation<T | undefined> {
+  let subscription = yield* stream;
+  let result = yield* subscription.next();
+
+  if (!result.done) {
+    return result.value;
   }
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -22,9 +22,11 @@ export interface Scope extends Operation<void> {
   close(): Future<void>;
 }
 
-export type Subscription<T, R> = Operation<IteratorResult<T, R>>;
-
 export type Stream<T, TReturn> = Operation<Subscription<T, TReturn>>;
+
+export interface Subscription<T, R> {
+  next(): Operation<IteratorResult<T, R>>;
+}
 
 export interface Port<T, R> {
   send(message: T): Operation<void>;

--- a/test/channel.test.ts
+++ b/test/channel.test.ts
@@ -29,11 +29,11 @@ describe("Channel", () => {
       yield* spawn(channel);
 
       let subscription = yield* output;
-      let result = yield* subscription;
+      let result = yield* subscription.next();
       actual.push(result.value as string);
 
       subscription = yield* output;
-      result = yield* subscription;
+      result = yield* subscription.next();
       actual.push(result.value as string);
     }
 
@@ -53,7 +53,7 @@ describe("Channel", () => {
       it("receives message on subscription", function* () {
         let subscription = yield* output;
         yield* input.send("hello");
-        let result = yield* subscription;
+        let result = yield* subscription.next();
         expect(result.done).toEqual(false);
         expect(result.value).toEqual("hello");
       });
@@ -62,7 +62,7 @@ describe("Channel", () => {
     describe("blocking on next", () => {
       it("receives message on subscription done", function* () {
         let subscription = yield* output;
-        let result = yield* spawn(() => subscription);
+        let result = yield* spawn(() => subscription.next());
         yield* sleep(10);
         yield* input.send("hello");
         expect(yield* result).toHaveProperty("value", "hello");
@@ -76,9 +76,9 @@ describe("Channel", () => {
         yield* send("hello");
         yield* send("foo");
         yield* send("bar");
-        expect(yield* subscription).toHaveProperty("value", "hello");
-        expect(yield* subscription).toHaveProperty("value", "foo");
-        expect(yield* subscription).toHaveProperty("value", "bar");
+        expect(yield* subscription.next()).toHaveProperty("value", "hello");
+        expect(yield* subscription.next()).toHaveProperty("value", "foo");
+        expect(yield* subscription.next()).toHaveProperty("value", "bar");
       });
     });
 
@@ -90,7 +90,7 @@ describe("Channel", () => {
 
         yield* input.send("hello");
 
-        expect(yield* subscription).toEqual({
+        expect(yield* subscription.next()).toEqual({
           done: false,
           value: "hello",
         });
@@ -104,11 +104,11 @@ describe("Channel", () => {
           let subscription = yield* output;
           yield* input.send("foo");
           yield* input.close();
-          expect(yield* subscription).toEqual({
+          expect(yield* subscription.next()).toEqual({
             done: false,
             value: "foo",
           });
-          expect(yield* subscription).toEqual({
+          expect(yield* subscription.next()).toEqual({
             done: true,
             value: undefined,
           });
@@ -122,11 +122,11 @@ describe("Channel", () => {
           yield* input.send("foo");
           yield* input.close(12);
 
-          expect(yield* subscription).toEqual({
+          expect(yield* subscription.next()).toEqual({
             done: false,
             value: "foo",
           });
-          expect(yield* subscription).toEqual({ done: true, value: 12 });
+          expect(yield* subscription.next()).toEqual({ done: true, value: 12 });
         });
       });
     });


### PR DESCRIPTION
## Motivation

> fixes https://github.com/thefrontside/effection/issues/693

In order to simplify working with streams and subscriptions, we need to be able to disambiguate them easily. The relationship between `Stream` and `Subscription` is the same as that between `Iterable` -> `Iterator` and `AsyncIterable` -> `AsyncIterator`.

### Approach
This converts `Subscription` into an API that is highly analogous to `AsyncIterator`. The `next()` method returns an `Operation` which yields an `IteratorResult` So in the same way `AsyncIterator` has:

```ts
next(): Promise<IteratorResult>;
```

The `Subscription` api will look like:

```ts
next(): Operation<IteratorResult>;
```

Once we have this in place, it is trivial to create a stream out of any Subscription:

```ts
function streamable(subscription: Subscription): Stream {
  return ({
    *[Symbol.iterator]() {
      return subscription;
    }
  });
}
```

We may decide later to rename `Stream` and `Subscription` to something else that re-enforces this analogy further. However, we haven't been able to settle on anything that obviously clicks, so we'll defer that for now, and instead focus on the API.