### PR TITLE
🐞Fix arguments passed to NodeJS

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -2,7 +2,7 @@
   "lock": false,
   "tasks": {
     "test": "deno test --allow-run=deno",
-    "test:node": "deno task build:npm 0.0.0 && node test/main/node.mjs",
+    "test:node": "deno task build:npm 0.0.0 && node test/main/node.mjs hello world",
     "build:npm": "deno run -A tasks/build-npm.ts"
   },
   "lint": {

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -86,7 +86,7 @@ export async function main(
               //@ts-expect-error type-checked by Deno, run on Node
               process.on("SIGINT", interrupt);
               //@ts-expect-error type-checked by Deno, run on Node
-              yield* body(global.process.argv.slice());
+              yield* body(global.process.argv.slice(2));
             } finally {
               //@ts-expect-error this runs on Node
               process.off("SIGINT", interrupt);

--- a/test/main/node.mjs
+++ b/test/main/node.mjs
@@ -1,5 +1,8 @@
 import { main } from "../../build/npm/esm/mod.js";
 
-await main(function* () {
+await main(function* ([hello, world]) {
+  if (hello !== "hello" && world !== "world") {
+    throw new Error("arguments were not properly passed to main operation");
+  }
   console.log("hello world");
 });


### PR DESCRIPTION
## Motivation
The process argument handling is different from Deno and NodeJS. The following script in Deno:

``` shellsession
$ deno script.ts hello world
```

will set `Deno.args` to `["hello", "world"]`. By contrast, the following in NodeJS:

``` shellsession
$ node script.mjs hello world
```

will set `process.argv` to
`["/path/to/node","/abs/path/to/script.mjs", "hello", "world"]`

The NodeJS way is similar to the argv of a `Bash` script, but the Deno way is more practical.

## Approach

This normalizes Node to behave like Deno, only passing the user arguments to the script. We can explore how to get the script name and the executable name later.