### PR TITLE
Exclude internal interfaces and types from external type docs

### DIFF
--- a/lib/events.ts
+++ b/lib/events.ts
@@ -10,6 +10,9 @@ type EventTypeFromEventTarget<T, K extends string> = `on${K}` extends keyof T
   ? Parameters<Extract<T[`on${K}`], FN>>[0]
   : Event;
 
+/**
+ * @ignore
+ */
 export type EventList<T> = T extends {
   addEventListener(type: infer P, ...args: any): void;
   // we basically ignore this but we need it so we always get the first override of addEventListener

--- a/lib/instructions.ts
+++ b/lib/instructions.ts
@@ -230,6 +230,9 @@ export function resource<T>(
   );
 }
 
+/**
+ * @ignore
+ */
 export function getframe(): Operation<Frame> {
   return instruction((frame) =>
     shiftSync<Result<Frame>>((k) => k.tail(Ok(frame)))

--- a/lib/result.ts
+++ b/lib/result.ts
@@ -1,4 +1,11 @@
 import type { Result } from "./types.ts";
 
+/**
+ * @ignore
+ */
 export const Ok = <T>(value: T): Result<T> => ({ ok: true, value });
+
+/**
+ * @ignore
+ */
 export const Err = <T>(error: Error): Result<T> => ({ ok: false, error });

--- a/lib/run/types.ts
+++ b/lib/run/types.ts
@@ -10,6 +10,9 @@ export type Exit<T> = {
   result: Result<T>;
 };
 
+/**
+ * @ignore
+ */
 export type FrameResult<T> = Result<void> & {
   exit: Exit<T>;
 };

--- a/lib/signal.ts
+++ b/lib/signal.ts
@@ -4,7 +4,7 @@ import { createQueue, type Queue } from "./queue.ts";
 import { resource } from "./instructions.ts";
 
 /**
- * Convert plain JavaScript function calls into a {link @Stream} that can
+ * Convert plain JavaScript function calls into a {@link Stream} that can
  * be consumed within an operation. If no operation is subscribed to a signal's
  * stream, then sending messages to it is a no-op.
  *

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -76,9 +76,6 @@ export interface Port<T, R> {
  * via same {@link `Stream`}, and messages sent to the channel are
  * received by all consumers. The channel is not buffered, so if there
  * are no consumers, the message is dropped.
- *
- * @typeParam T - type of channel messages
- * @typeParam TClose - type of final channel value
  */
 export interface Channel<T, TClose> {
   /**
@@ -125,6 +122,9 @@ export interface Context<T> extends Operation<T> {
 
 /* low-level interface Which you probably will not need */
 
+/**
+ * @ignore
+ */
 export type Result<T> = {
   readonly ok: true;
   value: T;
@@ -133,12 +133,18 @@ export type Result<T> = {
   error: Error;
 };
 
+/**
+ * @ignore
+ */
 export interface Instruction {
   (frame: Frame): Computation<Result<unknown>>;
 }
 
 import type { FrameResult } from "./run/types.ts";
 
+/**
+ * @ignore
+ */
 export interface Frame<T = unknown> extends Computation<FrameResult<T>> {
   id: number;
   context: Record<string, unknown>;


### PR DESCRIPTION
## Motivation

There are a lot of classes that we use internally that aren't well documented and that aren't really meant for public consumption.

## Approach

This just marks them with the `@ignore` attribute so that they won't
show up in our public api docs.
