### PR TITLE
Create parallel builds for the v2 site.

### DIFF
--- a/.github/workflows/v2-docs.yaml
+++ b/.github/workflows/v2-docs.yaml
@@ -22,9 +22,11 @@ jobs:
       - run: |
           cd website
           yarn install
-          yarn build
-          tar czvf ${{ github.ref_name }}.website.tgz -C public effection
-          cp *.website.tgz ..
+          yarn docusaurus build --config ./docusaurus.config.local.js --out-dir build/local
+          tar czvf ${{ github.ref_name }}.website.local.tgz -C build/local .
+          yarn docusaurus build --config ./docusaurus.config.prod.js --out-dir build/prod
+          tar czvf ${{ github.ref_name }}.website.prod.tgz -C build/prod .
+          cp *.tgz ..
 
       - run: node -pe '`relnum=${"${{ github.ref_name }}".substring("docs-v2-r".length)}`' >> $GITHUB_OUTPUT
         id: relnum

--- a/website/docusaurus.config.local.js
+++ b/website/docusaurus.config.local.js
@@ -1,0 +1,6 @@
+const base = require('./docusaurus.config');
+
+module.exports = {
+  ...base,
+  baseUrl: 'v2/',
+}

--- a/website/docusaurus.config.prod.js
+++ b/website/docusaurus.config.prod.js
@@ -1,0 +1,6 @@
+const base = require('./docusaurus.config');
+
+module.exports = {
+  ...base,
+  baseUrl: 'effection/v2/',
+}


### PR DESCRIPTION
## Motivation

When it is hosted in production, the website is at `effection/v2`, but when we're doing local development, the website is at `v2/`.


## Approach
Unfortunately, there is no way to control the docusaurus build at runtime, so this creates two builds, one that works at both paths.
