### PR TITLE
v2 docs: fix github release action specific

### DIFF
--- a/.github/workflows/v2-docs.yaml
+++ b/.github/workflows/v2-docs.yaml
@@ -22,10 +22,9 @@ jobs:
           yarn install
           yarn build
           tar czvf ${{ github.ref }}.website.tgz -C public effection
+          cp *.website.tgz ..
 
       - uses: ncipollo/release-action@v1
         with:
-          artifacts:
-            - "${{ github.ref }}.website.tgz"
-            - "${{ github.ref }}.apidocs.tgz"
+          artifacts: "*.tgz"
           token: ${{ secrets.FRONTSIDEJACK_GITHUB_TOKEN }}


### PR DESCRIPTION
## Motivation

The action schema is broken because artifacts has to be a dirglob, not an array.

