### PR TITLE
🐞mispelled process.argv for NodeJS

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -22,6 +22,12 @@ jobs:
         with:
           deno-version: v1.x
 
+      - name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 18.x
+          registry-url: https://registry.npmjs.com
+
       - name: format
         run: deno fmt --check
 
@@ -30,3 +36,5 @@ jobs:
 
       - name: test
         run: deno task test
+      - name: test:node
+        run: deno task test:node

--- a/deno.json
+++ b/deno.json
@@ -2,6 +2,7 @@
   "lock": false,
   "tasks": {
     "test": "deno test --allow-run=deno",
+    "test:node": "deno task build:npm 0.0.0 && node test/main/node.mjs",
     "build:npm": "deno run -A tasks/build-npm.ts"
   },
   "lint": {

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -86,7 +86,7 @@ export async function main(
               //@ts-expect-error type-checked by Deno, run on Node
               process.on("SIGINT", interrupt);
               //@ts-expect-error type-checked by Deno, run on Node
-              yield* body(global.process.args.slice());
+              yield* body(global.process.argv.slice());
             } finally {
               //@ts-expect-error this runs on Node
               process.off("SIGINT", interrupt);

--- a/test/main/node.mjs
+++ b/test/main/node.mjs
@@ -1,0 +1,5 @@
+import { main } from "../../build/npm/esm/mod.js";
+
+await main(function* () {
+  console.log("hello world");
+});


### PR DESCRIPTION
## Motivation

`process.argv` was misspelled causing a `TypeError`

## Approach

fix it.

### TODOs and Open Questions

- [x] Add tests for NodeJS
