### PR TITLE
feat: deploy docs to aptible

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,7 +6,7 @@ name: docs
 
 on:
   push:
-    branches: [main]
+    branches: [v3]
 
 env:
   APTIBLE_ENVIRONMENT: production

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,29 @@
+# if we want github releases to trigger deploy
+# on:
+#  release:
+#    types: [published]
+name: docs
+
+on:
+  push:
+    branches: [main]
+
+env:
+  APTIBLE_ENVIRONMENT: production
+  APTIBLE_APP: v3-www
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: webfactory/ssh-agent@v0.5.4
+        with:
+          ssh-private-key: ${{ secrets.APTIBLE_GIT_SSH_KEY }}
+      - name: Deploy to Aptible
+        run: |
+          ssh-keyscan beta.aptible.com >> ~/.ssh/known_hosts
+          git remote add aptible git@beta.aptible.com:${{ APTIBLE_ENVIRONMENT }}/${{ APTIBLE_APP }}.git
+          git push aptible ${{ github.sha }}:main

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,8 +9,8 @@ on:
     branches: [v3]
 
 env:
-  APTIBLE_ENVIRONMENT: production
-  APTIBLE_APP: v3-www
+  APTIBLE_ENVIRONMENT: frontside-production
+  APTIBLE_APP: effection-v3-www
 
 jobs:
   deploy:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM denoland/deno:1.34.1
+
+COPY . /app
+WORKDIR /app/www
+
+RUN deno cache main.ts
+
+EXPOSE 8000
+
+CMD ["deno", "run", "--allow-read=assets,docs", "--allow-net=0.0.0.0", "-A", "main.ts"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ RUN deno cache main.ts
 
 EXPOSE 8000
 
-CMD ["deno", "run", "--allow-read=assets,docs", "--allow-net=0.0.0.0", "-A", "main.ts"]
+CMD ["deno", "run", "--allow-read=assets,docs", "--allow-net=0.0.0.0", "main.ts"]


### PR DESCRIPTION
## Motivation

Deploy `v3` docs to Aptible.

This PR also adds CD via github workflow so on merge to `v3` it will trigger a deploy.

### TODOs

- [x] Create robot SSH keypair
- [x] Create Aptible account
- [x] Add public key to Aptible
- [x] Follow first-time UX flow
  - [x] Create `production` Environment
  - [x] Create `v3-www` App
- [x] Add private key to github secrets as `APTIBLE_GIT_SSH_KEY`
