### PR TITLE
Cleanup remaining V2 docs issues.

### DIFF
--- a/www/html/app.html.tsx
+++ b/www/html/app.html.tsx
@@ -51,18 +51,15 @@ export default function* AppHtml({ title }: Options): Operation<JSX.Element> {
           hreflang="x-default"
         />
         <link rel="stylesheet" href="/assets/prism-atom-one-dark.css" />
-        <link
-          href="https://fonts.googleapis.com/css?family=Inter&display=swap"
-          rel="stylesheet"
-        />
+        <link rel="stylesheet" href="https://use.typekit.net/ugs0ewy.css" />
       </head>
-      <body>
-        <header class="header w-full top-0 p-6 sticky tracking-wide">
+      <body class="max-w-screen-2xl m-auto">
+        <header class="header w-full top-0 p-6 sticky tracking-wide z-10">
           <div class="flex items-center justify-between">
             <div>
               <a
                 href="/"
-                class="flex items-end gap-x-2 after:content-['v3'] after:inline after:relative after:top-0 after:text-sm"
+                class="flex items-end gap-x-2 sm:gap-x-1 after:content-['v3'] after:inline after:relative after:top-0 after:text-sm"
               >
                 <img
                   src="/assets/images/effection-logo.svg"
@@ -72,19 +69,27 @@ export default function* AppHtml({ title }: Options): Operation<JSX.Element> {
             </div>
 
             <nav aria-label="Site Nav" class="text-sm">
-              <ul class="flex items-center gap-4 md:gap-16">
-                <NavLink href="/docs/introduction" text="Guides" />
-                <NavLink
-                  href="https://deno.land/x/effection/mod.ts"
-                  text="API"
-                />
-                <NavLink
-                  href="https://github.com/thefrontside/effection"
-                  text="Github"
-                />
-                <NavLink href="https://discord.gg/r6AvtnU" text="Discord" />
+              <ul class="flex items-center sm:gap-1.5 gap-3 md:gap-16">
                 <li>
-                  <ProjectSelect/>
+                  <a href="/docs/introduction">Guides</a>
+                </li>
+                <li>
+                  <a href="https://deno.land/x/effection/mod.ts">API</a>
+                </li>
+                <li class="sm:hidden">
+                  <a href="https://github.com/thefrontside/effection">Github</a>
+                </li>
+                <li class="hidden sm:block">
+                  <a href="https://github.com/thefrontside/effection"><IconGithHub/></a>
+                </li>
+                <li class="sm:hidden">
+                  <a href="https://discord.gg/r6AvtnU">Discord</a>
+                </li>
+                <li class="hidden sm:block">
+                  <a href="https://discord.gg/r6AvtnU"><IconDiscord/></a>
+                </li>
+                <li>
+                  <ProjectSelect />
                 </li>
               </ul>
             </nav>
@@ -93,22 +98,38 @@ export default function* AppHtml({ title }: Options): Operation<JSX.Element> {
         <main>
           {yield* outlet}
         </main>
-        <footer class="grid grid-cols-3 text-center bg-gray-100">
-          <section class="flex flex-col">
-            <h1>About</h1>
-            <a href="https://frontside.com">Maintained by Frontside</a>
+        <footer class="grid grid-cols-3 text-center text-gray-500 tracking-wide bg-gray-100 py-10 gap-y-4 leading-10">
+          <section class="flex flex-col gap-y-1">
+            <h1 class="text-sm uppercase font-bold text-blue-primary mb-4">
+              About
+            </h1>
+            <a class="" href="https://frontside.com">
+              Maintained by Frontside <IconExtern />
+            </a>
           </section>
-          <section class="flex flex-col">
-            <h1>OSS Projects</h1>
-            <a href="https://frontside.com/interactors">Interactors</a>
-            <a>Effection</a>
+          <section class="flex flex-col gap-y-1">
+            <h1 class="text-sm uppercase font-bold text-blue-primary mb-4">
+              OSS Projects
+            </h1>
+            <a href="https://frontside.com/interactors">
+              Interactors <IconExtern />
+            </a>
+            <a href="/V2">
+              Effection<em class="align-super text-xs">v2</em> <IconExtern />
+            </a>
           </section>
-          <section class="flex flex-col">
-            <h1>Community</h1>
-            <a href="https://discord.gg/r6AvtnU">Discord</a>
-            <a href="https://github.com/thefrontside/effection">GitHub</a>
+          <section class="flex flex-col gap-y-1">
+            <h1 class="text-sm uppercase font-bold text-blue-primary mb-4">
+              Community
+            </h1>
+            <a href="https://discord.gg/r6AvtnU">
+              Discord <IconExtern />
+            </a>
+            <a href="https://github.com/thefrontside/effection">
+              GitHub <IconExtern />
+            </a>
           </section>
-          <p class="col-span-3">
+          <p class="col-span-3 text-blue-primary text-xs py-4">
             Copyright © 2019 - {new Date().getFullYear()}{" "}
             The Frontside Software, Inc.
           </p>
@@ -118,15 +139,26 @@ export default function* AppHtml({ title }: Options): Operation<JSX.Element> {
   );
 }
 
-function NavLink({ href, text }: { href: string; text: string }) {
-  return (
-    <li>
-      <a
-        class=" "
-        href={href}
-      >
-        {text}
-      </a>
-    </li>
-  );
-}
+const IconExtern = () => (
+  <svg
+    class="inline"
+    width="13.5"
+    height="13.5"
+    aria-hidden="true"
+    viewBox="0 0 24 24"
+  >
+    <path
+      fill="currentColor"
+      d="M21 13v10h-21v-19h12v2h-10v15h17v-8h2zm3-12h-10.988l4.035 4-6.977 7.07 2.828 2.828 6.977-7.07 4.125 4.172v-11z"
+    >
+    </path>
+  </svg>
+);
+
+const IconGithHub = () => (
+  <svg height="16" focusable="false" aria-hidden="true" role="img" viewBox="0 0 16 16" fill="currentColor" stroke="none" xmlns="http://www.w3.org/2000/svg"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z"></path></svg>
+);
+
+const IconDiscord = () => (
+  <svg height="16" focusable="false" aria-hidden="true" role="img" viewBox="0 0 16 16" fill="currentColor" stroke="none" xmlns="http://www.w3.org/2000/svg"><path d="M13.545 2.907a13.227 13.227 0 0 0-3.257-1.011.05.05 0 0 0-.052.025c-.141.25-.297.577-.406.833a12.19 12.19 0 0 0-3.658 0 8.258 8.258 0 0 0-.412-.833.051.051 0 0 0-.052-.025c-1.125.194-2.22.534-3.257 1.011a.041.041 0 0 0-.021.018C.356 6.024-.213 9.047.066 12.032c.001.014.01.028.021.037a13.276 13.276 0 0 0 3.995 2.02.05.05 0 0 0 .056-.019c.308-.42.582-.863.818-1.329a.05.05 0 0 0-.01-.059.051.051 0 0 0-.018-.011 8.875 8.875 0 0 1-1.248-.595.05.05 0 0 1-.02-.066.051.051 0 0 1 .015-.019c.084-.063.168-.129.248-.195a.05.05 0 0 1 .051-.007c2.619 1.196 5.454 1.196 8.041 0a.052.052 0 0 1 .053.007c.08.066.164.132.248.195a.051.051 0 0 1-.004.085 8.254 8.254 0 0 1-1.249.594.05.05 0 0 0-.03.03.052.052 0 0 0 .003.041c.24.465.515.909.817 1.329a.05.05 0 0 0 .056.019 13.235 13.235 0 0 0 4.001-2.02.049.049 0 0 0 .021-.037c.334-3.451-.559-6.449-2.366-9.106a.034.034 0 0 0-.02-.019Zm-8.198 7.307c-.789 0-1.438-.724-1.438-1.612 0-.889.637-1.613 1.438-1.613.807 0 1.45.73 1.438 1.613 0 .888-.637 1.612-1.438 1.612Zm5.316 0c-.788 0-1.438-.724-1.438-1.612 0-.889.637-1.613 1.438-1.613.807 0 1.451.73 1.438 1.613 0 .888-.631 1.612-1.438 1.612Z"></path></svg>
+)

--- a/www/html/components/project-select.tsx
+++ b/www/html/components/project-select.tsx
@@ -18,12 +18,7 @@ export function ProjectSelect() {
         #${toggleId} ~ label#${closerId} {
           display: block;
         }
-        #${openerId} > aside {
-          background-color: white;
-          box-shadow: 0 2px 15px rgba(0,0,0,.1);
-          width: 200%;
-          left: -50%;
-        }
+
         #${toggleId} ~ #${openerId} li:hover {
           background: rgba(38,171,232,.1);
         }
@@ -39,9 +34,12 @@ export function ProjectSelect() {
         `}
       </style>
       <input type="checkbox" class="hidden" id={toggleId} checked />
-      <label id={openerId} class="relative" for={toggleId}>
-        OSS
-        <aside class="absolute m-4 rounded-md min-w-max z-50 text-blue-primary" style="left: -550%">
+      <label id={openerId} class="cursor-pointer" for={toggleId}>
+        <span class="sm:hidden">OSS</span>
+        <aside
+          class="absolute m-4 rounded-md text-blue-primary bg-white shadow-lg right-0 z-50"
+
+        >
           <h4 class="p-2.5 uppercase text-sm text-center font-normal min-w-max">
             Frontside Open Source
           </h4>

--- a/www/html/document.html.tsx
+++ b/www/html/document.html.tsx
@@ -14,7 +14,7 @@ export default function* (doc: Doc): Operation<JSX.Element> {
   let topics = docs.getTopics();
 
   return (
-    <section class="mx-auto md:pt-8 w-full justify-items-normal md:grid md:grid-cols-[200px_auto] lg:grid-cols-[200px_auto_200px] md:gap-4">
+    <section class="mx-auto md:pt-8 w-full justify-items-normal md:grid md:grid-cols-[225px_auto] lg:grid-cols-[225px_auto_200px] md:gap-4">
       <p class="text-right mr-4 md:hidden">
         <label class="cursor-pointer" for="nav-toggle">
           <Navburger />
@@ -29,14 +29,27 @@ export default function* (doc: Doc): Operation<JSX.Element> {
       </style>
       <input class="hidden" id="nav-toggle" type="checkbox" checked />
       <aside id="docbar" class="fixed top-0 h-full w-full grid grid-cols-2">
-        <nav class="bg-white pr-4 border-r-2 h-full">
+        <nav class="bg-white px-2 border-r-2 h-full pt-20">
           {topics.map((topic) => (
-            <hgroup class="prose text-sm">
-              <h3>{topic.name}</h3>
-              <menu class="pl-4">
-                {topic.items.map((doc) => (
-                  <li class="whitespace-nowrap">
-                    <a href={`/docs/${doc.id}`}>{doc.title}</a>
+            <hgroup>
+              <h3 class="text-lg">{topic.name}</h3>
+              <menu class="text-gray-700">
+                {topic.items.map((item) => (
+                  <li class="mt-1">
+                    {doc.id !== item.id
+                      ? (
+                        <a
+                          class="rounded px-4 block w-full h-full py-2 hover:bg-gray-100"
+                          href={`/docs/${item.id}`}
+                        >
+                          {item.title}
+                        </a>
+                      )
+                      : (
+                        <a class="rounded px-4 block w-full h-full py-2 bg-gray-100 cursor-default">
+                          {item.title}
+                        </a>
+                      )}
                   </li>
                 ))}
               </menu>
@@ -48,12 +61,25 @@ export default function* (doc: Doc): Operation<JSX.Element> {
       <aside>
         <nav class="hidden md:block fixed pl-4">
           {topics.map((topic) => (
-            <hgroup class="prose text-sm">
-              <h3>{topic.name}</h3>
-              <menu class="pl-4">
-                {topic.items.map((doc) => (
-                  <li class="">
-                    <a href={`/docs/${doc.id}`}>{doc.title}</a>
+            <hgroup>
+              <h3 class="text-lg">{topic.name}</h3>
+              <menu class="text-gray-700">
+                {topic.items.map((item) => (
+                  <li class="mt-1">
+                    {doc.id !== item.id
+                      ? (
+                        <a
+                          class="rounded px-4 block w-full h-full py-2 hover:bg-gray-100"
+                          href={`/docs/${item.id}`}
+                        >
+                          {item.title}
+                        </a>
+                      )
+                      : (
+                        <a class="rounded px-4 block w-full h-full py-2 bg-gray-100 cursor-default">
+                          {item.title}
+                        </a>
+                      )}
                   </li>
                 ))}
               </menu>
@@ -62,7 +88,7 @@ export default function* (doc: Doc): Operation<JSX.Element> {
         </nav>
       </aside>
       <Transform fn={liftTOC}>
-        <article class="prose px-4 min-w-full">
+        <article class="prose px-6 min-w-full">
           <h1>{doc.title}</h1>
           <Rehype
             plugins={[
@@ -80,7 +106,7 @@ export default function* (doc: Doc): Operation<JSX.Element> {
               [rehypeToc, {
                 cssClasses: {
                   toc:
-                    "hidden text-sm tracking-wide leading-loose lg:block relative whitespace-nowrap",
+                    "hidden text-sm font-light tracking-wide leading-loose lg:block relative whitespace-nowrap",
                   list: "fixed",
                 },
               }],
@@ -97,25 +123,33 @@ export default function* (doc: Doc): Operation<JSX.Element> {
 
 function NextPrevLinks({ doc }: { doc: Doc }): JSX.Element {
   return (
-    <menu class="grid grid-cols-2">
+    <menu class="grid grid-cols-2 my-10 gap-x-2 xl:gap-x-20 2xl:gap-x-40 text-lg">
       {doc.previous
         ? (
-          <li class="col-start-1 text-left">
+          <li class="col-start-1 text-left font-light border-1 rounded-lg p-4">
             Previous
-            <a class="block" href={`/docs/${doc.previous.id}`}>
-              ‹‹{doc.previous.title}
+            <a
+              class="py-2 block text-xl font-bold text-blue-primary no-underline tracking-wide leading-5 before:content-['«&nbsp;'] before:font-normal"
+              href={`/docs/${doc.previous.id}`}
+            >
+              {doc.previous.title}
             </a>
           </li>
         )
-        : ""}
+        : <li />}
       {doc.next
         ? (
-          <li class="col-start-2 text-right">
+          <li class="col-start-2 text-right font-light border-1 rounded-lg p-4">
             Next
-            <a class="block" href={`/docs/${doc.next.id}`}>{doc.next.title}</a>
+            <a
+              class="py-2 block text-xl font-bold text-blue-primary no-underline tracking-wide leading-5 after:content-['&nbsp;»'] after:font-normal"
+              href={`/docs/${doc.next.id}`}
+            >
+              {doc.next.title}
+            </a>
           </li>
         )
-        : ""}
+        : <li />}
     </menu>
   );
 }

--- a/www/lib/twind.ts
+++ b/www/lib/twind.ts
@@ -9,6 +9,7 @@ import {
 import type { Element } from "npm:@types/hast-format@2.3.0";
 import presetTailwind from "npm:@twind/preset-tailwind@1.1.4";
 import presetTypography from "npm:@twind/preset-typography@1.0.7";
+import defaultTheme from "npm:@twind/preset-tailwind@1.1.4/defaultTheme";
 
 function presetFrontside() {
   return {
@@ -30,7 +31,11 @@ function presetFrontside() {
           "blue-secondary": "#26ABE8",
           "pink-secondary": "#F74D7B",
         },
-      }
+        screens: {
+          ...defaultTheme.screens,
+          sm: { max : "540px" },
+        }
+      },
     },
   };
 }


### PR DESCRIPTION
## Motivation

We really want to launch the V3 doc site.

## Approach

This updates several things to be in line with the existing doc site:

1. fix an issue with the OSS links where they were overlaying the
2. Use the normal Frontside fonts
3. Make the footer nice.
4. make the Previous and Next navigation nice.
5. Make the topic navigation more like the old site with the hover effects

### Screenshots

before:

![image](https://github.com/thefrontside/effection/assets/4205/6ea463bc-9460-4253-8d01-69d478137628)

after:

![image](https://github.com/thefrontside/effection/assets/4205/bdf95db7-f1af-4b6a-b7ef-eb8b1e0acfca)
