### PR TITLE
✨Add low-level context operations right onto the context.

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -38,6 +38,27 @@ export interface Channel<T, TClose> {
   output: Stream<T, TClose>;
 }
 
+/**
+ * `Context`` defines a value which is in effect for a given scope which is an
+ * (action, resource, call, or spawn).
+ *
+ * When used as an operation, it gets the value of the Context from
+ * the current scope. If it has not been set, and there is no default
+ * value, then a `MissingContextError` will be raised.
+ */
+export interface Context<T> extends Operation<T> {
+  /**
+   * Set the value of the Context for the current scope.
+   */
+  set(value: T): Operation<T>;
+
+  /**
+   * Get the value of the Context from the current scope. If it has not been
+   * set, and there is no default value, then this will return `undefined`.
+   */
+  get(): Operation<T | undefined>;
+}
+
 /* low-level interface Which you probably will not need */
 
 export type Result<T> = {


### PR DESCRIPTION
## Motivation

Reading context is doable, writing context is extremely awkward. This was by design, but it is increasingly becoming a stumbling point. I'm finding that we have to lug around snippets of code to act as "context helpers" to make the task less arduous.

This is because when creating effects like loggers, template outlets, dispatch channels, etc... it is often necessary to pair some state with the operations that run on that state. Among other things, this is the general pattern for implementing [algebraic effect handlers][koka-effect-handlers] which is something we're going to be doing more and more of going forward.

As such, we need simple, type-safe, yet low-level wrappers around context.

## Approach

In the same way we went with the simplest possible thing that could work with the original context reading (just making it an opaque operation), I'm proposing a set of low-level helpers attached directly to the context that let you manipulate it for the current scope. These are `get()`, `set()`, and `expect()`. Currently, reading from a context behaves like `expect()` where an exception is raised if the context is not present. However, sometimes you may want to check if the context is set or not, and so you can use `get()` which will return `undefined` if not present.

```ts
/**
 * `Context`` defines a value which is in effect for a given scope which is an
 * (action, resource, call, or spawn)
 */
export interface Context<T> extends Operation<T> {
  /**
   * Set the value of the Context for the current scope.
   */
  set(value: T): Operation<T>;

  /**
   * Get the value of the Context from the current scope. If it has not been
   * set, and there is no default value, then this will return `undefined`.
   */
  get(): Operation<T | undefined>;

  /**
   * Gets the value of the Context from the current scope. If it has not been
   * set, and there is no default value, then raise a missing context error.
   */
  expect(): Operation<T>;
}
```

### TODOs and Open Questions

Other options considered, but which I think we should hold off on for now (but add them if they become useful):

#### `with()` that calls an operation with a context value.

```ts
yield* Context.with(value, function*() {
  yield* Context.get() //=> returns value;
});

yield* Context.get() //=> undefined
```

However, I found that in general, it was just as easy to use `Context.set()` and it had less rightward drift because contexts only set for the current scope, they will disappear after the current operation.

#### consider deprecating bare operation context, and instead force you to use `expect()`. 

I think this conveys intent much better.

before:

```ts
import { Logger } from "./logger.ts";

export function* log(message) {
  let logger = yield* Logger;
  logger.write(message);
}
```

after:

```ts
import { Logger } from "./logger.ts";

export function* log(message) {
  let logger = yield* Logger.expect();
  logger.write(message);
}
```

[koka-effect-handlers]: https://koka-lang.github.io/koka/doc/book.html#why-handlers
