### PR TITLE
Yarn docs running out of memory

### DIFF
--- a/.github/workflows/v2-docs.yaml
+++ b/.github/workflows/v2-docs.yaml
@@ -16,6 +16,8 @@ jobs:
           yarn prepack
           yarn docs
           tar czvf ${{ github.ref }}.apidocs.tgz -C docs api
+        env:
+          NODE_OPTIONS:--max_old_space_size=8192
 
       - run: |
           cd website


### PR DESCRIPTION
## Motivation

https://github.com/thefrontside/effection/actions/runs/6382375097/job/17320834799#step:4:122

## Approach

Allow more memory when running type docs
