### PR TITLE
Make v3 docs host  v2 docs `R4` and make configurable via env variable.

### DIFF
--- a/www/hooks/use-v2-docs.ts
+++ b/www/hooks/use-v2-docs.ts
@@ -120,7 +120,6 @@ function getApiUrl(revision: string | number): string {
 }
 
 function* loadTar(url: string) {
-  console.dir({ url });
   let signal = yield* useAbortSignal();
   let response = yield* expect(fetch(url, { signal }));
   if (response.ok) {

--- a/www/server.ts
+++ b/www/server.ts
@@ -9,7 +9,7 @@ import { AppHtml, DocumentHtml, IndexHtml } from "./html/templates.ts";
 export default function* start() {
   let v2docs = yield* useV2Docs({
     fetchEagerly: !!Deno.env.get("V2_DOCS_FETCH_EAGERLY"),
-    revision: 3,
+    revision: Number(Deno.env.get("V2_DOCS_REVISION")) ?? 4,
   });
 
   let docs = yield* loadDocs();


### PR DESCRIPTION
## Motivation

The V2 docs were upgraded to provide a nudge to the v3 website and make sure you could link from therer.

## Approach

This updates the baseline version of the V2 docs to `4`, but it also adds an environment variable "V2_DOCS_REVISION" which allows us to upgrade via setting an environment variable.


### Screeshots

announcement banner:

![image](https://github.com/thefrontside/effection/assets/4205/4c70763c-667b-483d-b6e4-752918765af4)

link to v3 in the footer

![image](https://github.com/thefrontside/effection/assets/4205/4fbb3f25-ecbf-45f9-9cd3-f9242a389888)

