### PR TITLE
[v3] switchMap operator on Stream

### DIFF
--- a/lib/switch-map.ts
+++ b/lib/switch-map.ts
@@ -1,0 +1,45 @@
+import type { Operation, Stream, Task } from "./types";
+import { createChannel } from "./channel";
+import { spawn } from "./instructions";
+
+export function switchMap<A, B>(op: (a: A) => Operation<Stream<B, unknown>>) {
+  return function <AClose>(stream: Stream<A, AClose>): Stream<B, AClose> {
+    return {
+      *[Symbol.iterator]() {
+        const channel = createChannel<B, AClose>();
+
+        yield* spawn(function* () {
+          let innerTask: Task<unknown> | undefined;
+          const final: AClose = yield* forEach(stream, function* (outer) {
+            if (innerTask) {
+              yield* innerTask.halt();
+            }
+            innerTask = yield* spawn(function* () {
+              const innerStream = yield* op(outer);
+              yield* forEach(innerStream, (inner) => channel.input.send(inner));
+            });
+          });
+          yield* channel.input.close(final);
+        });
+
+        return yield* channel.output;
+      },
+    };
+  };
+}
+
+// Can be replaced with for yield* each once it's available.
+function* forEach<T, TClose>(
+  stream: Stream<T, TClose>,
+  fn: (a: T) => Operation<void>
+): Operation<TClose> {
+  const subcription = yield* stream;
+  while (true) {
+    const next = yield* subcription.next();
+    if (next.done) {
+      return next.value;
+    } else {
+      yield* fn(next.value);
+    }
+  }
+}


### PR DESCRIPTION
## Motivation

[switchMap](https://rxjs.dev/api/index/function/switchMap) operation brings higher order control flow to reactive programming. 

Conceptually, a stream transformation flow can be perceived as an asynchronous computation pipeline (program). And `switchMap` gives us the power to switch between different pipeline (program) based on the upstream value, while gracefully cleaning up the previous, if any, pipeline.

<!-- REQUIRED
  Why are you introducing this change? Why is this change necessary? What
  are you trying to achieve with this change?
  If you have a relevant issue, add a link directly to the URL here.
 -->

## Approach

`swtichMap` accepts a mapper that maps each value from the upstream (source) stream to a `Operation<Stream<B>>`.

Internally, `switchMap` subscribes to the upstream (source) stream and runs the mapper on each value. Then it spawns a new task and executes the operation to get the mapped (inner) stream and subscribes to it within the task. Any values arrives on the mapped (inner) stream is then forwarded to the output stream of `switchMap` operator.

Before spawning a new task to execute the mapped operation, `switchMap` halts the previous task so that the subscription to previous mapped (inner) stream goes out of scope and "cancelled".

<!-- REQUIRED
  How does this change fulfill the purpose? Keep it high level. Avoid code-splaining.
-->

### Alternate Designs

 <!-- OPTIONAL
   Explain what other alternatives you considered and why you chose this option.
 -->

### Possible Drawbacks or Risks

 <!-- OPTIONAL
   What are the possible side-effects or negative impacts of this change?
 -->

### TODOs and Open Questions

<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the conclusion.
-->
- [ ] Tests

## Learning

<!-- OPTIONAL
  Share any blog posts, patterns, libraries, or documentation that helped you.
-->

## Screenshots

<!-- OPTIONAL
  If relevant, include "before" and "after" to demonstrate this change. Add a caption describing what each screenshot shows.
-->
