### PR TITLE
♻️Move the `close()` function from scope off of the Scope API.

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -56,7 +56,6 @@ export type Provide<T> = (value: T) => Operation<void>;
 
 export interface Scope {
   run<T>(operation: () => Operation<T>): Task<T>;
-  close(): Future<void>;
 }
 
 export type Stream<T, TReturn> = Operation<Subscription<T, TReturn>>;

--- a/test/channel.test.ts
+++ b/test/channel.test.ts
@@ -9,12 +9,13 @@ import {
 import type { Operation, Port, Stream } from "../mod.ts";
 import { createChannel, createScope, sleep, spawn } from "../mod.ts";
 
-let scope = createScope();
+let [scope, close] = createScope();
+
 describe("Channel", () => {
   $beforeEach(() => {
-    scope = createScope();
+    [scope, close] = createScope();
   });
-  $afterEach(() => scope.close());
+  $afterEach(() => close());
 
   it("does not use the same event twice when serially subscribed to a channel", function* () {
     let { input, output } = createChannel<string, void>();

--- a/test/scope.test.ts
+++ b/test/scope.test.ts
@@ -10,7 +10,7 @@ import {
 
 describe("Scope", () => {
   it("can be used to run actions", async () => {
-    let scope = createScope();
+    let [scope] = createScope();
     let t1 = scope.run(function* () {
       return 1;
     });
@@ -23,17 +23,17 @@ describe("Scope", () => {
 
   it("succeeds on close if the frame has errored", async () => {
     let error = new Error("boom!");
-    let scope = createScope();
+    let [scope, close] = createScope();
     let bomb = scope.run(function* () {
       throw error;
     });
     await expect(bomb).rejects.toEqual(error);
-    await expect(scope.close()).resolves.toBeUndefined();
+    await expect(close()).resolves.toBeUndefined();
   });
 
   it("errors on close if there is an problem in teardown", async () => {
     let error = new Error("boom!");
-    let scope = createScope();
+    let [scope, close] = createScope();
     scope.run(function* () {
       try {
         yield* suspend();
@@ -42,12 +42,12 @@ describe("Scope", () => {
         throw error;
       }
     });
-    await expect(scope.close()).rejects.toEqual(error);
+    await expect(close()).rejects.toEqual(error);
   });
 
   it("still closes open resources whenever something errors", async () => {
     let error = new Error("boom!");
-    let scope = createScope();
+    let [scope, close] = createScope();
     let tester: Tester = {};
 
     scope.run(function* () {
@@ -58,7 +58,7 @@ describe("Scope", () => {
     scope.run(function* () {
       throw error;
     });
-    await expect(scope.close()).resolves.toEqual(void 0);
+    await expect(close()).resolves.toEqual(void 0);
     expect(tester.status).toEqual("closed");
   });
 


### PR DESCRIPTION
## Motivation

Part two of the scope improvements in #751 That is, closing a scope is an option available to the code that created the scope. Those who merely use the scope, do not need to be able to close it.

```js
let [scope, close] = createScope();
try {
  await scope.run(someOperation);
} finally {
  await close();
}
```

## Approach

Move the close function off of the scope

### Alternate Designs

I did consider also making the tuple returned by `createScope` an interface so that it could be captured as a single object and/or destructured.

```js
let newScope = createScope();
await newScope.run(myOp);
await newScope.close();
```

It would still allow restructuring:

```js
let { scope, close } = createScope();
```

Funny, now I'm kinda leaning towards this... The main reason to have the tuple instead of the record is that it is very easy to rename the function references in your destructuring assignment.

```js
let [testScope, teardown] = createScope();
```
vs
```js
let { scope: testScope, close: teardown } = createScope();
```
