### PR TITLE
Mount V2 docs at /V2/ subpath in Effection V3 site

### DIFF
--- a/www/deno.json
+++ b/www/deno.json
@@ -1,6 +1,6 @@
 {
   "tasks": {
-    "dev": "deno run -A lib/watch.ts html docs lib -- deno run -A --lock-write main.ts",
+    "dev": "deno run -A lib/watch.ts html docs lib hooks -- deno run -A --lock-write main.ts",
     "build": "deno run -A docs/build.ts"
   },
   "lint": {

--- a/www/deno.lock
+++ b/www/deno.lock
@@ -8,6 +8,7 @@
       "npm:@twind/core@1.1.3": "npm:@twind/core@1.1.3",
       "npm:@twind/preset-tailwind@1.1.4": "npm:@twind/preset-tailwind@1.1.4_@twind+core@1.1.3",
       "npm:@twind/preset-typography@1.0.7": "npm:@twind/preset-typography@1.0.7_@twind+core@1.1.3",
+      "npm:hast-util-select@6.0.1": "npm:hast-util-select@6.0.1",
       "npm:hast-util-to-html@9.0.0": "npm:hast-util-to-html@9.0.0",
       "npm:rehype-add-classes@1.0.0": "npm:rehype-add-classes@1.0.0",
       "npm:rehype-autolink-headings@6.1.1": "npm:rehype-autolink-headings@6.1.1",
@@ -170,6 +171,10 @@
         "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
         "dependencies": {}
       },
+      "bcp-47-match@2.0.3": {
+        "integrity": "sha512-JtTezzbAibu8G0R9op9zb3vcWZd9JF6M0xOYGPn0fNCd7wOpRB1mU2mH9T8gaBGbAAyIIVgB2G7xG0GP98zMAQ==",
+        "dependencies": {}
+      },
       "boolbase@1.0.0": {
         "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
         "dependencies": {}
@@ -210,6 +215,10 @@
         "integrity": "sha512-HYPSb7y/Z7BNDCOrakL4raGO2zltZkbeXyAd6Tg9obzix6QhzxCotdBl6VT0Dv4vZfJGVz3WL/xaEI9Ly3ul0g==",
         "dependencies": {}
       },
+      "css-selector-parser@2.3.2": {
+        "integrity": "sha512-JjnG6/pdLJh3iqipq7kteNVtbIczsU2A1cNxb+VAiniSuNmrB/NI3us4rSCfArvlwRXYly+jZhUUfEoInSH9Qg==",
+        "dependencies": {}
+      },
       "csstype@3.1.2": {
         "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==",
         "dependencies": {}
@@ -238,6 +247,10 @@
       },
       "diff@5.1.0": {
         "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
+        "dependencies": {}
+      },
+      "direction@2.0.1": {
+        "integrity": "sha512-9S6m9Sukh1cZNknO1CWAr2QAWsbKLafQiyM5gZ7VgXHeuaoUwffKN4q6NC4A/Mf9iiPlOXQEKW/Mv/mh9/3YFA==",
         "dependencies": {}
       },
       "entities@4.5.0": {
@@ -345,6 +358,12 @@
         "integrity": "sha512-X2+RwZIMTMKpXUzlotatPzWj8bspCymtXH3cfG3iQKV+wPF53Vgaqxi/eLqGck0wKq1kS9nvoB1wchbCPEL8sg==",
         "dependencies": {}
       },
+      "hast-util-has-property@3.0.0": {
+        "integrity": "sha512-MNilsvEKLFpV604hwfhVStK0usFY/QmM5zX16bo7EjnAEGofr5YyI37kzopBlZJkHD4t887i+q/C8/tr5Q94cA==",
+        "dependencies": {
+          "@types/hast": "@types/hast@3.0.1"
+        }
+      },
       "hast-util-heading-rank@2.1.1": {
         "integrity": "sha512-iAuRp+ESgJoRFJbSyaqsfvJDY6zzmFoEnL1gtz1+U8gKtGGj1p0CVlysuUAUjq95qlZESHINLThwJzNGmgGZxA==",
         "dependencies": {
@@ -408,6 +427,27 @@
           "zwitch": "zwitch@1.0.5"
         }
       },
+      "hast-util-select@6.0.1": {
+        "integrity": "sha512-KPNOtLqeJCcFRyxQm9BakO3bdIQfremXraw4mh9jxsJ+L593v/VdP3G9Dfjahacl/bw8PPvIFseaXzElKOYRpA==",
+        "dependencies": {
+          "@types/hast": "@types/hast@3.0.1",
+          "@types/unist": "@types/unist@3.0.0",
+          "bcp-47-match": "bcp-47-match@2.0.3",
+          "comma-separated-tokens": "comma-separated-tokens@2.0.3",
+          "css-selector-parser": "css-selector-parser@2.3.2",
+          "devlop": "devlop@1.1.0",
+          "direction": "direction@2.0.1",
+          "hast-util-has-property": "hast-util-has-property@3.0.0",
+          "hast-util-to-string": "hast-util-to-string@3.0.0",
+          "hast-util-whitespace": "hast-util-whitespace@3.0.0",
+          "not": "not@0.1.0",
+          "nth-check": "nth-check@2.1.1",
+          "property-information": "property-information@6.3.0",
+          "space-separated-tokens": "space-separated-tokens@2.0.2",
+          "unist-util-visit": "unist-util-visit@5.0.0",
+          "zwitch": "zwitch@2.0.4"
+        }
+      },
       "hast-util-to-estree@2.3.3": {
         "integrity": "sha512-ihhPIUPxN0v0w6M5+IiAZZrn0LH2uZomeWwhn7uP7avZC6TE7lIiEh2yBMPr5+zi1aUCXq6VoYRgs2Bw9xmycQ==",
         "dependencies": {
@@ -461,6 +501,12 @@
         "integrity": "sha512-02AQ3vLhuH3FisaMM+i/9sm4OXGSq1UhOOCpTLLQtHdL3tZt7qil69r8M8iDkZYyC0HCFylcYoP+8IO7ddta1A==",
         "dependencies": {
           "@types/hast": "@types/hast@2.3.6"
+        }
+      },
+      "hast-util-to-string@3.0.0": {
+        "integrity": "sha512-OGkAxX1Ua3cbcW6EJ5pT/tslVb90uViVkcJ4ZZIMW/R33DX/AkcJcRrPebPwJkHYwlDHXz4aIwvAAaAdtrACFA==",
+        "dependencies": {
+          "@types/hast": "@types/hast@3.0.1"
         }
       },
       "hast-util-whitespace@1.0.4": {
@@ -1129,6 +1175,12 @@
       },
       "nth-check@1.0.2": {
         "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
+        "dependencies": {
+          "boolbase": "boolbase@1.0.0"
+        }
+      },
+      "nth-check@2.1.1": {
+        "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
         "dependencies": {
           "boolbase": "boolbase@1.0.0"
         }

--- a/www/deno.lock
+++ b/www/deno.lock
@@ -2,6 +2,7 @@
   "version": "3",
   "packages": {
     "specifiers": {
+      "npm:@hazae41/foras@2.1.1": "npm:@hazae41/foras@2.1.1",
       "npm:@jsdevtools/rehype-toc@3.0.2": "npm:@jsdevtools/rehype-toc@3.0.2",
       "npm:@mdx-js/mdx@2.3.0": "npm:@mdx-js/mdx@2.3.0",
       "npm:@twind/core@1.1.3": "npm:@twind/core@1.1.3",
@@ -19,6 +20,24 @@
       "npm:unified@10.1.2": "npm:unified@10.1.2"
     },
     "npm": {
+      "@hazae41/foras@2.1.1": {
+        "integrity": "sha512-iBWx2Q0UYn4IFjdL043Kv1fJCytKFZwtx7DzGHcpDeg+zuEJklsM+oQkRmnUvrJCz/kBKdPQfCjNwDZ4kCc09w==",
+        "dependencies": {
+          "@hazae41/result": "@hazae41/result@1.1.4"
+        }
+      },
+      "@hazae41/option@1.0.22": {
+        "integrity": "sha512-/cNF5CITJMDOkQdIofM0qNEVLBvD7o8ZxBi9G9ypOU9j/8tGuFx2iMlDacnc5DdxY7Xutsyk9iZ7XtVuY4F82A==",
+        "dependencies": {
+          "@hazae41/result": "@hazae41/result@1.1.4"
+        }
+      },
+      "@hazae41/result@1.1.4": {
+        "integrity": "sha512-vTXpiiX8w0DLW1U8SIr195q/roK+fHet6pz46ESEdWNT+GAO7mIk1ME47nA8mEGSiuRBqR6STxJLKNelPaiTig==",
+        "dependencies": {
+          "@hazae41/option": "@hazae41/option@1.0.22"
+        }
+      },
       "@jsdevtools/rehype-toc@3.0.2": {
         "integrity": "sha512-n5JEf16Wr4mdkRMZ8wMP/wN9/sHmTjRPbouXjJH371mZ2LEGDl72t8tEsMRNFerQN/QJtivOxqK1frdGa4QK5Q==",
         "dependencies": {}
@@ -1549,6 +1568,37 @@
     "https://deno.land/std@0.190.0/path/win32.ts": "d186344e5583bcbf8b18af416d13d82b35a317116e6460a5a3953508c3de5bba",
     "https://deno.land/std@0.190.0/streams/byte_slice_stream.ts": "225d57263a34325d7c96cb3dafeb478eec0e6fd05cd0458d678752eadd132bb4",
     "https://deno.land/std@0.190.0/version.ts": "c3fdbeb886289441c29bb900612bb35815659717391f631be2c14a34fca40c52",
+    "https://deno.land/std@0.203.0/archive/_common.ts": "a25e3f8089ac3fddd968f73693be9d56bd5fbfa1d4b483828dbce829bb518bd2",
+    "https://deno.land/std@0.203.0/archive/untar.ts": "c3a0100fb005d66c5e42ef55dd268c368b894954fa27c9fb3ecafd73af22e877",
+    "https://deno.land/std@0.203.0/assert/assert.ts": "9a97dad6d98c238938e7540736b826440ad8c1c1e54430ca4c4e623e585607ee",
+    "https://deno.land/std@0.203.0/assert/assertion_error.ts": "4d0bde9b374dfbcbe8ac23f54f567b77024fb67dbb1906a852d67fe050d42f56",
+    "https://deno.land/std@0.203.0/bytes/copy.ts": "939d89e302a9761dcf1d9c937c7711174ed74c59eef40a1e4569a05c9de88219",
+    "https://deno.land/std@0.203.0/collections/_utils.ts": "5114abc026ddef71207a79609b984614e66a63a4bda17d819d56b0e72c51527e",
+    "https://deno.land/std@0.203.0/collections/deep_merge.ts": "9db788ba56cb05b65c77166b789e58e125dff159b7f41bf4d19dc1cba19ecb8b",
+    "https://deno.land/std@0.203.0/encoding/_util.ts": "f368920189c4fe6592ab2e93bd7ded8f3065b84f95cd3e036a4a10a75649dcba",
+    "https://deno.land/std@0.203.0/encoding/base64.ts": "cc03110d6518170aeaa68ec97f89c6d6e2276294b30807e7332591d7ce2e4b72",
+    "https://deno.land/std@0.203.0/http/etag.ts": "807382795850cde5c437c74bcc09392bc0fc56de348fc1271f383f4b28935b9f",
+    "https://deno.land/std@0.203.0/http/http_status.ts": "8a7bcfe3ac025199ad804075385e57f63d055b2aed539d943ccc277616d6f932",
+    "https://deno.land/std@0.203.0/http/util.ts": "4cf044067febaa26d0830e356b0f3a5f76d701a60d7ff7a516fad7b192f4c3a7",
+    "https://deno.land/std@0.203.0/io/buf_reader.ts": "f7a43953b05eecbaea56ebcb654035bc91e117d6986a0b2d346c1d0de1d4dac4",
+    "https://deno.land/std@0.203.0/io/buffer.ts": "2108faba32659e5a390bb59b1b4578ff0120b185d9310dd6fbf3b3a3d5775715",
+    "https://deno.land/std@0.203.0/media_types/_db.ts": "7606d83e31f23ce1a7968cbaee852810c2cf477903a095696cdc62eaab7ce570",
+    "https://deno.land/std@0.203.0/media_types/_util.ts": "0879b04cc810ff18d3dcd97d361e03c9dfb29f67d7fc4a9c6c9d387282ef5fe8",
+    "https://deno.land/std@0.203.0/media_types/content_type.ts": "ad98a5aa2d95f5965b2796072284258710a25e520952376ed432b0937ce743bc",
+    "https://deno.land/std@0.203.0/media_types/format_media_type.ts": "f5e1073c05526a6f5a516ac5c5587a1abd043bf1039c71cde1166aa4328c8baf",
+    "https://deno.land/std@0.203.0/media_types/get_charset.ts": "18b88274796fda5d353806bf409eb1d2ddb3f004eb4bd311662c4cdd8ac173db",
+    "https://deno.land/std@0.203.0/media_types/parse_media_type.ts": "31ccf2388ffab31b49500bb89fa0f5de189c8897e2ee6c9954f207637d488211",
+    "https://deno.land/std@0.203.0/media_types/type_by_extension.ts": "8c210d4e28ea426414dd8c61146eefbcc7e091a89ccde54bbbe883a154856afd",
+    "https://deno.land/std@0.203.0/media_types/vendor/mime-db.v1.52.0.ts": "6925bbcae81ca37241e3f55908d0505724358cda3384eaea707773b2c7e99586",
+    "https://deno.land/std@0.203.0/path/_constants.ts": "e49961f6f4f48039c0dfed3c3f93e963ca3d92791c9d478ac5b43183413136e0",
+    "https://deno.land/std@0.203.0/path/_extname.ts": "eaaa5aae1acf1f03254d681bd6a8ce42a9cb5b7ff2213a9d4740e8ab31283664",
+    "https://deno.land/std@0.203.0/path/_join.ts": "815f5e85b042285175b1492dd5781240ce126c23bd97bad6b8211fe7129c538e",
+    "https://deno.land/std@0.203.0/path/_normalize.ts": "a19ec8706b2707f9dd974662a5cd89fad438e62ab1857e08b314a8eb49a34d81",
+    "https://deno.land/std@0.203.0/path/_os.ts": "30b0c2875f360c9296dbe6b7f2d528f0f9c741cecad2e97f803f5219e91b40a2",
+    "https://deno.land/std@0.203.0/path/_util.ts": "4e191b1bac6b3bf0c31aab42e5ca2e01a86ab5a0d2e08b75acf8585047a86221",
+    "https://deno.land/std@0.203.0/path/extname.ts": "62c4b376300795342fe1e4746c0de518b4dc9c4b0b4617bfee62a2973a9555cf",
+    "https://deno.land/std@0.203.0/path/join.ts": "31c5419f23d91655b08ec7aec403f4e4cd1a63d39e28f6e42642ea207c2734f8",
+    "https://deno.land/std@0.203.0/streams/read_all.ts": "3b20a50af87d1bfebefa9c2dbda49e2b214d8ab0382ffdcc8ce858af80a912be",
     "https://deno.land/x/continuation@0.1.5/mod.ts": "690def2735046367b3e1b4bc6e51b5912f2ed09c41c7df7a55c060f23720ad33",
     "https://deno.land/x/hastx@v0.0.5/jsx-runtime.ts": "5e1db59ceea4834b8d248a018a5adfc73a09922d8dcdaa3a3bb228c884da0f6c"
   }

--- a/www/hooks/use-v2-docs.ts
+++ b/www/hooks/use-v2-docs.ts
@@ -1,0 +1,129 @@
+import type { Operation } from "effection";
+import { each, expect, resource, spawn, stream } from "effection";
+import { Foras, GzDecoder } from "npm:@hazae41/foras@2.1.1";
+import { Untar } from "https://deno.land/std@0.203.0/archive/untar.ts";
+import { serveTar, type TarEntry } from "freejack/serve-tar.ts";
+import type { ServeHandler } from "../lib/types.ts";
+
+export interface V2Docs {
+  serveWebsite: ServeHandler;
+  serveApidocs: ServeHandler;
+}
+
+export interface UseV2DocsOptions {
+  revision: number | {
+    website: string;
+    apidocs: string;
+  };
+}
+
+const variant = Deno.env.get("V2_WEBSITE_VARIENT_PROD") ?? "local";
+
+export function useV2Docs(options: UseV2DocsOptions): Operation<V2Docs> {
+  return resource(function* (provide) {
+    let { revision } = options;
+
+    let websiteArchiveUrl = typeof revision === "number"
+      ? `https://github.com/thefrontside/effection/releases/download/docs-v2-r${revision}/docs-v2-r${revision}.website.${variant}.tgz`
+      : revision.website;
+    let apidocsArchiveUrl = typeof revision === "number"
+      ? `https://github.com/thefrontside/effection/releases/download/docs-v2-r${revision}/docs-v2-r${revision}.apidocs.tgz`
+      : revision.apidocs;
+
+    yield* expect(Foras.initBundledOnce());
+
+    let website = yield* spawn(() => loadTar(websiteArchiveUrl));
+    let apidocs = yield* spawn(() => loadTar(apidocsArchiveUrl));
+
+    yield* provide({
+      serveWebsite: {
+        *middleware(_, request) {
+          return yield* expect(serveTar(request, {
+            tarRoot: "site",
+            urlRoot: "V2",
+            entries: yield* website,
+          }));
+        },
+      },
+      serveApidocs: {
+        *middleware(_, request) {
+          return yield* expect(serveTar(request, {
+            tarRoot: "api/v2",
+            urlRoot: "V2/api",
+            entries: yield* apidocs,
+          }));
+        },
+      },
+    });
+  });
+}
+
+function* loadTar(url: string) {
+  let response = yield* expect(fetch(url));
+  if (response.ok) {
+    let website = new Map<string, TarEntry>();
+    if (response.body) {
+      let gunzip = new GzDecoder();
+      let reader = response.body.getReader();
+      try {
+        let next = yield* expect(reader.read());
+        while (!next.done) {
+          gunzip.write(next.value);
+          next = yield* expect(reader.read());
+        }
+        gunzip.flush();
+      } finally {
+        yield* expect(reader.cancel());
+      }
+      let tar = gunzip.finish().copyAndDispose();
+      let bytesRead = 0;
+
+      let untar = new Untar({
+        read(buf) {
+          let remaining = tar.length - bytesRead;
+          let length = Math.min(remaining, buf.length);
+          if (length === 0) {
+            return Promise.resolve(null);
+          }
+          for (let i = 0; i < length; i++) {
+            buf[i] = tar[bytesRead + i];
+          }
+          bytesRead += length;
+          return Promise.resolve(length);
+        },
+      });
+
+      for (let entry of yield* each(stream(untar))) {
+        if (entry.type === "directory" && entry.fileName.endsWith("/")) {
+          //@ts-expect-error shut up
+          entry.content = new Blob();
+          //@ts-expect-error shut up
+          website.set(entry.fileName.slice(0, -1), entry);
+        } else {
+          let parts: BlobPart[] = [];
+          let buf = new Uint8Array(2048);
+          try {
+            while (true) {
+              let bytesRead = yield* expect(entry.read(buf));
+              if (bytesRead == null) {
+                break;
+              } else {
+                parts.push(buf.slice(0, bytesRead));
+              }
+            }
+          } finally {
+            yield* expect(entry.discard());
+          }
+          //@ts-expect-error shut up
+          entry.content = new Blob(parts);
+          //@ts-expect-error shut up
+          website.set(entry.fileName, entry);
+        }
+        yield* each.next;
+      }
+    }
+    return website;
+  } else {
+    throw new Error(`${response.status}: ${response.statusText}`);
+  }
+}

--- a/www/html/app.html.tsx
+++ b/www/html/app.html.tsx
@@ -31,7 +31,7 @@ export default function* AppHtml({ title }: Options): Operation<JSX.Element> {
         />
         <meta
           name="twitter:image"
-          content="/assets/images/meta-effection.png"
+          content={yield* useUrl("/assets/images/meta-effection.png")}
         />
         <link rel="icon" href="/assets/images/favicon-effection.png" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/www/html/app.html.tsx
+++ b/www/html/app.html.tsx
@@ -1,5 +1,5 @@
 import type { Operation } from "effection";
-import { outlet } from "freejack/view.ts";
+import { outlet, useUrl } from "freejack/view.ts";
 
 export interface Options {
   title: string;
@@ -19,7 +19,7 @@ export default function* AppHtml({ title }: Options): Operation<JSX.Element> {
         />
         <meta
           property="og:url"
-          content="https://frontside.com/effection/docs/guides/introduction"
+          content={yield* useUrl("/")}
         />
         <meta
           property="og:description"
@@ -37,16 +37,16 @@ export default function* AppHtml({ title }: Options): Operation<JSX.Element> {
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <link
           rel="canonical"
-          href="https://frontside.com/effection/docs/guides/introduction"
+          href={yield* useUrl("/")}
         />
         <link
           rel="alternate"
-          href="https://frontside.com/effection/docs/guides/introduction"
+          href={yield* useUrl("/")}
           hreflang="en"
         />
         <link
           rel="alternate"
-          href="https://frontside.com/effection/docs/guides/introduction"
+          href={yield* useUrl("/")}
           hreflang="x-default"
         />
         <link rel="stylesheet" href="/assets/prism-atom-one-dark.css" />
@@ -59,7 +59,10 @@ export default function* AppHtml({ title }: Options): Operation<JSX.Element> {
         <header class="header w-full top-0 p-6 sticky tracking-wide">
           <div class="flex items-center justify-between">
             <div>
-              <a href="/">
+              <a
+                href="/"
+                class="flex items-end gap-x-2 after:content-['v3'] after:inline after:relative after:top-0 after:text-sm"
+              >
                 <img
                   src="/assets/images/effection-logo.svg"
                   alt="Effection Logo"

--- a/www/html/document.html.tsx
+++ b/www/html/document.html.tsx
@@ -71,7 +71,7 @@ export default function* (doc: Doc): Operation<JSX.Element> {
                 behavior: "append",
                 properties: {
                   className:
-                    "opacity-0 group-hover:opacity-100 after:content-['#']",
+                    "opacity-0 group-hover:opacity-100 after:content-['#'] after:ml-1.5",
                 },
               }],
               [rehypeAddClasses, {

--- a/www/lib/html.ts
+++ b/www/lib/html.ts
@@ -4,12 +4,18 @@ import type { Operation } from "effection";
 import { toHtml } from "npm:hast-util-to-html@9.0.0";
 
 import { twind } from "freejack/twind.ts";
+import { BaseUrl, CurrentRequest } from "freejack/view.ts";
 
 export const html = {
   get(operation: (params: Params) => Operation<JSX.Element>): ServeHandler {
     return {
       method: "GET",
-      *middleware(params) {
+      *middleware(params, request) {
+        yield* CurrentRequest.set(request);
+        let url = new URL(request.url);
+        url.pathname = "/";
+        yield* BaseUrl.set(url);
+
         let top = yield* operation(params);
 
         twind(top);

--- a/www/lib/rebase.ts
+++ b/www/lib/rebase.ts
@@ -1,0 +1,30 @@
+import { posixNormalize } from "https://deno.land/std@0.203.0/path/_normalize.ts";
+
+import { selectAll } from "npm:hast-util-select@6.0.1";
+import type { Element } from "hastx/jsx-runtime";
+
+/**
+ * Rebase an HTML document at a different URL. This replaces all `<a href>` and
+ * `<img src>` attributes that contain an absolute path. Any path that is
+ * relative or contains a fully qualitfied URL will be left alone.
+ *
+ * @param tree - the HTML tree to transform
+ * @param baseUrl - a string representing a fully qualified url, e.g.
+ *   http://frontside.com/effection
+ */
+export function rebase(tree: JSX.Element, baseUrl?: string): void {
+  if (baseUrl) {
+    let base = new URL(baseUrl);
+    let hrefs: Element[] = selectAll('[href^="/"],[src^="/"]', tree);
+    for (let element of hrefs) {
+      let properties = element.properties!;
+
+      if (properties.href) {
+        properties.href = posixNormalize(`${base.pathname}${properties.href}`);
+      }
+      if (properties.src) {
+        properties.src = posixNormalize(`${base.pathname}${properties.src}`);
+      }
+    }
+  }
+}

--- a/www/lib/serve-tar.ts
+++ b/www/lib/serve-tar.ts
@@ -1,0 +1,343 @@
+import { createCommonResponse } from "https://deno.land/std@0.203.0/http/util.ts";
+import {
+  isRedirectStatus,
+  Status,
+} from "https://deno.land/std@0.203.0/http/http_status.ts";
+import {
+  calculate,
+  ifNoneMatch,
+} from "https://deno.land/std@0.203.0/http/etag.ts";
+import { posixNormalize } from "https://deno.land/std@0.203.0/path/_normalize.ts";
+import { extname } from "https://deno.land/std@0.203.0/path/extname.ts";
+import { contentType } from "https://deno.land/std@0.203.0/media_types/content_type.ts";
+import { join } from "https://deno.land/std@0.203.0/path/join.ts";
+import type { TarEntry as $TarEntry } from "https://deno.land/std@0.203.0/archive/untar.ts";
+
+export interface TarEntry extends $TarEntry {
+  content: Blob;
+}
+
+export interface ServeTarOptions {
+  entries: Map<string, TarEntry>;
+  urlRoot?: string;
+  tarRoot?: string;
+  enableCors?: boolean;
+  quiet?: boolean;
+  headers?: string[];
+  etagAlgorithm?: AlgorithmIdentifier;
+  showDirListing?: boolean;
+  showIndex?: boolean;
+  showDotfiles?: boolean;
+}
+
+export interface ServeTarEntryOptions {
+  /** The algorithm to use for generating the ETag.
+   *
+   * @default {"SHA-256"}
+   */
+  etagAlgorithm?: AlgorithmIdentifier;
+}
+
+/**
+ * Returns an HTTP Response with the requested file as the body.
+ * @param req The server request context used to cleanup the file handle.
+ * @param filePath Path of the file to serve.
+ */
+export async function serveTarEntry(
+  req: Request,
+  entry: TarEntry,
+  { etagAlgorithm: algorithm }: ServeTarEntryOptions = {},
+): Promise<Response> {
+  if (entry.type === "directory") {
+    await req.body?.cancel();
+    return createCommonResponse(Status.NotFound);
+  }
+
+  const headers = createBaseHeaders();
+
+  // // Set date header if access timestamp is available
+  // if (entry.atime) {
+  //   headers.set("date", fileInfo.atime.toUTCString());
+  // }
+
+  const etag = entry.mtime
+    ? await calculate({
+      mtime: new Date(entry.mtime * 1000),
+      size: entry.fileSize ?? 0,
+    }, { algorithm })
+    : await HASHED_DENO_DEPLOYMENT_ID;
+
+  // Set last modified header if last modification timestamp is available
+  if (entry.mtime) {
+    headers.set("last-modified", new Date(entry.mtime * 1000).toUTCString());
+  }
+  if (etag) {
+    headers.set("etag", etag);
+  }
+
+  if (etag || entry.mtime) {
+    // If a `if-none-match` header is present and the value matches the tag or
+    // if a `if-modified-since` header is present and the value is bigger than
+    // the access timestamp value, then return 304
+    let ifNoneMatchValue = req.headers.get("if-none-match");
+    let ifModifiedSinceValue = req.headers.get("if-modified-since");
+    if (
+      (!ifNoneMatch(ifNoneMatchValue, etag)) ||
+      (ifNoneMatchValue === null &&
+        entry.mtime &&
+        ifModifiedSinceValue &&
+        (entry.mtime * 1000) <
+          new Date(ifModifiedSinceValue).getTime() + 1000)
+    ) {
+      return createCommonResponse(Status.NotModified, null, { headers });
+    }
+  }
+
+  // Set mime-type using the file extension in filePath
+  const contentTypeValue = contentType(extname(entry.fileName));
+  if (contentTypeValue) {
+    headers.set("content-type", contentTypeValue);
+  }
+
+  const fileSize = entry.fileSize ?? 0;
+
+  const rangeValue = req.headers.get("range");
+
+  // handle range request
+  // Note: Some clients add a Range header to all requests to limit the size of the response.
+  // If the file is empty, ignore the range header and respond with a 200 rather than a 416.
+  // https://github.com/golang/go/blob/0d347544cbca0f42b160424f6bc2458ebcc7b3fc/src/net/http/fs.go#L273-L276
+  if (rangeValue && 0 < fileSize) {
+    const parsed = parseRangeHeader(rangeValue, fileSize);
+
+    // Returns 200 OK if parsing the range header fails
+    if (!parsed) {
+      // Set content length
+      headers.set("content-length", `${fileSize}`);
+
+      return createCommonResponse(Status.OK, entry.content, { headers });
+    }
+
+    // Return 416 Range Not Satisfiable if invalid range header value
+    if (
+      parsed.end < 0 ||
+      parsed.end < parsed.start ||
+      fileSize <= parsed.start
+    ) {
+      // Set the "Content-range" header
+      headers.set("content-range", `bytes */${fileSize}`);
+
+      return createCommonResponse(
+        Status.RequestedRangeNotSatisfiable,
+        undefined,
+        { headers },
+      );
+    }
+
+    // clamps the range header value
+    const start = Math.max(0, parsed.start);
+    const end = Math.min(parsed.end, fileSize - 1);
+
+    // Set the "Content-range" header
+    headers.set("content-range", `bytes ${start}-${end}/${fileSize}`);
+
+    // Set content length
+    const contentLength = end - start + 1;
+    headers.set("content-length", `${contentLength}`);
+
+    // Return 206 Partial Content
+    let sliced = entry.content.slice(start, end);
+
+    return createCommonResponse(Status.PartialContent, sliced, { headers });
+  }
+
+  // Set content length
+  headers.set("content-length", `${fileSize}`);
+
+  return createCommonResponse(Status.OK, readable(entry), { headers });
+}
+
+export async function serveTar(
+  req: Request,
+  opts: ServeTarOptions,
+): Promise<Response> {
+  let response: Response = await createServeTarResponse(req, opts);
+
+  // Do not update the header if the response is a 301 redirect.
+  const isRedirectResponse = isRedirectStatus(response.status);
+
+  if (opts.enableCors && !isRedirectResponse) {
+    response.headers.append("access-control-allow-origin", "*");
+    response.headers.append(
+      "access-control-allow-headers",
+      "Origin, X-Requested-With, Content-Type, Accept, Range",
+    );
+  }
+
+  if (!opts.quiet) serverLog(req, response.status);
+
+  if (opts.headers && !isRedirectResponse) {
+    for (const header of opts.headers) {
+      const headerSplit = header.split(":");
+      const name = headerSplit[0];
+      const value = headerSplit.slice(1).join(":");
+      response.headers.append(name, value);
+    }
+  }
+
+  return response;
+}
+
+async function createServeTarResponse(
+  req: Request,
+  opts: ServeTarOptions,
+) {
+  let target = opts.tarRoot || "";
+  let urlRoot = opts.urlRoot;
+  let showIndex = opts.showIndex ?? true;
+  //let showDotfiles = opts.showDotfiles || false;
+  let { etagAlgorithm, /* showDirListing, quiet, */ entries } = opts;
+
+  let url = new URL(req.url);
+  let decodedUrl = decodeURIComponent(url.pathname);
+  let normalizedPath = posixNormalize(decodedUrl);
+
+  if (urlRoot && !normalizedPath.startsWith("/" + urlRoot)) {
+    return createCommonResponse(Status.NotFound);
+  }
+
+  // Redirect paths like `/foo////bar` and `/foo/bar/////` to normalized paths.
+  if (normalizedPath !== decodedUrl) {
+    url.pathname = normalizedPath;
+    return Response.redirect(url, 301);
+  }
+
+  if (urlRoot) {
+    normalizedPath = normalizedPath.replace(urlRoot, "");
+  }
+
+  // Remove trailing slashes to avoid ENOENT errors
+  // when accessing a path to a file with a trailing slash.
+  while (normalizedPath.endsWith("/")) {
+    normalizedPath = normalizedPath.slice(0, -1);
+  }
+
+  let tarPath = join(target, normalizedPath);
+
+  let entry = entries.get(tarPath);
+
+  if (!entry) {
+    return createCommonResponse(Status.NotFound);
+  }
+
+  // For files, remove the trailing slash from the path.
+  if (entry.type === "file" && url.pathname.endsWith("/")) {
+    url.pathname = url.pathname.slice(0, -1);
+    return Response.redirect(url, 301);
+  }
+  // For directories, the path must have a trailing slash.
+  if (entry.type === "directory" && !url.pathname.endsWith("/")) {
+    // On directory listing pages,
+    // if the current URL's pathname doesn't end with a slash, any
+    // relative URLs in the index file will resolve against the parent
+    // directory, rather than the current directory. To prevent that, we
+    // return a 301 redirect to the URL with a slash.
+    url.pathname += "/";
+    return Response.redirect(url, 301);
+  }
+
+  // if target is file, serve file.
+  if (entry.type === "file") {
+    return await serveTarEntry(req, entry, {
+      etagAlgorithm,
+    });
+  }
+
+  // if target is directory, serve index or dir listing.
+  if (showIndex) { // serve index.html
+    const indexPath = join(tarPath, "index.html");
+
+    let indexEntry = entries.get(indexPath);
+    if (indexEntry?.type === "file") {
+      return await serveTarEntry(req, indexEntry, {
+        etagAlgorithm,
+      });
+    }
+  }
+
+  // if (showDirListing) { // serve directory list
+  //   return serveTarIndex(fsPath, { showDotfiles, target, quiet });
+  // }
+
+  return createCommonResponse(Status.NotFound);
+}
+
+function createBaseHeaders(): Headers {
+  return new Headers({
+    server: "tar",
+    // Set "accept-ranges" so that the client knows it can make range requests on future requests
+    "accept-ranges": "bytes",
+  });
+}
+
+function serverLog(req: Request, status: number) {
+  const d = new Date().toISOString();
+  const dateFmt = `[${d.slice(0, 10)} ${d.slice(11, 19)}]`;
+  const url = new URL(req.url);
+  const s = `${dateFmt} [${req.method}] ${url.pathname}${url.search} ${status}`;
+  // using console.debug instead of console.log so chrome inspect users can hide request logs
+  console.debug(s);
+}
+
+const ENV_PERM_STATUS =
+  Deno.permissions.querySync?.({ name: "env", variable: "DENO_DEPLOYMENT_ID" })
+    .state ?? "granted"; // for deno deploy
+const DENO_DEPLOYMENT_ID = ENV_PERM_STATUS === "granted"
+  ? Deno.env.get("DENO_DEPLOYMENT_ID")
+  : undefined;
+const HASHED_DENO_DEPLOYMENT_ID = DENO_DEPLOYMENT_ID
+  ? calculate(DENO_DEPLOYMENT_ID, { weak: true })
+  : undefined;
+
+/**
+ * parse range header.
+ *
+ * ```ts ignore
+ * parseRangeHeader("bytes=0-100",   500); // => { start: 0, end: 100 }
+ * parseRangeHeader("bytes=0-",      500); // => { start: 0, end: 499 }
+ * parseRangeHeader("bytes=-100",    500); // => { start: 400, end: 499 }
+ * parseRangeHeader("bytes=invalid", 500); // => null
+ * ```
+ *
+ * Note: Currently, no support for multiple Ranges (e.g. `bytes=0-10, 20-30`)
+ */
+function parseRangeHeader(rangeValue: string, fileSize: number) {
+  const rangeRegex = /bytes=(?<start>\d+)?-(?<end>\d+)?$/u;
+  const parsed = rangeValue.match(rangeRegex);
+
+  if (!parsed || !parsed.groups) {
+    // failed to parse range header
+    return null;
+  }
+
+  const { start, end } = parsed.groups;
+  if (start !== undefined) {
+    if (end !== undefined) {
+      return { start: +start, end: +end };
+    } else {
+      return { start: +start, end: fileSize - 1 };
+    }
+  } else {
+    if (end !== undefined) {
+      // example: `bytes=-100` means the last 100 bytes.
+      return { start: fileSize - +end, end: fileSize - 1 };
+    } else {
+      // failed to parse range header
+      return null;
+    }
+  }
+}
+
+function readable(entry: TarEntry): BodyInit {
+  return entry.content;
+}

--- a/www/lib/server.ts
+++ b/www/lib/server.ts
@@ -83,10 +83,11 @@ export function serve(paths: Record<string, ServeHandler>): Operation<Handler> {
           } else {
             let segment = result[0];
             let handler = segment.handler as ServeHandler;
-            if (request.method.toUpperCase() === handler.method) {
+            if (
+              !handler.method || request.method.toUpperCase() === handler.method
+            ) {
               return yield* handler.middleware(segment.params, request);
             } else {
-              console.dir({ not: "found" });
               return new Response("Not Found", {
                 status: 404,
                 statusText: "Not Found",

--- a/www/lib/types.ts
+++ b/www/lib/types.ts
@@ -4,6 +4,6 @@ import type { HttpMethod } from "https://deno.land/std@0.188.0/http/method.ts";
 export type Params = Record<string, string>;
 
 export interface ServeHandler {
-  method: HttpMethod;
+  method?: HttpMethod;
   middleware: (params: Params, request: Request) => Operation<Response>;
 }

--- a/www/lib/view.ts
+++ b/www/lib/view.ts
@@ -1,3 +1,4 @@
+import { posixNormalize } from "https://deno.land/std@0.203.0/path/_normalize.ts";
 import { createContext, type Operation } from "effection";
 
 const Outlet = createContext<JSX.Element>("outlet");
@@ -18,4 +19,29 @@ export function* render(
     content = yield* template;
   }
   return content;
+}
+
+export const BaseUrl = createContext<URL>("baseUrl");
+
+export function* useBaseUrl(): Operation<URL> {
+  return yield* BaseUrl;
+}
+
+export const CurrentRequest = createContext<Request>("Request");
+
+export function* useRequest() {
+  return yield* CurrentRequest;
+}
+
+export function* useUrl(path: string): Operation<string> {
+  let normalizedPath = posixNormalize(path);
+  if (normalizedPath.startsWith("/")) {
+    let base = yield* BaseUrl;
+    let url = new URL(base);
+    url.pathname = posixNormalize(`${base.pathname}${path}`);
+    return url.toString();
+  } else {
+    let request = yield* useRequest();
+    return new URL(path, request.url).toString();
+  }
 }

--- a/www/server.ts
+++ b/www/server.ts
@@ -2,10 +2,13 @@ import { serve } from "freejack/server.ts";
 import { html } from "freejack/html.ts";
 import { render } from "freejack/view.ts";
 import { Docs, loadDocs, useDocs } from "./docs/docs.ts";
+import { useV2Docs } from "./hooks/use-v2-docs.ts";
 
 import { AppHtml, DocumentHtml, IndexHtml } from "./html/templates.ts";
 
 export default function* start() {
+  let v2docs = yield* useV2Docs({ revision: 3 });
+
   let docs = yield* loadDocs();
   yield* Docs.set(docs);
 
@@ -31,5 +34,10 @@ export default function* start() {
         DocumentHtml(doc),
       );
     }),
+
+    "/V2": v2docs.serveWebsite,
+    "/V2/*path": v2docs.serveWebsite,
+    "/V2/api": v2docs.serveApidocs,
+    "/V2/api/*path": v2docs.serveApidocs,
   });
 }

--- a/www/server.ts
+++ b/www/server.ts
@@ -7,7 +7,10 @@ import { useV2Docs } from "./hooks/use-v2-docs.ts";
 import { AppHtml, DocumentHtml, IndexHtml } from "./html/templates.ts";
 
 export default function* start() {
-  let v2docs = yield* useV2Docs({ revision: 3 });
+  let v2docs = yield* useV2Docs({
+    fetchEagerly: !!Deno.env.get("V2_DOCS_FETCH_EAGERLY"),
+    revision: 3,
+  });
 
   let docs = yield* loadDocs();
   yield* Docs.set(docs);


### PR DESCRIPTION
## Motivation

As part of https://github.com/thefrontside/effection/issues/767, we want to make sure that V2 documentation is always accessible to users as they migrate.

## Approach

Rather than maintain three websites and three deployments (V3, V2, and V2-apidocs), two on netlify, and the other deno.com, this consolidates all three into a single, simple server on deno.com

The html for the V3 site is served via html templates, the `V2` sites are served by downloading [pre-built versions from Github Releases](https://github.com/thefrontside/effection/releases/tag/docs-v2-r3) as `.tgz` files. Once downloaded, they are kept in memory until the server is restarted so serving is as fast, or faster than from the file system.

There is a slight wrinkle in Docusaurus (the docs tool used for v3) in that it cannot handle being mounted at different base urls without having to re-build, so there is a `local.tgz` version which assumes `/V2` as the basis for the V2 site, and `prod.tgz` which is built with `/effection/V2/` as its base for the `v2 site` since it will be served from `https://frontside.com/effection/V2`

### Previews

- **V2** https://effection--mount-v2-docs-onto-v3.deno.dev/V2/
- **V2 API** https://effection--mount-v2-docs-onto-v3.deno.dev/V2/api/
- **V3** https://effection--mount-v2-docs-onto-v3.deno.dev/

### Implementation Notes

The portion that actually serves the tar file, was taken directly from the [`serveDir()`](https://deno.land/std@0.203.0/http/file_server.ts?s=serveDir)  function from the Deno standard library, and just adapted to access the tarball in every place where it would access the file system.
