### PR TITLE
♻️🔥Simplify the Scope API by removing "group-ish" functionality.

### DIFF
--- a/lib/run/frame.ts
+++ b/lib/run/frame.ts
@@ -2,6 +2,7 @@ import type { Frame, Operation, Result, Task } from "../types.ts";
 
 import { futurize } from "../future.ts";
 import { evaluate } from "../deps.ts";
+import { lazy } from "../lazy.ts";
 
 import { createEventStream } from "./event-stream.ts";
 import { createBlock } from "./block.ts";
@@ -53,7 +54,7 @@ export function createFrame<T>(options: FrameOptions<T>): Frame<T> {
       });
       return child;
     },
-    enter(): Task<T> {
+    enter: lazy(() => {
       let task = create<Task<T>>("Task", {}, {
         ...futurize<T>(function* () {
           let blockResult = yield* block;
@@ -80,7 +81,7 @@ export function createFrame<T>(options: FrameOptions<T>): Frame<T> {
       });
       block.enter(frame);
       return task;
-    },
+    }),
     *crash(error: Error) {
       teardown.close(Err(error));
       return yield* frame;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -54,7 +54,7 @@ export type Reject = (error: Error) => void;
 
 export type Provide<T> = (value: T) => Operation<void>;
 
-export interface Scope extends Operation<void> {
+export interface Scope {
   run<T>(operation: () => Operation<T>): Task<T>;
   close(): Future<void>;
 }

--- a/test/scope.test.ts
+++ b/test/scope.test.ts
@@ -4,7 +4,6 @@ import {
   createScope,
   resource,
   run,
-  sleep,
   suspend,
   useScope,
 } from "../mod.ts";
@@ -97,66 +96,6 @@ describe("Scope", () => {
       expect(second).toEqual(2);
       expect(third).toEqual(2);
     });
-  });
-
-  it("only shuts down the tasks that it created when closing", async () => {
-    await run(function* () {
-      let t1: Tester = {};
-      let t2: Tester = {};
-      let s1 = yield* useScope();
-      let s2 = yield* useScope();
-
-      s1.run(function* () {
-        yield* useTester(t1);
-        yield* suspend();
-      });
-
-      s2.run(function* () {
-        yield* useTester(t2);
-        yield* suspend();
-      });
-
-      expect(t1.status).toEqual("open");
-      expect(t2.status).toEqual("open");
-
-      yield* s1.close();
-
-      expect(t1.status).toEqual("closed");
-      expect(t2.status).toEqual("open");
-
-      yield* s2.close();
-
-      expect(t1.status).toEqual("closed");
-      expect(t2.status).toEqual("closed");
-    });
-  });
-
-  it("awaits all of its open tasks when it is yielded to", async () => {
-    let message = "";
-    let scope = createScope();
-
-    scope.run(function* () {
-      yield* sleep(0);
-      message += "hello";
-    });
-
-    scope.run(function* () {
-      yield* sleep(5);
-      message += " world";
-    });
-
-    await run(() => scope);
-    expect(message).toEqual("hello world");
-  });
-
-  it("fails when one of its outstanding tasks fails", async () => {
-    let error = new Error("boom!");
-    let scope = createScope();
-    scope.run(function* () {
-      yield* sleep(10);
-      throw error;
-    });
-    await expect(run(() => scope)).rejects.toEqual(error);
   });
 });
 


### PR DESCRIPTION
## Motivation

Step one of https://github.com/thefrontside/effection/issues/751

## Approach

This rips out all the child tracking which is already the job of a frame. Also, because there is now a 1:1 relationship between frame and scope, there is also, by extension, a 1:1 relationship between frame and task, and also scope and task. We can make the task lazy, and just use it as our shutdown logic.
