### PR TITLE
🐛main operation was failing without explicit exit.

### DIFF
--- a/lib/main.ts
+++ b/lib/main.ts
@@ -63,7 +63,7 @@ export async function main(
 
       try {
         let interrupt = () => resolve({ status: 130, signal: "SIGINT" });
-        return yield* withHost({
+        yield* withHost({
           *deno() {
             hardexit = (status) => Deno.exit(status);
             try {
@@ -95,11 +95,11 @@ export async function main(
             }
           },
         });
+
+        yield* exit(0);
       } catch (error) {
         resolve({ status: 1, error });
       }
-
-      yield* exit(0);
     })
   );
 

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -34,6 +34,21 @@ describe("main", () => {
     });
   });
 
+  it("exits gracefully with 0 on implicit exit", async () => {
+    await run(function* () {
+      let cmd = yield* useCommand("deno", {
+        stdout: "piped",
+        args: ["run", "test/main/ok.implicit.ts"],
+      });
+
+      let stdout = yield* buffer(cmd.stdout);
+      let status = yield* cmd.status;
+
+      yield* detect(stdout, "goodbye.");
+      expect(status.code).toEqual(0);
+    });
+  });
+
   it("exits gracefully on explicit exit failure exit()", async () => {
     await run(function* () {
       let cmd = yield* useCommand("deno", {

--- a/test/main/ok.implicit.ts
+++ b/test/main/ok.implicit.ts
@@ -1,0 +1,15 @@
+import { sleep } from "../../lib/sleep.ts";
+import { spawn, suspend } from "../../lib/instructions.ts";
+import { main } from "../../lib/main.ts";
+
+await main(function* () {
+  yield* spawn(function* () {
+    try {
+      yield* suspend();
+    } finally {
+      console.log("goodbye.");
+    }
+  });
+
+  yield* sleep(10);
+});


### PR DESCRIPTION
## Motivation

`main()` only works correctly whenever you call `yield* exit()` or if there was a error, because it relies on resolving a containing action (the entire main method is just one big action).

However, if your operation completes successfully and you _don't_ invoke the exit operation, then it fails because the main action never resolves. This was because we were returning early from the action.

## Approach

This removes the return statement and places the implicit exit into a more prominent location so that we are always guaranteed to resolve ith an exit status no matter what.
