### PR TITLE
add covector change tags and use tagged version

### DIFF
--- a/.changes/config.json
+++ b/.changes/config.json
@@ -9,6 +9,12 @@
       ]
     }
   },
+  "changeTags": {
+    "feat": "New Features",
+    "enhance": "Enhancements",
+    "bug": "Bug Fixes",
+    "deps": "Dependencies"
+  },
   "packages": {
     "@effection/channel": {
       "path": "./packages/channel",
@@ -22,23 +28,17 @@
     "@effection/duplex-channel": {
       "path": "./packages/duplex-channel",
       "manager": "javascript",
-      "dependencies": [
-        "effection"
-      ]
+      "dependencies": ["effection"]
     },
     "@effection/dispatch": {
       "path": "./packages/dispatch",
       "manager": "javascript",
-      "dependencies": [
-        "effection"
-      ]
+      "dependencies": ["effection"]
     },
     "@effection/atom": {
       "path": "./packages/atom",
       "manager": "javascript",
-      "dependencies": [
-        "effection"
-      ]
+      "dependencies": ["effection"]
     },
     "@effection/core": {
       "path": "./packages/core",
@@ -60,24 +60,17 @@
     "@effection/events": {
       "path": "./packages/events",
       "manager": "javascript",
-      "dependencies": [
-        "@effection/core",
-        "@effection/stream"
-      ]
+      "dependencies": ["@effection/core", "@effection/stream"]
     },
     "@effection/fetch": {
       "path": "./packages/fetch",
       "manager": "javascript",
-      "dependencies": [
-        "@effection/core"
-      ]
+      "dependencies": ["@effection/core"]
     },
     "@effection/inspect": {
       "path": "./packages/inspect",
       "manager": "javascript",
-      "dependencies": [
-        "@effection/inspect-server"
-      ]
+      "dependencies": ["@effection/inspect-server"]
     },
     "@effection/inspect-server": {
       "path": "./packages/inspect-server",
@@ -93,75 +86,52 @@
     "@effection/inspect-utils": {
       "path": "./packages/inspect-utils",
       "manager": "javascript",
-      "dependencies": [
-        "@effection/atom",
-        "@effection/dispatch",
-        "effection"
-      ]
+      "dependencies": ["@effection/atom", "@effection/dispatch", "effection"]
     },
     "@effection/main": {
       "path": "./packages/main",
       "manager": "javascript",
-      "dependencies": [
-        "@effection/core"
-      ]
+      "dependencies": ["@effection/core"]
     },
     "@effection/mocha": {
       "path": "./packages/mocha",
       "manager": "javascript",
-      "dependencies": [
-        "effection"
-      ]
+      "dependencies": ["effection"]
     },
     "@effection/jest": {
       "path": "./packages/jest",
       "manager": "javascript",
-      "dependencies": [
-        "effection"
-      ]
+      "dependencies": ["effection"]
     },
     "@effection/process": {
       "path": "./packages/process",
       "manager": "javascript",
-      "dependencies": [
-        "effection"
-      ]
+      "dependencies": ["effection"]
     },
     "@effection/react": {
       "path": "./packages/react",
       "manager": "javascript",
-      "dependencies": [
-        "effection"
-      ]
+      "dependencies": ["effection"]
     },
     "@effection/subscription": {
       "path": "./packages/subscription",
       "manager": "javascript",
-      "dependencies": [
-        "@effection/core"
-      ]
+      "dependencies": ["@effection/core"]
     },
     "@effection/stream": {
       "path": "./packages/stream",
       "manager": "javascript",
-      "dependencies": [
-        "@effection/core",
-        "@effection/subscription"
-      ]
+      "dependencies": ["@effection/core", "@effection/subscription"]
     },
     "@effection/websocket-client": {
       "path": "./packages/websocket-client",
       "manager": "javascript",
-      "dependencies": [
-        "effection"
-      ]
+      "dependencies": ["effection"]
     },
     "@effection/websocket-server": {
       "path": "./packages/websocket-server",
       "manager": "javascript",
-      "dependencies": [
-        "effection"
-      ]
+      "dependencies": ["effection"]
     },
     "@effection/inspect-ui": {
       "path": "./packages/inspect-ui",
@@ -176,9 +146,7 @@
     "@effection/vitest": {
       "path": "./packages/vitest",
       "manager": "javascript",
-      "dependencies": [
-        "effection"
-      ]
+      "dependencies": ["effection"]
     }
   }
 }

--- a/.github/workflows/covector-preview.yaml
+++ b/.github/workflows/covector-preview.yaml
@@ -12,11 +12,11 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           registry-url: "https://registry.npmjs.org"
-      - uses: volta-cli/action@v3
+      - uses: volta-cli/action@v4
       - run: yarn install --immutable
       - run: yarn prepack
       - name: covector preview
-        uses: jbolda/covector/packages/action@main
+        uses: jbolda/covector/packages/action@covector-v0.9
         id: covector
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.github/workflows/covector-status.yaml
+++ b/.github/workflows/covector-status.yaml
@@ -10,11 +10,11 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: volta-cli/action@v3
+      - uses: volta-cli/action@v4
       - run: yarn install --immutable
       - run: yarn prepack
       - name: covector status
-        uses: jbolda/covector/packages/action@main
+        uses: jbolda/covector/packages/action@covector-v0.9
         id: covector
         with:
           command: "status"

--- a/.github/workflows/covector-version-or-publish.yml
+++ b/.github/workflows/covector-version-or-publish.yml
@@ -25,11 +25,11 @@ jobs:
         run: |
           git config --global user.name "${{ github.event.pusher.name }}"
           git config --global user.email "${{ github.event.pusher.email }}"
-      - uses: volta-cli/action@v3
+      - uses: volta-cli/action@v4
       - run: yarn install --immutable
       - run: yarn prepack
       - name: covector version or publish (publish when no change files present)
-        uses: jbolda/covector/packages/action@covector-v0.7
+        uses: jbolda/covector/packages/action@covector-v0.9
         id: covector
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}


### PR DESCRIPTION
## Motivation

Covector added a feature to "tag" changes to automatically group them in the changelog. Worth adding this config, and this will possibly alleviate the error seen in #707.

## Approach

Add the config as we also have set in simulacrum. There were also a few workflows that used the main branch of covector. I set those to a specific tagged version to improve stability.
