### PR TITLE
use abort-controller fork that also works in browser

### DIFF
--- a/.changes/fix-abort-controller.md
+++ b/.changes/fix-abort-controller.md
@@ -1,0 +1,4 @@
+---
+"@effection/core": patch
+---
+use AbortController polyfill that works in the browser

--- a/.changes/fix-abort-controller.md
+++ b/.changes/fix-abort-controller.md
@@ -1,4 +1,5 @@
 ---
 "@effection/core": patch
+"@effection/main": patch
 ---
 use AbortController polyfill that works in the browser

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,7 +27,7 @@
     "src/**/*"
   ],
   "dependencies": {
-    "abort-controller": "^3.0.0"
+    "@chainsafe/abort-controller": "^3.0.1"
   },
   "devDependencies": {
     "rimraf": "^3.0.2"

--- a/packages/core/src/abort-signal.ts
+++ b/packages/core/src/abort-signal.ts
@@ -1,6 +1,6 @@
 import { spawn } from './operations/spawn';
 import { Resource } from "./operation";
-import { AbortController, AbortSignal } from 'abort-controller';
+import { AbortController, AbortSignal } from '@chainsafe/abort-controller';
 
 /**
  * Create an

--- a/yarn.lock
+++ b/yarn.lock
@@ -380,6 +380,13 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@chainsafe/abort-controller@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@chainsafe/abort-controller/-/abort-controller-3.0.1.tgz#9f99ff6c641fa08e76ca346ecea54496ccb0662e"
+  integrity sha512-oyq0qgFJDIIgLpyPwTv4j/sHX/MITatFzY3/b42VSldyZfnUC1lYBx5RwFvzBv1Sq4APOj2VCZO23pDRwy5kew==
+  dependencies:
+    event-target-shim "^5.0.0"
+
 "@cspotcode/source-map-support@^0.8.0":
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
@@ -2213,13 +2220,6 @@ abab@^2.0.3, abab@^2.0.5:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.6.tgz#41b80f2c871d19686216b82309231cfd3cb3d291"
   integrity sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==
-
-abort-controller@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
-  integrity sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==
-  dependencies:
-    event-target-shim "^5.0.0"
 
 abortcontroller-polyfill@^1.1.9:
   version "1.7.5"


### PR DESCRIPTION
see https://github.com/ChainSafe/lodestar/pull/2725

## Motivation

I tried creating a test project for a client side browser app, but it didn't work because it couldn't import `AbortController`

## Approach

Found a fork of "abort-controller" that fixes export for browser: https://github.com/ChainSafe/abort-controller/commit/6cf91169a6e7ba3d3b62a379ee9b6ec982a751d4


## Screenshots

![Screenshot 2023-06-07 at 15 44 37](https://github.com/thefrontside/effection/assets/20795/db7c16b4-c90d-48ca-a4f9-a2ffc5e99b3a)

