### PR TITLE
✨Add `Signal` and `Queue` interfaces for stream creation

### DIFF
--- a/lib/mod.ts
+++ b/lib/mod.ts
@@ -18,3 +18,5 @@ export * from "./events.ts";
 export * from "./main.ts";
 export * from "./all.ts";
 export * from "./each.ts";
+export * from "./queue.ts";
+export * from "./signal.ts";

--- a/lib/queue.ts
+++ b/lib/queue.ts
@@ -1,0 +1,97 @@
+import type { Resolve, Subscription } from "./types.ts";
+import { action, suspend } from "./instructions.ts";
+
+/**
+ * A FIFO queue which can be used to implement the {@link Subscription}
+ * interface directly. Most of the time, you will use either a {@link Signal}
+ * or a {@link Channel} as the mechanism, but `Queue` allows you to manage
+ * a single subscription directly.
+ *
+ * @typeParam T the type of the items in the queue
+ * @typeParam TClose the type of the value that the queue is closed with
+ */
+export interface Queue<T, TClose> {
+  /**
+   * Add a value to the queue. The oldest value currently in the queue will
+   * be the first to be read.
+   * @param item - the value to add
+   */
+  add(item: T): void;
+
+  /**
+   * Close the queue.
+   * @param value - the queue's final value.
+   */
+  close(value: TClose): void;
+
+  /**
+   * A subscription representing the values of the queue. Values added soonest
+   * will be available soonest. Any callers awaiting the `next()` value of the
+   * subscription will contend for the same buffer of values.
+   */
+  subscription: Subscription<T, TClose>;
+}
+
+/**
+ * Creates a new queue. Queues are unlimited in size and sending a message to a
+ * queue is always synchronous.
+ *
+ * @example
+ *
+ * ```javascript
+ * import { each, main, createQueue } from 'effection';
+ *
+ * await main(function*() {
+ *   let queue = createQueue<number>();
+ *   queue.send(1);
+ *   queue.send(2);
+ *   queue.send(3);
+ *
+ *   let next = yield* queue.subscription.next();
+ *   while (!next.done) {
+ *     console.log("got number", next.value);
+ *     next = yield* queue.subscription.next();
+ *   }
+ * });
+ * ```
+ *
+ * @typeParam T the type of the items in the queue
+ * @typeParam TClose the type of the value that the queue is closed with
+ */
+export function createQueue<T, TClose>(): Queue<T, TClose> {
+  type Item = IteratorResult<T, TClose>;
+
+  let items: Item[] = [];
+  let consumers = new Set<Resolve<Item>>();
+
+  function enqueue(item: Item) {
+    items.unshift(item);
+    while (items.length > 0 && consumers.size > 0) {
+      let [consume] = consumers;
+      let top = items.pop() as Item;
+      consume(top);
+    }
+  }
+
+  return {
+    add: (value) => enqueue({ done: false, value }),
+    close: (value) => enqueue({ done: true, value }),
+    subscription: {
+      *next() {
+        let item = items.pop();
+        if (item) {
+          return item;
+        } else {
+          return yield* action<Item>(function* (resolve) {
+            try {
+              consumers.add(resolve);
+              yield* suspend();
+            } finally {
+              consumers.delete(resolve);
+            }
+          });
+        }
+      },
+    },
+  };
+}

--- a/lib/signal.ts
+++ b/lib/signal.ts
@@ -1,0 +1,110 @@
+import type { Stream } from "./types.ts";
+
+import { createQueue, type Queue } from "./queue.ts";
+import { resource } from "./instructions.ts";
+
+/**
+ * Convert plain JavaScript function calls into a {link @Stream} that can
+ * be consumed within an operation. If no operation is subscribed to a signal's
+ * stream, then sending messages to it is a no-op.
+ *
+ * Signals are particularly suited to be installed as event listeners.
+ *
+ * @example
+ * ```ts
+ * import { createSignal, each } from "effection";
+ *
+ * export function* logClicks(function*(button) {
+ *   let { send, stream } = createSignal<MouseEvent>();
+ *
+ *   button.addEventListener("click", send);
+ *
+ *   try {
+ *     for (let click of yield* each(stream)) {
+ *       console.log(`click:`, click);
+ *       yield* each.next;
+ *     }
+ *   } finally {
+ *     button.removeEventListener("click", send);
+ *   }
+ * })
+ * ````
+ *
+ * @typeParam T - type of each event sent by this signal
+ * @typeParam TClose - type of the final event sent by this signal
+ */
+export interface Signal<T, TClose> {
+  /**
+   * Send a value to all the consumers of this signal.
+   *
+   * @param value - the value to send.
+   */
+  send(value: T): void;
+
+  /**
+   * Send the final value of this signal to all its consumers.
+   * @param value - the final value.
+   */
+  close(value: TClose): void;
+
+  /**
+   * The {@link Stream} that receives events that are sent to this signal.
+   */
+  stream: Stream<T, TClose>;
+}
+
+/**
+ * Create a new {@link Signal}
+ *
+ * Signal should be used when you need to send messages to a stream
+ * from _outside_ of an operation. The most common case of this is to
+ * connect a plain, synchronous JavaScript callback to an operation.
+ *
+ * @example
+ * ```javascript
+ * function* logClicks(button) {
+ *   let clicks = createSignal<MouseEvent>();
+ *   try {
+ *     button.addEventListener("click", clicks.send);
+ *
+ *     for (let click of yield* each(clicks)) {
+ *       console.log("click", click);
+ *     }
+ *    } finally {
+ *      button.removeEventListener("click", clicks.send);
+ *    }
+ * }
+ * ```
+ *
+ * Do not use a signal to send messages from within an operation as it could
+ * result in out-of-scope code being executed. In those cases, you should use a
+ * {@link Channel}.
+ */
+export function createSignal<T, TClose = never>(): Signal<T, TClose> {
+  let subscribers = new Set<Queue<T, TClose>>();
+
+  let stream: Stream<T, TClose> = resource(function* Subscription(provide) {
+    let queue = createQueue<T, TClose>();
+    subscribers.add(queue);
+
+    try {
+      yield* provide(queue.subscription);
+    } finally {
+      subscribers.delete(queue);
+    }
+  });
+
+  function send(value: T) {
+    for (let queue of [...subscribers]) {
+      queue.add(value);
+    }
+  }
+
+  function close(value: TClose) {
+    for (let queue of [...subscribers]) {
+      queue.close(value);
+    }
+  }
+
+  return { send, close, stream };
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -71,8 +71,24 @@ export interface Port<T, R> {
   close(value: R): Operation<void>;
 }
 
+/**
+ * A broadcast channel that multiple consumers can subscribe to the
+ * via same {@link `Stream`}, and messages sent to the channel are
+ * received by all consumers. The channel is not buffered, so if there
+ * are no consumers, the message is dropped.
+ *
+ * @typeParam T - type of channel messages
+ * @typeParam TClose - type of final channel value
+ */
 export interface Channel<T, TClose> {
+  /**
+   * The port through which messages to the channel are sent.
+   */
   input: Port<T, TClose>;
+
+  /**
+   * The stream through which all messages to the channel are read.
+   */
   output: Stream<T, TClose>;
 }
 

--- a/test/queue.test.ts
+++ b/test/queue.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "./suite.ts";
+import {
+  action,
+  createQueue,
+  type Operation,
+  run,
+  sleep,
+  spawn,
+} from "../mod.ts";
+
+describe("Queue", () => {
+  it("adds value to an already waiting listener", async () => {
+    await run(function* () {
+      let q = createQueue<string, never>();
+      let listener = yield* spawn(() => q.subscription.next());
+      q.add("hello");
+      expect(yield* listener).toEqual({ done: false, value: "hello" });
+    });
+  });
+
+  it("only adds value to one listener if there are multiple", async () => {
+    await run(function* () {
+      let { add, subscription } = createQueue<string, never>();
+      let listener1 = yield* spawn(() => abortAfter(subscription.next(), 10));
+      let listener2 = yield* spawn(() => abortAfter(subscription.next(), 10));
+      add("hello");
+      expect([yield* listener1, yield* listener2].filter(Boolean)).toEqual([{
+        done: false,
+        value: "hello",
+      }]);
+    });
+  });
+
+  it("queues value if there is no listener", async () => {
+    await run(function* () {
+      let { add, subscription } = createQueue<string, never>();
+      add("hello");
+      expect(yield* subscription.next()).toEqual({
+        done: false,
+        value: "hello",
+      });
+    });
+  });
+
+  it("can close", async () => {
+    await run(function* () {
+      let { close, subscription } = createQueue<string, number>();
+      let listener = yield* spawn(() => subscription.next());
+      close(42);
+      expect(yield* listener).toEqual({ done: true, value: 42 });
+    });
+  });
+});
+
+function abortAfter<T>(op: Operation<T>, ms: number): Operation<T | void> {
+  return action(function* (resolve, reject) {
+    yield* spawn(function* () {
+      try {
+        resolve(yield* op);
+      } catch (error) {
+        reject(error);
+      }
+    });
+    yield* sleep(ms);
+    resolve();
+  });
+}

--- a/www/docs/collections.mdx
+++ b/www/docs/collections.mdx
@@ -449,8 +449,138 @@ because the body of the loop only executes for iterator result where the `done`
 property is `false`. It does _not_ execute for the last iterator result where
 `done` is true.
 
+## Creating your own streams
+
+Most of the examples thus far have shown how to consume streams that
+are originated from within an operation, and so have used the
+preferred mechanism for that which is the [Channel][channel]. To do
+this, we run the channel's `send()` operation. But because `send()` is
+an operation, it means that in order to send a message to the stream,
+we must already have to be inside an operation. However, this poses a
+problem for events that originate from _outside_ of an operation such
+as an event listener. In this case, we need to be able to call a plain
+vanilla javascript function which is not an operation, and still
+notify any subscribers to a stream. For these cases there is the
+[`Signal`][signal] interface which can be created with
+[`createSignal`](createSignal) function.
+
+In the following example, we use a signal as an event callback to log
+all of the events
+
+
+```javascript
+import { createSignal, each } from "effection";
+
+export function* logClicks(button) {
+  let { send, stream } = createSignal();
+  try {
+    button.addEventListener("click", send);
+
+    for (let click of yield* each(stream)) {
+      console.dir({ click });
+      yield* each.next;
+    }
+  } finally {
+    button.removeEventListener("click", send);
+  }
+}
+```
+
+First, we create the signal, then attach its `send()` function to the
+event target's callback. It then loops over every click event received
+in this way and logs out its contents to the console. Notice that,
+like a well-behaved operation, we make sure to uninstall the listener
+on the button so that we left it in the same state we found it.
+
+This is a good demonstration of the concept, but it isn't as useful as
+it could be because any time we want to do something like the above to
+consume a stream of clicks, we'd first need to create a signal, attach
+the signal's callback, and then iterate over its content. For example,
+if we wanted to make an operation that disabled a button by preventing
+the default action every time, we would have to regurgitate the same
+boilerplate code as in our click logger:
+
+```javascript
+import { createSignal, each } from "effection";
+
+export function* cancelClicks(button) {
+  let { send, stream } = createSignal();
+  try {
+    button.addEventListener("click", send);
+
+    for (let click of yield* each(stream)) {
+      click.preventDefault();
+      yield* each.next;
+    }
+  } finally {
+    button.removeEventListener("click", send);
+  }
+}
+```
+
+In other words, the problem with this method, is that you have to
+define the stream and consume it in the same place. But what we'd like
+to do instead is to define the stream in one place, but consume it in
+another. That way, we could specify the setup and teardown logic once,
+but utilize it multiple times. If we had a way to do that, say a `clicksOn()`
+function that could take any html element and return a stream of clicks on that
+element, then we could write something like the following:
+
+```javascript
+function* logAndCancel(button) {
+  let clicks = clicksOn(button);
+
+  yield* spawn(function*() {
+    for (let click of yield* each(clicks)) {
+      console.log(click);
+      yield* each.next;
+    }
+  })
+
+  yield* spawn(function*() {
+    for (let click of yield* each(clicks)) {
+    click.preventDefault();
+    yield* each.next;
+  }
+})
+}
+```
+
+It turns out that [resources][resources] are just what we need to make this
+happen. If you recall, a [`Stream`][stream] is just an [`Operation`][operation]
+that returns a [`Subscription`][subscription]. So the simplest way to implement
+such an operation is as a _resource that provides a subscription_.
+
+>💡Most of the time, you won't need to implement your own streams, but when you
+> do, a resource is the easiest way to do it.
+
+Armed with resources, we can now implement our hypothetical `clicksOn` utility.
+
+```javascript
+import { resource } from "effection"
+
+export function clicksOn(button) {
+  return resource(function*(provide) {
+    let { send, stream } = createSignal();
+    try {
+      button.addEventListener("click", send);
+
+      let subscription = yield* stream;
+      yield* provide(subscription);
+
+    } finally {
+      button.removeEventListener("click", send);
+    }
+  });
+}
+```
+
+We have now encapsulated the setup and teardown of our listener in a single
+place, but the actual consuming of the stream of clicks can happen anywhere.
+
 [rx]: https://rxjs.dev
 [introduction]: ./introduction
+[resources]: ./docs/resources
 [async-iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncIterator
 [async-iteration-protocols]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_async_iterator_and_async_iterable_protocols
 [asynchronous iterators]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of
@@ -458,6 +588,8 @@ property is `false`. It does _not_ execute for the last iterator result where
 [subscription]: https://deno.land/x/effection/mod.ts?s=Subscription
 [stream]: https://deno.land/x/effection/mod.ts?s=Stream
 [channel]: https://deno.land/x/effection/mod.ts?s=Channel
+[signal]: https://deno.land/x/effection/mod.ts?s=Signal
+[createSignal]: https://deno.land/x/effection/mod.ts?s=createSignal
 [filter]: https://deno.land/x/effection/mod.ts?s=filter
 [map]: https://deno.land/x/effection/mod.ts?s=map
 [pipe]: https://deno.land/x/effection/mod.ts?s=pipe


### PR DESCRIPTION
## Motivation

It turns out that `Channel` wasn't the perfect primitive because it requires a scope in which to `send()`. This is super annoying for callbacks because they are from JavasScript -> Effection and you don't have a scope. Rather than make one up, this introduces a `createSignal` function which allows you do directly dispatch events to any number of consuming operations.

## Approach

This creates a low level "Queue" class which can be used to directly manage a subscription. Signal is implemented on top of that, and then channel is implemented directly on top of that.