### PR TITLE
✨get/set context values from `Scope` API

### DIFF
--- a/lib/context.ts
+++ b/lib/context.ts
@@ -1,32 +1,29 @@
 import type { Context } from "./types.ts";
-import { getframe } from "./instructions.ts";
+import { create } from "./run/create.ts";
+import { useScope } from "./run/scope.ts";
 
-export function createContext<T>(name: string, defaultValue?: T): Context<T> {
-  function* get() {
-    let frame = yield* getframe();
+export function createContext<T>(key: string, defaultValue?: T): Context<T> {
+  let context: Context<T> = create<Context<T>>(`Context`, { key }, {
+    defaultValue,
+    *get() {
+      let scope = yield* useScope();
+      return scope.get(context);
+    },
+    *set(value: T) {
+      let scope = yield* useScope();
+      return scope.set(context, value);
+    },
+    *[Symbol.iterator]() {
+      let value = yield* context.get();
+      if (typeof value === "undefined") {
+        throw new MissingContextError(`missing required context: '${key}'`);
+      } else {
+        return value;
+      }
+    },
+  });
 
-    return (frame.context[name] ?? defaultValue) as T | undefined;
-  }
-
-  function* set(value: T) {
-    let frame = yield* getframe();
-
-    frame.context[name] = value;
-
-    return value;
-  }
-
-  function* expect() {
-    let value = yield* get();
-
-    if (typeof value === "undefined") {
-      throw new MissingContextError(`missing required context: '${name}'`);
-    } else {
-      return value;
-    }
-  }
-
-  return { get, set, [Symbol.iterator]: expect };
+  return context;
 }
 
 class MissingContextError extends Error {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -56,6 +56,8 @@ export type Provide<T> = (value: T) => Operation<void>;
 
 export interface Scope {
   run<T>(operation: () => Operation<T>): Task<T>;
+  get<T>(context: Context<T>): T | undefined;
+  set<T>(context: Context<T>, value: T): T;
 }
 
 export type Stream<T, TReturn> = Operation<Subscription<T, TReturn>>;
@@ -83,6 +85,16 @@ export interface Channel<T, TClose> {
  * value, then a `MissingContextError` will be raised.
  */
 export interface Context<T> extends Operation<T> {
+  /**
+   * A unique identifier for this context.
+   */
+  readonly key: string;
+
+  /**
+   * The value of the context if has not been defined for the current operation.
+   */
+  readonly defaultValue?: T;
+
   /**
    * Set the value of the Context for the current scope.
    */

--- a/test/scope.test.ts
+++ b/test/scope.test.ts
@@ -97,6 +97,15 @@ describe("Scope", () => {
       expect(third).toEqual(2);
     });
   });
+
+  it("can get and set a context programatically", async () => {
+    let context = createContext<string>("aString");
+    let [scope] = createScope();
+    expect(scope.get(context)).toEqual(void 0);
+    expect(scope.set(context, "Hello World!")).toEqual("Hello World!");
+    expect(scope.get(context)).toEqual("Hello World!");
+    await expect(scope.run(() => context)).resolves.toEqual("Hello World!");
+  });
 });
 
 interface Tester {


### PR DESCRIPTION
## Motivation

> This is part 3 of 3 in #751 

Whenever you are creating a scope from scratch, you need to be able to interact with the context to make sure that things are available for children of that scope.

<!-- REQUIRED
  Why are you introducing this change? Why is this change necessary? What
  are you trying to achieve with this change?
  If you have a relevant issue, add a link directly to the URL here.
 -->

## Approach

This adds the `get/set` method to scope, and then switches Context to use them to do its job.
