### PR TITLE
Bundle v2 documentation as release artifact.

### DIFF
--- a/.github/workflows/v2-docs.yaml
+++ b/.github/workflows/v2-docs.yaml
@@ -1,0 +1,31 @@
+name: Publish V2 Docs
+
+on:
+  push:
+    tags:
+      - "docs-v2-r*"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: volta-cli/action@v4
+      - run: |
+          yarn install
+          yarn prepack
+          yarn docs
+          tar czvf ${{ github.ref }}.apidocs.tgz -C docs api
+
+      - run: |
+          cd website
+          yarn install
+          yarn build
+          tar czvf ${{ github.ref }}.website.tgz -C public effection
+
+      - uses: ncipollo/release-action@v1
+        with:
+          artifacts:
+            - "${{ github.ref }}.website.tgz"
+            - "${{ github.ref }}.apidocs.tgz"
+          token: ${{ secrets.FRONTSIDEJACK_GITHUB_TOKEN }}

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -2,7 +2,7 @@ module.exports = {
   title: 'Effection',
   tagline: 'Structured Concurrency for JavaScript',
   url: 'https://frontside.com',
-  baseUrl: '/effection/',
+  baseUrl: '/effection/v2/',
   onBrokenLinks: 'throw',
   favicon: 'images/favicon-effection.png',
   organizationName: 'thefrontside',

--- a/website/package.json
+++ b/website/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "start": "docusaurus start --no-open",
-    "build": "docusaurus build --out-dir public/effection",
+    "build": "docusaurus build --out-dir public/effection/v2",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "serve": "docusaurus serve --dir public"
@@ -37,6 +37,6 @@
     ]
   },
   "volta": {
-    "extends": "../../package.json"
+    "extends": "../package.json"
   }
 }


### PR DESCRIPTION
## Motivation
As part of the move to v3, we're going to be moving the current documentation from `/effection/` -> `/effection/v2/`. The new website based on Deno deploy will simply serve this site at a sub url. However, in order to do this, we need to be able to access this website as a single artifact that can be downloaded and served.

## Approach

This creates a workflow on the `v2` branch that, when it sees a tag conforming to `docs-v2-r(N)` It will build the documentation and publish it as a GitHub Release. That way, the main documentation site can download it, cache it, and serve it as a static set of files from the `/v2/` subpath.

The release is comprised of both the website and the apidocs. This allows us to update v2 documentation and deploy it to the main website as needed.

As an example, pushing `docs-v2-r1` tag to the repository, will take that tag, build the website and the api docs and create a GitHub release with:

```
docs-v2-r1.website.tgz
docs-v2-r1.apidocs.tgz
```

Because the website only served as a single unit, this uses a monotonic increasing version number: r1, r2, r3, r4, etc...
