### PR TITLE
Fix broken link in v2 website that caused build to fail

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -77,7 +77,7 @@ module.exports = {
             },
             {
               label: "Effection v3",
-              to: "/effection/",
+              to: "https://frontside.com/effection",
             },
           ],
         },

--- a/website/docusaurus.config.local.js
+++ b/website/docusaurus.config.local.js
@@ -77,7 +77,7 @@ module.exports = {
             },
             {
               label: "Effection v3",
-              to: "/effection/",
+              to: "https://frontside.com/effection",
             },
           ],
         },


### PR DESCRIPTION
## Motivation

There was a bad link in the Docusaurus site that was causing builds to fail.e

## Approach

Use an absolute URL to prevent Docusaurus from mangling.
