### PR TITLE
Use `ref_name` instead of `ref` for doc artifacts

### DIFF
--- a/.github/workflows/v2-docs.yaml
+++ b/.github/workflows/v2-docs.yaml
@@ -15,7 +15,7 @@ jobs:
           yarn install
           yarn prepack
           yarn docs
-          tar czvf ${{ github.ref }}.apidocs.tgz -C docs api
+          tar czvf ${{ github.ref_name }}.apidocs.tgz -C docs api
         env:
           NODE_OPTIONS: --max_old_space_size=8192
 
@@ -23,7 +23,7 @@ jobs:
           cd website
           yarn install
           yarn build
-          tar czvf ${{ github.ref }}.website.tgz -C public effection
+          tar czvf ${{ github.ref_name }}.website.tgz -C public effection
           cp *.website.tgz ..
 
       - uses: ncipollo/release-action@v1


### PR DESCRIPTION
## Motivation

The workflow context `github.ref` contains the full path to the ref inside the git repository: e.g. `/refs/tags/docs-v2-r1`, but we actually just want the `ref_name` which in the former case would be `docs-v2-r1`.

## Learning

https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
