### PR TITLE
✨Add all()

### DIFF
--- a/lib/all.ts
+++ b/lib/all.ts
@@ -1,0 +1,58 @@
+// deno-lint-ignore-file no-explicit-any
+import type { Operation, Task } from "./types.ts";
+import { useScope } from "./run/scope.ts";
+
+/**
+ * Block and wait for all of the given operations to complete. Returns
+ * an array of values that the given operations evaluated to. This has
+ * the same purpose as
+ * [Promise.all](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/all).
+ *
+ * If any of the operations become errored, then `all` will also become errored.
+ *
+ * ### Example
+ *
+ * ``` javascript
+ * import { all, expect, main } from 'effection';
+ *
+ * await main(function*() {
+ *  let [google, bing] = yield* all([
+ *    expect(fetch('http://google.com')),
+ *    expect(fetch('http://bing.com')),
+ *   ]);
+ *  // ...
+ * });
+ * ```
+ *
+ * @param operations a list of operations to wait for
+ * @returns the list of values that the operations evaluate to, in the order they were given
+ */
+export function all<T extends Operation<any>[]>(
+  operations: T,
+): Operation<All<T>> {
+  return {
+    name: "all",
+    count: operations.length,
+    *[Symbol.iterator]() {
+      let scope = yield* useScope();
+      let tasks: Task<T>[] = [];
+      for (let operation of operations) {
+        tasks.push(scope.run(() => operation));
+      }
+      let results: T[] = [];
+      for (let task of tasks) {
+        results.push(yield* task);
+      }
+      return results;
+    },
+  } as Operation<All<T>>;
+}
+
+/**
+ * This type allows you to infer heterogenous operation types.
+ * e.g. `all([sleep(0), expect(fetch("https://google.com")])`
+ * will have a type of `Operation<Array<void | Request>>`
+ */
+type All<T extends Operation<any>[]> = {
+  [P in keyof T]: T[P] extends Operation<infer TArg> ? TArg : never;
+};

--- a/lib/mod.ts
+++ b/lib/mod.ts
@@ -16,3 +16,4 @@ export * from "./pipe.ts";
 export * from "./op.ts";
 export * from "./events.ts";
 export * from "./main.ts";
+export * from "./all.ts";

--- a/test/all.test.ts
+++ b/test/all.test.ts
@@ -1,0 +1,95 @@
+import {
+  asyncReject,
+  asyncResolve,
+  asyncResource,
+  describe,
+  expect,
+  it,
+  syncReject,
+  syncResolve,
+} from "./suite.ts";
+
+import { all, run, sleep } from "../mod.ts";
+
+describe("all()", () => {
+  it("resolves when the given list is empty", async () => {
+    let result = await run(() => all([]));
+
+    expect(result).toEqual([]);
+  });
+
+  it("resolves when all of the given operations resolve", async () => {
+    let result = await run(() =>
+      all([
+        syncResolve("quox"),
+        asyncResolve(10, "foo"),
+        asyncResolve(5, "bar"),
+        asyncResolve(15, "baz"),
+      ])
+    );
+
+    expect(result).toEqual(["quox", "foo", "bar", "baz"]);
+  });
+
+  it("rejects when one of the given operations rejects asynchronously first", async () => {
+    let result = run(() =>
+      all([
+        asyncResolve(10, "foo"),
+        asyncReject(5, "bar"),
+        asyncResolve(15, "baz"),
+      ])
+    );
+
+    await expect(result).rejects.toHaveProperty("message", "boom: bar");
+  });
+
+  it("rejects when one of the given operations rejects asynchronously and another operation does not complete", async () => {
+    let result = run(() => all([sleep(0), asyncReject(5, "bar")]));
+
+    await expect(result).rejects.toHaveProperty("message", "boom: bar");
+  });
+
+  it("resolves when all of the given operations resolve synchronously", async () => {
+    let result = run(() =>
+      all([
+        syncResolve("foo"),
+        syncResolve("bar"),
+        syncResolve("baz"),
+      ])
+    );
+
+    await expect(result).resolves.toEqual(["foo", "bar", "baz"]);
+  });
+
+  it("rejects when one of the given operations rejects synchronously first", async () => {
+    let result = run(() =>
+      all([
+        syncResolve("foo"),
+        syncReject("bar"),
+        syncResolve("baz"),
+      ])
+    );
+
+    await expect(result).rejects.toHaveProperty("message", "boom: bar");
+  });
+
+  it("rejects when one of the operations reject", async () => {
+    await run(function* () {
+      let fooStatus = { status: "pending" };
+      let error;
+      try {
+        yield* all([
+          asyncResource(20, "foo", fooStatus),
+          asyncReject(10, "bar"),
+        ]);
+      } catch (err) {
+        error = err;
+      }
+
+      expect(fooStatus.status).toEqual("pending");
+      expect(error).toHaveProperty("message", "boom: bar");
+      yield* sleep(40);
+      expect(fooStatus.status).toEqual("pending");
+    });
+  });
+});


### PR DESCRIPTION
## Motivation
The docs use `all()` and `race()` extensively, so we need to have at least some plausible versions of these functions.

## Approach
This ports over the tests from `v2`, and is implemented as about the simplest version of `all()` that I could get working. However, there is a failing test, and while I think that we can ship it while it still fails, we do need to fix it before releasing `3.0.0`.

### TODOs and Open Questions

- [ ] Our test fails because all() is spawning resources that fail, but any resource that fails while `all()` is running should cause the `all()` to raise an exception error in a resource while it is initializing. We could have any number of resources running, and if any of them fails before the all is completed, we need to be able to catch it.
