### PR TITLE
♻️ Make each task run in its own frame.

### DIFF
--- a/lib/instructions.ts
+++ b/lib/instructions.ts
@@ -9,7 +9,6 @@ import type {
 } from "./types.ts";
 
 import { reset, shift } from "./deps.ts";
-import { createFrameTask } from "./run/frame.ts";
 import { Err, Ok } from "./result.ts";
 
 /**
@@ -123,8 +122,10 @@ export function action<T>(
           let resolve: Resolve<T> = (value) => settle(Ok(value));
           let reject: Reject = (error) => settle(Err(error));
 
-          let child = frame.createChild();
-          let block = child.run(() => operation(resolve, reject));
+          let child = frame.createChild(function* () {
+            yield* operation(resolve, reject);
+            yield* suspend();
+          });
 
           yield* reset(function* () {
             let result = yield* child;
@@ -133,14 +134,7 @@ export function action<T>(
             }
           });
 
-          yield* reset(function* () {
-            let blockResult = yield* block;
-            if (!blockResult.result.ok) {
-              settle(blockResult.result);
-            }
-          });
-
-          block.enter();
+          child.enter();
         });
       };
     },
@@ -152,27 +146,16 @@ export function spawn<T>(operation: () => Operation<T>): Operation<Task<T>> {
     *[Symbol.iterator]() {
       return yield function Spawn(frame) {
         return shift<Result<Task<T>>>(function* (k) {
-          let child = frame.createChild();
-          let block = child.run(operation);
-
-          let task = createFrameTask(child, block);
+          let child = frame.createChild<T>(operation);
 
           yield* reset(function* () {
-            let blockResult = yield* block;
-            let destruction = yield* child.destroy();
-            if (!destruction.ok) {
-              yield* frame.crash(destruction.error);
-            } else if (
-              blockResult.aborted &&
-              !blockResult.result.ok
-            ) {
-              yield* frame.crash(blockResult.result.error);
-            } else if (!blockResult.result.ok) {
-              yield* frame.crash(blockResult.result.error);
+            let result = yield* child;
+            if (!result.ok) {
+              yield* frame.crash(result.error);
             }
           });
 
-          block.enter();
+          let task = child.enter();
 
           k.tail(Ok(task));
         });
@@ -186,42 +169,23 @@ export function resource<T>(
 ): Operation<T> {
   return {
     *[Symbol.iterator]() {
-      return yield function Resource(frame) {
-        return shift<Result<T>>(function* (k) {
-          let child = frame.createChild();
-          let provide = (value: T): Operation<void> => {
-            return {
-              *[Symbol.iterator]() {
-                return yield () =>
-                  shift<Result<void>>(function* () {
-                    k.tail(Ok(value));
-                  });
-              },
-            };
-          };
+      return yield (frame) =>
+        shift<Result<T>>(function* (k) {
+          function* provide(value: T) {
+            k.tail(Ok(value));
+            yield* suspend();
+          }
+
+          let child = frame.createChild(() => operation(provide));
           yield* reset(function* () {
             let result = yield* child;
             if (!result.ok) {
+              k.tail(result);
               yield* frame.crash(result.error);
             }
           });
-          let block = child.run(() => operation(provide));
-
-          yield* reset(function* () {
-            let done = yield* block;
-            if (!done.result.ok) {
-              k.tail(done.result);
-            } else if (done.result.ok) {
-              let err = new Error(
-                `resource exited without ever providing anything`,
-              );
-              k.tail(Err(err));
-            }
-          });
-
-          block.enter();
+          child.enter();
         });
-      };
     },
   };
 }

--- a/lib/run.ts
+++ b/lib/run.ts
@@ -1,11 +1,8 @@
 import type { Operation, Task } from "./types.ts";
-import { createFrame, createFrameTask } from "./run/frame.ts";
+import { createFrame } from "./run/frame.ts";
 export * from "./run/scope.ts";
 
 export function run<T>(operation: () => Operation<T>): Task<T> {
-  let frame = createFrame();
-  let block = frame.run(operation);
-  let task = createFrameTask(frame, block);
-  block.enter();
-  return task;
+  let frame = createFrame<T>({ operation });
+  return frame.enter();
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -73,11 +73,11 @@ export interface Instruction {
   (frame: Frame, signal: AbortSignal): Computation<Result<unknown>>;
 }
 
-export interface Frame extends Computation<Result<void>> {
+export interface Frame<T = unknown> extends Computation<Result<void>> {
   id: number;
   context: Record<string, unknown>;
-  createChild(): Frame;
-  run<T>(operation: () => Operation<T>): Block<T>;
+  createChild<C>(operation: () => Operation<C>): Frame<C>;
+  enter(): Task<T>;
   crash(error: Error): Computation<Result<void>>;
   destroy(): Computation<Result<void>>;
 }
@@ -94,6 +94,6 @@ export type BlockResult<T> =
 
 export interface Block<T = unknown> extends Computation<BlockResult<T>> {
   name: string;
-  enter(): void;
+  enter(frame: Frame<T>): void;
   abort(): Computation<Result<void>>;
 }

--- a/test/resource.test.ts
+++ b/test/resource.test.ts
@@ -44,6 +44,21 @@ describe("resource", () => {
     await expect(task).rejects.toHaveProperty("message", "moo");
   });
 
+  it("raises an error if an error occurs after init", async () => {
+    let task = run(function* () {
+      yield* spawn(function* () {
+        yield* sleep(5);
+        throw new Error("moo");
+      });
+      try {
+        yield* sleep(10);
+      } catch (error) {
+        return error;
+      }
+    });
+    await expect(task).rejects.toHaveProperty("message", "moo");
+  });
+
   it("terminates resource when task completes", async () => {
     let result = await run(function* () {
       return yield* createResource({ status: "pending" });

--- a/test/scope.test.ts
+++ b/test/scope.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from "./suite.ts";
-import { action, createScope, resource, run, useScope } from "../mod.ts";
+import {
+  createContext,
+  createScope,
+  resource,
+  run,
+  sleep,
+  suspend,
+  useScope,
+} from "../mod.ts";
 
 describe("Scope", () => {
   it("can be used to run actions", async () => {
@@ -14,60 +22,154 @@ describe("Scope", () => {
     expect(await t2).toEqual(2);
   });
 
-  it("can be used to run bare resources", async () => {
-    let scope = createScope();
-    let t1 = await scope.run(() => tester);
-    let t2 = await scope.run(() => tester);
-    expect(t1.status).toEqual("open");
-    expect(t2.status).toEqual("open");
-    await scope.close();
-    expect(t1.status).toEqual("closed");
-    expect(t2.status).toEqual("closed");
-  });
-
-  it("errors on close if the frame has errored", async () => {
+  it("succeeds on close if the frame has errored", async () => {
     let error = new Error("boom!");
     let scope = createScope();
     let bomb = scope.run(function* () {
       throw error;
     });
     await expect(bomb).rejects.toEqual(error);
+    await expect(scope.close()).resolves.toBeUndefined();
+  });
+
+  it("errors on close if there is an problem in teardown", async () => {
+    let error = new Error("boom!");
+    let scope = createScope();
+    scope.run(function* () {
+      try {
+        yield* suspend();
+      } finally {
+        // deno-lint-ignore no-unsafe-finally
+        throw error;
+      }
+    });
     await expect(scope.close()).rejects.toEqual(error);
   });
 
   it("still closes open resources whenever something errors", async () => {
     let error = new Error("boom!");
     let scope = createScope();
-    let t = await scope.run(() => tester);
+    let tester: Tester = {};
+
+    scope.run(function* () {
+      yield* useTester(tester);
+      yield* suspend();
+    });
+
     scope.run(function* () {
       throw error;
     });
-    await expect(scope.close()).rejects.toEqual(error);
-    expect(t.status).toEqual("closed");
+    await expect(scope.close()).resolves.toEqual(void 0);
+    expect(tester.status).toEqual("closed");
   });
 
   it("let's you capture scope from an operation", async () => {
-    let t = await run(function* () {
+    let tester: Tester = {};
+    await run(function* () {
       let scope = yield* useScope();
-      let t = yield* action<Tester>(function* (resolve) {
-        resolve(yield* scope.run(() => tester));
+      scope.run(function* () {
+        yield* useTester(tester);
+        yield* suspend();
       });
-      expect(t.status).toEqual("open");
-      return t;
+      expect(tester.status).toEqual("open");
     });
-    expect(t.status).toEqual("closed");
+    expect(tester.status).toEqual("closed");
+  });
+
+  it("has a separate context for each operation it runs", async () => {
+    let cxt = createContext<number>("number");
+
+    function* incr() {
+      let value = yield* cxt;
+      return yield* cxt.set(value + 1);
+    }
+
+    await run(function* () {
+      let scope = yield* useScope();
+      yield* cxt.set(1);
+
+      let first = yield* scope.run(incr);
+      let second = yield* scope.run(incr);
+      let third = yield* scope.run(incr);
+
+      expect(yield* cxt).toEqual(1);
+      expect(first).toEqual(2);
+      expect(second).toEqual(2);
+      expect(third).toEqual(2);
+    });
+  });
+
+  it("only shuts down the tasks that it created when closing", async () => {
+    await run(function* () {
+      let t1: Tester = {};
+      let t2: Tester = {};
+      let s1 = yield* useScope();
+      let s2 = yield* useScope();
+
+      s1.run(function* () {
+        yield* useTester(t1);
+        yield* suspend();
+      });
+
+      s2.run(function* () {
+        yield* useTester(t2);
+        yield* suspend();
+      });
+
+      expect(t1.status).toEqual("open");
+      expect(t2.status).toEqual("open");
+
+      yield* s1.close();
+
+      expect(t1.status).toEqual("closed");
+      expect(t2.status).toEqual("open");
+
+      yield* s2.close();
+
+      expect(t1.status).toEqual("closed");
+      expect(t2.status).toEqual("closed");
+    });
+  });
+
+  it("awaits all of its open tasks when it is yielded to", async () => {
+    let message = "";
+    let scope = createScope();
+
+    scope.run(function* () {
+      yield* sleep(0);
+      message += "hello";
+    });
+
+    scope.run(function* () {
+      yield* sleep(5);
+      message += " world";
+    });
+
+    await run(() => scope);
+    expect(message).toEqual("hello world");
+  });
+
+  it("fails when one of its outstanding tasks fails", async () => {
+    let error = new Error("boom!");
+    let scope = createScope();
+    scope.run(function* () {
+      yield* sleep(10);
+      throw error;
+    });
+    await expect(run(() => scope)).rejects.toEqual(error);
   });
 });
 
 interface Tester {
-  status: "open" | "closed";
+  status?: "open" | "closed";
 }
 
-const tester = resource<Tester>(function* (provide) {
-  let t: Tester = { status: "open" };
-  try {
-    yield* provide(t);
-  } finally {
-    t.status = "closed";
-  }
-});
+const useTester = (state: Tester) =>
+  resource<Tester>(function* (provide) {
+    try {
+      state.status = "open";
+      yield* provide(state);
+    } finally {
+      state.status = "closed";
+    }
+  });


### PR DESCRIPTION
## Motivation
There are a lot of problems with the way execution is currently handled that are outlined in this issue
https://github.com/thefrontside/effection/issues/728 owing to the fact that there can be many tasks executing against the same frame.

## Approach
This removes that capability, and now the `Block` interface is really private to the `Frame` object. This makes the code a lot simpler.

However, there is one tradeoff that was necessary to make in order for this to work. You can now no longer start "bare resources" with `scope.run()` because they will shut down the frame containing them as soon as the instruction that allocates the resource is finished. Instead, if you want to run a resource from a scope, you will have to suspend it.

```js
scope.run(function*() {
  yield* useResource();
  yield* suspend();
});
```