### PR TITLE
[covector] handle specific version check

### DIFF
--- a/.changes/config.json
+++ b/.changes/config.json
@@ -3,9 +3,9 @@
   "pkgManagers": {
     "javascript": {
       "version": true,
-      "getPublishedVersion": "node ../../.scripts/checkIfPublished.mjs ${ pkgFile.pkg.name } ${ pkg.tag ? pkg.tag : 'latest' }",
+      "getPublishedVersion": "node ../../.scripts/checkIfPublished.mjs ${ pkgFile.pkg.name } ${ pkgFile.version }",
       "publish": [
-        "npm publish --access public ${ pkg.tag ? '--tag ' + pkg.tag : '' }"
+        "npm publish --access public${ pkg.tag ? ' --tag ' + pkg.tag : '' }"
       ]
     }
   },

--- a/.scripts/checkIfPublished.mjs
+++ b/.scripts/checkIfPublished.mjs
@@ -1,5 +1,5 @@
-import { main } from 'effection';
-import { fetch } from '@effection/fetch';
+import { main } from "effection";
+import { fetch } from "@effection/fetch";
 
 const pkgName = process.argv[2];
 const tag = process.argv[3];
@@ -12,11 +12,15 @@ main(function* () {
 function* packageExists(name, tag) {
   let request = yield fetch(`https://registry.npmjs.com/${name}`);
   if (request.status === 404) {
-    return 'not published';
+    return "package not published";
   } else if (request.status < 400) {
     let response = yield request.json();
-    return response['dist-tags'][tag];
+    if (tag in response.versions && "version" in response.versions[tag]) {
+      return response.versions[tag].version;
+    } else {
+      return "version not published";
+    }
   } else {
-    throw new Error('request error');
+    throw new Error("request error");
   }
 }


### PR DESCRIPTION
## Motivation

With the incoming v3, it is important to support publishing on both v2 and v3.

## Approach

The previous version of the check script only looked at the latest tag. This updated version will check if that exact version on the branch has been published in the past. If it hasn't and is ready to publish, it will proceed with the publish.
