### PR TITLE
📄Mark clearly which docs have not been updated.

### DIFF
--- a/www/docs/collections.mdx
+++ b/www/docs/collections.mdx
@@ -3,6 +3,10 @@ id: collections
 title: Streams and Subscriptions
 ---
 
+>⚠️ These docs have not been updated from version 2 of Effection, and do not
+> apply to version 3. The information you find here may be of use, but may
+> also be outdated or misleading.
+
 Effection ships with a powerful library for working with streams of values.
 This allows you to create complex systems where evented code, stateful code and
 concurrent asynchronous code all are working together seamlessly.

--- a/www/docs/inspector.mdx
+++ b/www/docs/inspector.mdx
@@ -3,6 +3,10 @@ id: inspector
 title: Inspector
 ---
 
+>⚠️ These docs have not been updated from version 2 of Effection, and do not
+> apply to version 3. The information you find here may be of use, but may
+> also be outdated or misleading.
+
 We have created a powerful visual inspector for Effection. The inspector can
 show you which tasks are currently running. You can click on a task to focus in
 on it, see which tasks completed or failed and more.

--- a/www/docs/processes.mdx
+++ b/www/docs/processes.mdx
@@ -3,6 +3,10 @@ id: processes
 title: Spawning processes
 ---
 
+>⚠️ These docs have not been updated from version 2 of Effection, and do not
+> apply to version 3. The information you find here may be of use, but may
+> also be outdated or misleading.
+
 Effection simplifies the process of managing any kind of resource, and we've
 taken great care to provide a good experience when you want to spawn external
 processes.

--- a/www/docs/react.mdx
+++ b/www/docs/react.mdx
@@ -1,6 +1,0 @@
----
-id: react
-title: React Integration
----
-
-*Coming soon!*

--- a/www/docs/structure.json
+++ b/www/docs/structure.json
@@ -14,8 +14,6 @@
   "Advanced": [
     "testing.mdx",
     "inspector.mdx",
-    "processes.mdx",
-    "react.mdx",
-    "websockets.mdx"
+    "processes.mdx"
   ]
 }

--- a/www/docs/testing.mdx
+++ b/www/docs/testing.mdx
@@ -3,6 +3,10 @@ id: testing
 title: Testing
 ---
 
+>⚠️ These docs have not been updated from version 2 of Effection, and do not
+> apply to version 3. The information you find here may be of use, but may
+> also be outdated or misleading.
+
 Effection not only simplifies the process of writing tests, but by
 managing all the timing complexity of your setup and teardown, it can
 often make new kinds of tests possible that beforehand may have seemed
@@ -89,12 +93,7 @@ express all of your test operations.
 
 Once we make those changes, our test case now looks like this.
 
-<Tabs
-  groupId="jest-and-mocha-replacement"
-  defaultValue="jest"
-  values={[{label: 'Jest', value: 'jest'}, {label: 'Mocha', value: 'mocha'}]}>
-
-  <TabItem value="jest">
+> TODO: tab item
 
 ``` javascript
 import { beforeEach, afterEach, it } from '@effection/jest';
@@ -116,8 +115,7 @@ describe("a server", () => {
 });
 ```
 
-  </TabItem>
-  <TabItem value="mocha">
+> TODO: tab item
 
 ``` javascript
 import { beforeEach, afterEach, it } from '@effection/mocha';
@@ -139,9 +137,6 @@ describe("a server", () => {
 });
 ```
 
-  </TabItem>
-</Tabs>
-
 But so far, we've only traded one syntax for another. Now however, we can
 begin to leverage the power of Effection to make our test cases not only more
 concise, but also more flexible. To do this, we use the fact that each test
@@ -152,12 +147,7 @@ child of our test-scoped task, then when the test task goes away, so
 will our server.
 
 
-<Tabs
-  groupId="jest-and-mocha-resource"
-  defaultValue="jest"
-  values={[{label: 'Jest', value: 'jest'}, {label: 'Mocha', value: 'mocha'}]}>
-
-  <TabItem value="jest">
+> TODO: tab item
 
 ``` javascript
 import { ensure } from 'effection';
@@ -181,8 +171,7 @@ describe("a server", () => {
 });
 ```
 
-  </TabItem>
-  <TabItem value="mocha">
+> TODO: tab item
 
 ``` javascript
 import { ensure } from 'effection';
@@ -206,9 +195,6 @@ describe("a server", () => {
 });
 ```
 
-  </TabItem>
-</Tabs>
-
 We don't have to write an `afterEach()` _at all_ anymore, because the resource
 knows how to tear itself down no matter where it ends up running.
 
@@ -218,11 +204,7 @@ start it once before all of the tests run, so we move it to a _suite_ level
 hook. Before, we would have had to remember to convert our teardown hook as
 well, but with Effection, we can just move our resource to its new location.
 
-<Tabs
-  groupId="jest-and-mocha-resource"
-  defaultValue="jest"
-  values={[{label: 'Jest', value: 'jest'}, {label: 'Mocha', value: 'mocha'}]}>
-  <TabItem value="jest">
+> TODO: tab item
 
 ``` javascript
 import { ensure } from 'effection';
@@ -246,8 +228,7 @@ describe("a server", () => {
 });
 ```
 
-  </TabItem>
-  <TabItem value="mocha">
+> TODO: tab item
 
 ``` javascript
 import { ensure } from 'effection';
@@ -270,9 +251,6 @@ describe("a server", () => {
   });
 });
 ```
-
-  </TabItem>
-</Tabs>
 
 It is common to extract such resources into re-usable functions that can be
 embedded anywhere into your test suite, and you never have to worry about them
@@ -297,11 +275,7 @@ export function createServer(options) {
 
 Then we can use it easily in any test case:
 
-<Tabs
-  groupId="jest-and-mocha-reuse"
-  defaultValue="jest"
-  values={[{label: 'Jest', value: 'jest'}, {label: 'Mocha', value: 'mocha'}]}>
-  <TabItem value="jest">
+> TODO: tab item
 
 ``` javascript
 import { beforeAll, it } from '@effection/jest';
@@ -317,10 +291,9 @@ describe("a server", () => {
     expect(response.ok).toBe(true);
   });
 });
-```
+``
 
-  </TabItem>
-  <TabItem value="mocha">
+> TODO: tab item
 
 ``` javascript
 import { before, it } from '@effection/mocha';
@@ -338,9 +311,6 @@ describe("a server", () => {
 });
 ```
 
-  </TabItem>
-</Tabs>
-
 ### Test Scope
 
 As hinted at above, there are two separate levels of task in
@@ -352,11 +322,7 @@ and halted after every single test. Any tasks spawned within it will
 be halted immediately after the test is finished. For example:
 
 
-<Tabs
-  groupId="jest-and-mocha-reuse"
-  defaultValue="jest"
-  values={[{label: 'Jest', value: 'jest'}, {label: 'Mocha', value: 'mocha'}]}>
-  <TabItem value="jest">
+> TODO: tab item
 
 ``` javascript
 import { beforeAll, beforeEach, it } from '@effection/jest';
@@ -393,8 +359,7 @@ describe("a server", () => {
 });
 ```
 
-  </TabItem>
-  <TabItem value="mocha">
+> TODO: tab item
 
 ``` javascript
 import { before, beforeEach, it } from '@effection/mocha';
@@ -430,9 +395,6 @@ describe("a server", () => {
   });
 });
 ```
-
-  </TabItem>
-</Tabs>
 
 ### Caveats
 

--- a/www/docs/typescript.mdx
+++ b/www/docs/typescript.mdx
@@ -2,6 +2,11 @@
 id: typescript
 title: TypeScript
 ---
+
+>⚠️ These docs have not been updated from version 2 of Effection, and do not
+> apply to version 3. The information you find here may be of use, but may
+> also be outdated or misleading.q
+
 Effection is written in TypeScript and comes bundled with its own type
 definitions. Effection doesn't require any special setup to use in a
 TypeScript project, but there are some TypeScript specific

--- a/www/docs/websockets.mdx
+++ b/www/docs/websockets.mdx
@@ -1,6 +1,0 @@
----
-id: websockets
-title: WebSocket
----
-
-*Coming soon!*


### PR DESCRIPTION
## Motivation

We're sharing out links more and more of the documentation as we promulgate v3. It can be really confusing since some of the docs do not apply at all to v3, and are very misleading as regards `v2`

## Approach

The goal is to have the docs we _have_ rewritten be useful, but those that are outdated or broken to clearly communicate that they are unreliable.

- Add a warning at the top of pages which have not yet been updated indicating that the information is likely outdated.
- fix compile errors in the testing tab until we can get the `<TabItem>` 
- remove the docs that were never written for `v2` (react and websocket)