### PR TITLE
Add nice name and description for release

### DIFF
--- a/.github/workflows/v2-docs.yaml
+++ b/.github/workflows/v2-docs.yaml
@@ -26,7 +26,12 @@ jobs:
           tar czvf ${{ github.ref_name }}.website.tgz -C public effection
           cp *.website.tgz ..
 
+      - run: node -pe '`relnum=${"${{ github.ref_name }}".substring("docs-v2-r".length)}`' >> $GITHUB_OUTPUT
+        id: relnum
+
       - uses: ncipollo/release-action@v1
         with:
+          name: V2 Documentation R${{ steps.relnum.outputs.relnum }}
+          body: Website and API documentation for Effection V2 (R${{ steps.relnum.outputs.relnum  }})
           artifacts: "*.tgz"
           token: ${{ secrets.FRONTSIDEJACK_GITHUB_TOKEN }}


### PR DESCRIPTION
## Motivation

The V2 doc release is part of the source code's home page, so it should be minimally explanatory. We use it as a `s3` bucket, but it's part of our public face.

## Screenshots

![image](https://github.com/thefrontside/effection/assets/4205/7477563f-679a-4206-a85e-0d6853a1841a)

![image](https://github.com/thefrontside/effection/assets/4205/4a129761-e34e-4acb-86f0-575d141da902)
