### PR TITLE
Publish New Versions

### DIFF
--- a/.changes/add-cause-property.md
+++ b/.changes/add-cause-property.md
@@ -1,4 +1,0 @@
----
-"@effection/core": patch
----
-Add the `cause` property to all wrapped errors

--- a/packages/atom/CHANGELOG.md
+++ b/packages/atom/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @effection/atom
 
+## \[2.0.8]
+
+### Dependencies
+
+- Upgraded to `effection@2.0.8`
+
 ## \[2.0.7]
 
 ### Dependencies

--- a/packages/atom/package.json
+++ b/packages/atom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/atom",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "State atom implementation for effection",
   "main": "dist-cjs/index.js",
   "types": "dist-esm/index.d.ts",
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "assert-ts": "^0.2.2",
-    "effection": "2.0.7",
+    "effection": "2.0.8",
     "fp-ts": "^2.8.2",
     "monocle-ts": "^2.3.3"
   }

--- a/packages/channel/CHANGELOG.md
+++ b/packages/channel/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## \[2.0.6]
+
+### Dependencies
+
+- Upgraded to `@effection/core@2.2.3`
+- Upgraded to `@effection/events@2.0.6`
+- Upgraded to `@effection/stream@2.0.6`
+
 ## \[2.0.5]
 
 ### Dependencies

--- a/packages/channel/package.json
+++ b/packages/channel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/channel",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "MPMC Channel implementation for effection",
   "main": "dist-cjs/index.js",
   "module": "dist-esm/index.js",
@@ -31,8 +31,8 @@
     "extends": "../../package.json"
   },
   "dependencies": {
-    "@effection/core": "2.2.2",
-    "@effection/events": "2.0.5",
-    "@effection/stream": "2.0.5"
+    "@effection/core": "2.2.3",
+    "@effection/events": "2.0.6",
+    "@effection/stream": "2.0.6"
   }
 }

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @effection/core
 
+## \[2.2.3]
+
+- [`96b0ce0`](https://github.com/thefrontside/effection/commit/96b0ce039445d5831e96e0f0ced96537a111b9cb) Add the `cause` property to all wrapped errors
+
 ## \[2.2.2]
 
 - [`5d5a9ba`](https://github.com/thefrontside/effection/commit/5d5a9ba4c33c04531abd084c9fc4d1e12d430e8c) use AbortController polyfill that works in the browser

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/core",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "main": "dist-cjs/index.js",
   "module": "dist-esm/index.js",
   "sideEffects": false,

--- a/packages/dispatch/CHANGELOG.md
+++ b/packages/dispatch/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## \[2.0.8]
+
+### Dependencies
+
+- Upgraded to `effection@2.0.8`
+
 ## \[2.0.7]
 
 ### Dependencies

--- a/packages/dispatch/package.json
+++ b/packages/dispatch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/dispatch",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "Splits a subscription into multiple subscriptions",
   "main": "dist-cjs/index.js",
   "module": "dist-esm/index.js",
@@ -31,6 +31,6 @@
     "extends": "../../package.json"
   },
   "dependencies": {
-    "effection": "2.0.7"
+    "effection": "2.0.8"
   }
 }

--- a/packages/duplex-channel/CHANGELOG.md
+++ b/packages/duplex-channel/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## \[2.0.8]
+
+### Dependencies
+
+- Upgraded to `effection@2.0.8`
+
 ## \[2.0.7]
 
 ### Dependencies

--- a/packages/duplex-channel/package.json
+++ b/packages/duplex-channel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/duplex-channel",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "A bidirectional channel for effection",
   "main": "dist-cjs/index.js",
   "module": "dist-esm/index.js",
@@ -28,7 +28,7 @@
     "mocha": "mocha -r ts-node/register"
   },
   "dependencies": {
-    "effection": "2.0.7"
+    "effection": "2.0.8"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/effection/CHANGELOG.md
+++ b/packages/effection/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## \[2.0.8]
+
+### Dependencies
+
+- Upgraded to `@effection/core@2.2.3`
+- Upgraded to `@effection/channel@2.0.6`
+- Upgraded to `@effection/events@2.0.6`
+- Upgraded to `@effection/fetch@2.0.7`
+- Upgraded to `@effection/subscription@2.0.6`
+- Upgraded to `@effection/stream@2.0.6`
+
 ## \[2.0.7]
 
 ### Dependencies

--- a/packages/effection/package.json
+++ b/packages/effection/package.json
@@ -1,6 +1,6 @@
 {
   "name": "effection",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "Structured concurrency and effects for JavaScript",
   "homepage": "https://frontside.com/effection",
   "repository": {
@@ -28,13 +28,13 @@
     "prepack": "tsc --build tsconfig.esm.json && tsc --build tsconfig.cjs.json && cpy ../../README.md ."
   },
   "dependencies": {
-    "@effection/channel": "2.0.5",
-    "@effection/core": "2.2.2",
-    "@effection/events": "2.0.5",
-    "@effection/fetch": "2.0.6",
+    "@effection/channel": "2.0.6",
+    "@effection/core": "2.2.3",
+    "@effection/events": "2.0.6",
+    "@effection/fetch": "2.0.7",
     "@effection/main": "2.1.2",
-    "@effection/stream": "2.0.5",
-    "@effection/subscription": "2.0.5"
+    "@effection/stream": "2.0.6",
+    "@effection/subscription": "2.0.6"
   },
   "devDependencies": {
     "@babel/core": "^7.14.8",

--- a/packages/events/CHANGELOG.md
+++ b/packages/events/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## \[2.0.6]
+
+### Dependencies
+
+- Upgraded to `@effection/core@2.2.3`
+- Upgraded to `@effection/stream@2.0.6`
+
 ## \[2.0.5]
 
 ### Dependencies

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/events",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Helpers for listening to events with effection",
   "main": "dist-cjs/index.js",
   "module": "dist-esm/index.js",
@@ -28,8 +28,8 @@
     "mocha": "mocha -r ts-node/register"
   },
   "dependencies": {
-    "@effection/core": "2.2.2",
-    "@effection/stream": "2.0.5"
+    "@effection/core": "2.2.3",
+    "@effection/stream": "2.0.6"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/fetch/CHANGELOG.md
+++ b/packages/fetch/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @effection/fetch
 
+## \[2.0.7]
+
+### Dependencies
+
+- Upgraded to `@effection/core@2.2.3`
+
 ## \[2.0.6]
 
 ### Dependencies

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/fetch",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "Fetch operation for Effection",
   "main": "dist-cjs/index.js",
   "module": "dist-esm/index.js",
@@ -28,7 +28,7 @@
     "mocha": "mocha -r ts-node/register"
   },
   "dependencies": {
-    "@effection/core": "2.2.2",
+    "@effection/core": "2.2.3",
     "@effection/mocha": "^2.0.6",
     "cross-fetch": "3.1.5"
   },

--- a/packages/inspect-server/CHANGELOG.md
+++ b/packages/inspect-server/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @effection/inspect-server
 
+## \[2.2.5]
+
+### Dependencies
+
+- Upgraded to `effection@2.0.8`
+- Upgraded to `@effection/atom@2.0.8`
+- Upgraded to `@effection/inspect-utils@2.1.8`
+- Upgraded to `@effection/websocket-server@2.0.8`
+- Upgraded to `@effection/inspect-ui@2.3.4`
+
 ## \[2.2.4]
 
 ### Dependencies

--- a/packages/inspect-server/package.json
+++ b/packages/inspect-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/inspect-server",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "description": "Inspect server for inspecting effection processes",
   "main": "dist-cjs/index.js",
   "types": "dist-esm/index.d.ts",
@@ -29,11 +29,11 @@
     "examples:basic": "ts-node ./examples/basic.ts"
   },
   "dependencies": {
-    "@effection/atom": "2.0.7",
-    "@effection/inspect-ui": "2.3.3",
-    "@effection/inspect-utils": "2.1.7",
-    "@effection/websocket-server": "2.0.7",
-    "effection": "2.0.7",
+    "@effection/atom": "2.0.8",
+    "@effection/inspect-ui": "2.3.4",
+    "@effection/inspect-utils": "2.1.8",
+    "@effection/websocket-server": "2.0.8",
+    "effection": "2.0.8",
     "node-static": "^0.7.11",
     "websocket": "^1.0.34"
   },

--- a/packages/inspect-ui/CHANGELOG.md
+++ b/packages/inspect-ui/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @effection/inspect-ui
 
+## \[2.3.4]
+
+### Dependencies
+
+- Upgraded to `effection@2.0.8`
+- Upgraded to `@effection/inspect-utils@2.1.8`
+- Upgraded to `@effection/react@2.2.4`
+- Upgraded to `@effection/websocket-client@2.0.8`
+
 ## \[2.3.3]
 
 ### Dependencies

--- a/packages/inspect-ui/package.json
+++ b/packages/inspect-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/inspect-ui",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "description": "Web interface for inspecting effection applications",
   "main": "app/index.ts",
   "types": "dist-esm/index.d.ts",
@@ -31,7 +31,7 @@
     "mocha": "mocha -r ts-node/register --timeout 5000"
   },
   "dependencies": {
-    "@effection/react": "2.2.3",
+    "@effection/react": "2.2.4",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.57",
@@ -45,8 +45,8 @@
     "react-router-dom": "^6.3.0"
   },
   "devDependencies": {
-    "@effection/inspect-utils": "2.1.7",
-    "@effection/websocket-client": "2.0.7",
+    "@effection/inspect-utils": "2.1.8",
+    "@effection/websocket-client": "2.0.8",
     "@interactors/material-ui": "^4.1.0",
     "@types/jsdom-global": "^3.0.2",
     "@types/react": "^17.0.50",
@@ -54,7 +54,7 @@
     "@types/react-router": "^5.1.17",
     "@types/react-router-dom": "^5.3.1",
     "copyfiles": "^2.4.1",
-    "effection": "2.0.7",
+    "effection": "2.0.8",
     "eslint-plugin-react": "^7.31.8",
     "eslint-plugin-react-hooks": "^4.6.0",
     "events": "^3.3.0",

--- a/packages/inspect-utils/CHANGELOG.md
+++ b/packages/inspect-utils/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @effection/inspect-utils
 
+## \[2.1.8]
+
+### Dependencies
+
+- Upgraded to `effection@2.0.8`
+- Upgraded to `@effection/dispatch@2.0.8`
+- Upgraded to `@effection/atom@2.0.8`
+
 ## \[2.1.7]
 
 ### Dependencies

--- a/packages/inspect-utils/package.json
+++ b/packages/inspect-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/inspect-utils",
-  "version": "2.1.7",
+  "version": "2.1.8",
   "description": "Helper functions and types for inspecting effection applications",
   "main": "dist-cjs/index.js",
   "types": "dist-esm/index.d.ts",
@@ -28,9 +28,9 @@
     "mocha": "mocha -r ts-node/register"
   },
   "dependencies": {
-    "@effection/atom": "2.0.7",
-    "@effection/dispatch": "2.0.7",
-    "effection": "2.0.7"
+    "@effection/atom": "2.0.8",
+    "@effection/dispatch": "2.0.8",
+    "effection": "2.0.8"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/inspect/CHANGELOG.md
+++ b/packages/inspect/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @effection/inspect
 
+## \[2.1.11]
+
+### Dependencies
+
+- Upgraded to `@effection/inspect-server@2.2.5`
+
 ## \[2.1.10]
 
 ### Dependencies

--- a/packages/inspect/package.json
+++ b/packages/inspect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/inspect",
-  "version": "2.1.10",
+  "version": "2.1.11",
   "description": "Injects an inspector into an Effection application",
   "main": "index.cjs.js",
   "module": "index.esm.js",
@@ -23,7 +23,7 @@
     "docs": "echo noop"
   },
   "dependencies": {
-    "@effection/inspect-server": "2.2.4"
+    "@effection/inspect-server": "2.2.5"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/jest/CHANGELOG.md
+++ b/packages/jest/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @effection/jest
 
+## \[2.0.6]
+
+### Dependencies
+
+- Upgraded to `effection@2.0.8`
+
 ## \[2.0.5]
 
 ### Dependencies

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/jest",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Effection Integration for the Jest framework",
   "main": "dist-cjs/index.js",
   "module": "dist-esm/index.js",
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "assert-ts": "^0.3.4",
-    "effection": "2.0.7"
+    "effection": "2.0.8"
   },
   "peerDependencies": {
     "jest": "^27.0.0"

--- a/packages/mocha/CHANGELOG.md
+++ b/packages/mocha/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @effection/mocha
 
+## \[2.0.8]
+
+### Dependencies
+
+- Upgraded to `effection@2.0.8`
+
 ## \[2.0.7]
 
 ### Dependencies

--- a/packages/mocha/package.json
+++ b/packages/mocha/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/mocha",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "Effection Subscriptions",
   "main": "dist-cjs/index.js",
   "module": "dist-esm/index.js",
@@ -27,7 +27,7 @@
     "mocha": "mocha -r ts-node/register"
   },
   "dependencies": {
-    "effection": "2.0.7"
+    "effection": "2.0.8"
   },
   "peerDependencies": {
     "mocha": "^10.0.0"

--- a/packages/process/CHANGELOG.md
+++ b/packages/process/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @effection/process
 
+## \[2.1.4]
+
+### Dependencies
+
+- Upgraded to `effection@2.0.8`
+
 ## \[2.1.3]
 
 ### Dependencies

--- a/packages/process/package.json
+++ b/packages/process/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/process",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "Spawn and manage external processes with Effection",
   "main": "dist-cjs/index.js",
   "module": "dist-esm/index.js",
@@ -34,7 +34,7 @@
   "dependencies": {
     "cross-spawn": "^7.0.3",
     "ctrlc-windows": "^2.1.0",
-    "effection": "2.0.7",
+    "effection": "2.0.8",
     "shellwords": "^0.1.1"
   },
   "volta": {

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @effection/react
 
+## \[2.2.4]
+
+### Dependencies
+
+- Upgraded to `effection@2.0.8`
+
 ## \[2.2.3]
 
 ### Dependencies

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/react",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "Hooks for integrating effection into react applications",
   "main": "dist-cjs/index.js",
   "module": "dist-esm/index.js",
@@ -28,7 +28,7 @@
     "mocha": "mocha -r ts-node/register"
   },
   "dependencies": {
-    "effection": "2.0.7"
+    "effection": "2.0.8"
   },
   "devDependencies": {
     "@types/react": "^17.0.8",

--- a/packages/stream/CHANGELOG.md
+++ b/packages/stream/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## \[2.0.6]
+
+### Dependencies
+
+- Upgraded to `@effection/core@2.2.3`
+- Upgraded to `@effection/subscription@2.0.6`
+
 ## \[2.0.5]
 
 ### Dependencies

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/stream",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Effection Stream",
   "main": "dist-cjs/index.js",
   "module": "dist-esm/index.js",
@@ -28,8 +28,8 @@
     "mocha": "mocha -r ts-node/register"
   },
   "dependencies": {
-    "@effection/core": "2.2.2",
-    "@effection/subscription": "2.0.5"
+    "@effection/core": "2.2.3",
+    "@effection/subscription": "2.0.6"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/subscription/CHANGELOG.md
+++ b/packages/subscription/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @effection/subscription
 
+## \[2.0.6]
+
+### Dependencies
+
+- Upgraded to `@effection/core@2.2.3`
+
 ## \[2.0.5]
 
 ### Dependencies

--- a/packages/subscription/package.json
+++ b/packages/subscription/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/subscription",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Effection Subscriptions",
   "main": "dist-cjs/index.js",
   "module": "dist-esm/index.js",
@@ -28,7 +28,7 @@
     "mocha": "mocha -r ts-node/register"
   },
   "dependencies": {
-    "@effection/core": "2.2.2"
+    "@effection/core": "2.2.3"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/vitest/CHANGELOG.md
+++ b/packages/vitest/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @effection/vitest
 
+## \[2.1.2]
+
+### Dependencies
+
+- Upgraded to `effection@2.0.8`
+
 ## \[2.1.1]
 
 ### Dependencies

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/vitest",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Effection Integration for the Vitest framework",
   "types": "dist-esm/index.d.ts",
   "main": "dist-cjs/index.js",
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "assert-ts": "^0.3.4",
-    "effection": "2.0.7"
+    "effection": "2.0.8"
   },
   "peerDependencies": {
     "vitest": "^0.25.0"

--- a/packages/websocket-client/CHANGELOG.md
+++ b/packages/websocket-client/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @effection/websocket-client
 
+## \[2.0.8]
+
+### Dependencies
+
+- Upgraded to `effection@2.0.8`
+
 ## \[2.0.7]
 
 ### Dependencies

--- a/packages/websocket-client/package.json
+++ b/packages/websocket-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/websocket-client",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "A websocket client for Effection in node and browser",
   "main": "dist-cjs/index.js",
   "module": "dist-esm/index.js",
@@ -28,7 +28,7 @@
     "mocha": "mocha -r ts-node/register"
   },
   "dependencies": {
-    "effection": "2.0.7",
+    "effection": "2.0.8",
     "isomorphic-ws": "^4.0.1"
   },
   "devDependencies": {

--- a/packages/websocket-server/CHANGELOG.md
+++ b/packages/websocket-server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @effection/websocket-server
 
+## \[2.0.8]
+
+### Dependencies
+
+- Upgraded to `effection@2.0.8`
+
 ## \[2.0.7]
 
 ### Dependencies

--- a/packages/websocket-server/package.json
+++ b/packages/websocket-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effection/websocket-server",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "A simple websocket server for Effection",
   "main": "dist-cjs/index.js",
   "module": "dist-esm/index.js",
@@ -28,7 +28,7 @@
     "mocha": "mocha -r ts-node/register"
   },
   "dependencies": {
-    "effection": "2.0.7",
+    "effection": "2.0.8",
     "ws": "^7.4.6"
   },
   "devDependencies": {


### PR DESCRIPTION
# Version Updates

Merging this PR will release new versions of the following packages based on your change files.




# @effection/channel

## [2.0.6]
### Dependencies

- Upgraded to `@effection/core@2.2.3`
- Upgraded to `@effection/events@2.0.6`
- Upgraded to `@effection/stream@2.0.6`



# @effection/duplex-channel

## [2.0.8]
### Dependencies

- Upgraded to `effection@2.0.8`



# @effection/dispatch

## [2.0.8]
### Dependencies

- Upgraded to `effection@2.0.8`



# @effection/atom

## [2.0.8]
### Dependencies

- Upgraded to `effection@2.0.8`



# @effection/core

## [2.2.3]
- [`96b0ce0`](https://github.com/thefrontside/effection/commit/96b0ce039445d5831e96e0f0ced96537a111b9cb) Add the `cause` property to all wrapped errors



# effection

## [2.0.8]
### Dependencies

- Upgraded to `@effection/core@2.2.3`
- Upgraded to `@effection/channel@2.0.6`
- Upgraded to `@effection/events@2.0.6`
- Upgraded to `@effection/fetch@2.0.7`
- Upgraded to `@effection/subscription@2.0.6`
- Upgraded to `@effection/stream@2.0.6`



# @effection/events

## [2.0.6]
### Dependencies

- Upgraded to `@effection/core@2.2.3`
- Upgraded to `@effection/stream@2.0.6`



# @effection/fetch

## [2.0.7]
### Dependencies

- Upgraded to `@effection/core@2.2.3`



# @effection/inspect

## [2.1.11]
### Dependencies

- Upgraded to `@effection/inspect-server@2.2.5`



# @effection/inspect-server

## [2.2.5]
### Dependencies

- Upgraded to `effection@2.0.8`
- Upgraded to `@effection/atom@2.0.8`
- Upgraded to `@effection/inspect-utils@2.1.8`
- Upgraded to `@effection/websocket-server@2.0.8`
- Upgraded to `@effection/inspect-ui@2.3.4`



# @effection/inspect-utils

## [2.1.8]
### Dependencies

- Upgraded to `effection@2.0.8`
- Upgraded to `@effection/dispatch@2.0.8`
- Upgraded to `@effection/atom@2.0.8`



# @effection/mocha

## [2.0.8]
### Dependencies

- Upgraded to `effection@2.0.8`



# @effection/jest

## [2.0.6]
### Dependencies

- Upgraded to `effection@2.0.8`



# @effection/process

## [2.1.4]
### Dependencies

- Upgraded to `effection@2.0.8`



# @effection/react

## [2.2.4]
### Dependencies

- Upgraded to `effection@2.0.8`



# @effection/subscription

## [2.0.6]
### Dependencies

- Upgraded to `@effection/core@2.2.3`



# @effection/stream

## [2.0.6]
### Dependencies

- Upgraded to `@effection/core@2.2.3`
- Upgraded to `@effection/subscription@2.0.6`



# @effection/websocket-client

## [2.0.8]
### Dependencies

- Upgraded to `effection@2.0.8`



# @effection/websocket-server

## [2.0.8]
### Dependencies

- Upgraded to `effection@2.0.8`



# @effection/inspect-ui

## [2.3.4]
### Dependencies

- Upgraded to `effection@2.0.8`
- Upgraded to `@effection/inspect-utils@2.1.8`
- Upgraded to `@effection/react@2.2.4`
- Upgraded to `@effection/websocket-client@2.0.8`



# @effection/vitest

## [2.1.2]
### Dependencies

- Upgraded to `effection@2.0.8`