### PR TITLE
✨for yield* each loops

### DIFF
--- a/lib/each.ts
+++ b/lib/each.ts
@@ -1,0 +1,107 @@
+import type { Operation, Stream, Subscription } from "./types.ts";
+import { createContext } from "./context.ts";
+
+/**
+ * Consume an effection stream using a simple for-of loop.
+ *
+ * Given any stream, you can access its values sequentially using the `each()`
+ * operation just as you would use `for await of` loop with an async iterable:
+ *
+ * ```javascript
+ * function* logvalues(stream) {
+ *   for (let value of yield* each(stream)) {
+ *     console.log(value);
+ *     yield* each.next
+ *   }
+ * }
+ * ```
+ * You must always invoke `each.next` at the end of each iteration of the loop,
+ * including if the interation ends with a `continue` statement.
+ *
+ * Note that just as with async iterators, there is no way to consume the
+ * `TClose` value of a stream using the `for-each` loop.
+ *
+ * @typeParam T - the type of each value in the stream.
+ * @param stream - the stream to iterate
+ * @returns an operation to iterate `stream`
+ */
+export const each = iterate as Each;
+
+/**
+ * @ignore
+ */
+export type Each = typeof iterate & {
+  /**
+   * Indicate that the current iteration in a for-each loop is complete.
+   *
+   * @see {@link each}
+   */
+  next: Operation<void>;
+};
+
+interface EachLoop<T> {
+  subscription: Subscription<T, unknown>;
+  current: IteratorResult<T>;
+  stale?: true;
+}
+
+const EachStack = createContext<EachLoop<unknown>[]>("each");
+
+function iterate<T>(stream: Stream<T, unknown>): Operation<Iterable<T>> {
+  return {
+    *[Symbol.iterator]() {
+      let subscription = yield* stream;
+      let current = yield* subscription.next();
+      let stack = yield* EachStack.get();
+      if (!stack) {
+        stack = yield* EachStack.set([]);
+      }
+
+      let context: EachLoop<T> = { subscription, current };
+
+      stack.push(context);
+
+      let iterator: Iterator<T> = {
+        next() {
+          if (context.stale) {
+            let error = new Error(
+              `for each loop did not use each.next operation before continuing`,
+            );
+            error.name = "IterationError";
+            throw error;
+          } else {
+            context.stale = true;
+            return context.current;
+          }
+        },
+        return() {
+          stack!.pop();
+          return { done: true, value: void 0 };
+        },
+      };
+
+      return {
+        [Symbol.iterator]: () => iterator,
+      };
+    },
+  };
+}
+
+iterate.next = {
+  name: "each.next",
+  *[Symbol.iterator]() {
+    let stack = yield* EachStack;
+    let context = stack[stack.length - 1];
+    if (!context) {
+      let error = new Error(`cannot call next() outside of an iteration`);
+      error.name = "IterationError";
+      throw error;
+    }
+    let current = yield* context.subscription.next();
+    delete context.stale;
+    context.current = current;
+    if (current.done) {
+      stack.pop();
+    }
+  },
+} as Operation<void>;

--- a/lib/mod.ts
+++ b/lib/mod.ts
@@ -17,3 +17,4 @@ export * from "./op.ts";
 export * from "./events.ts";
 export * from "./main.ts";
 export * from "./all.ts";
+export * from "./each.ts";

--- a/test/each.test.ts
+++ b/test/each.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "./suite.ts";
+import { createChannel, each, run, spawn } from "../mod.ts";
+
+describe("each", () => {
+  it("can be used to iterate a stream", async () => {
+    await run(function* () {
+      let { input, output } = createChannel<string, void>();
+      let actual = [] as string[];
+      yield* spawn(function* () {
+        for (let value of yield* each(output)) {
+          actual.push(value);
+          yield* each.next;
+        }
+      });
+
+      yield* input.send("one");
+      yield* input.send("two");
+      yield* input.send("three");
+
+      expect(actual).toEqual(["one", "two", "three"]);
+    });
+  });
+
+  it("can be used to iterate nested streams", async () => {
+    await run(function* () {
+      let actual = [] as string[];
+      let outer = createChannel<string>();
+      let inner = createChannel<string>();
+
+      yield* spawn(function* () {
+        for (let value of yield* each(outer.output)) {
+          actual.push(value);
+          for (let value of yield* each(inner.output)) {
+            actual.push(value);
+            yield* each.next;
+          }
+          yield* each.next;
+        }
+      });
+
+      yield* outer.input.send("one");
+      yield* inner.input.send("two");
+      yield* inner.input.send("two and a half");
+      yield* inner.input.close();
+      yield* outer.input.send("three");
+      yield* inner.input.send("four");
+      yield* inner.input.close();
+      yield* outer.input.close();
+
+      expect(actual).toEqual(["one", "two", "two and a half", "three", "four"]);
+    });
+  });
+
+  it("handles context correctly if you break out of a loop", async () => {
+    await expect(run(function* () {
+      let { input, output } = createChannel<string>();
+
+      yield* spawn(function* () {
+        for (let _ of yield* each(output)) {
+          break;
+        }
+        // we're out of the loop, each.next should be invalid.
+        yield* each.next;
+      });
+
+      yield* input.send("hello");
+    })).rejects.toHaveProperty("name", "IterationError");
+  });
+
+  it("throws an error if you forget to invoke each.next", async () => {
+    await expect(run(function* () {
+      let { input, output } = createChannel<string>();
+      yield* spawn(function* () {
+        for (let _ of yield* each(output)) {
+          _;
+        }
+      });
+      yield* input.send("hello");
+    })).rejects.toHaveProperty("name", "IterationError");
+  });
+
+  it("throws an error if you invoke each.next out of context", async () => {
+    await expect(run(() => each.next)).rejects.toHaveProperty(
+      "name",
+      "MissingContextError",
+    );
+  });
+});


### PR DESCRIPTION
> Note: supersedes #727 

## Motivation

One of the design goals of Effection is to provide structured concurrency primitives that are very aligned with ordinary JavaScript and let libraries provide the higher abstractions based on those primitives. This is why we have `Streams` for AsyncIterables, and `Subscription` for `AsyncIterator`. What was missing was a natural way to consume streams that felt like the `for await of` loop.

## Approach

This introduces the `each()` and `each.next` operations that let you consume any stream completely naturally.

```javascript
for (let value of yield* each(stream)) {
  console.log(value);
  yield* each.next;
}
```