### PR TITLE
✨Beef up the `call()` function to promises and async fns

### DIFF
--- a/lib/async.ts
+++ b/lib/async.ts
@@ -1,7 +1,11 @@
 import type { Operation, Stream, Subscription } from "./types.ts";
 
 import { action } from "./instructions.ts";
+import { call } from "./call.ts";
 
+/**
+ * @deprecated use {@link call} instead
+ */
 export function expect<T>(promise: Promise<T>): Operation<T> {
   return action(function* (resolve, reject) {
     promise.then(resolve, reject);
@@ -10,7 +14,7 @@ export function expect<T>(promise: Promise<T>): Operation<T> {
 
 export function subscribe<T, R>(iter: AsyncIterator<T, R>): Subscription<T, R> {
   return {
-    next: () => expect(iter.next()),
+    next: () => call(iter.next),
   };
 }
 

--- a/lib/call.ts
+++ b/lib/call.ts
@@ -1,12 +1,77 @@
 import type { Operation } from "./types.ts";
 import { action } from "./instructions.ts";
+import { pause } from "./pause.ts";
 
-export function call<T>(fn: () => Operation<T>): Operation<T> {
+/**
+ * Pause the current operation, and run a promises, async functions, or
+ * operations within a new scope. The calling operation will resumed (or errored)
+ * once call is completed.
+ *
+ * `call()` is a uniform integration point for calling async functions,
+ * evaluating promises; as well as generator functions and operations. It can be
+ * used to treat a promise as an operation.
+ *
+ * @example
+ * ```js
+ * let response = yield* call(fetch('https://google.com'));
+ * ```
+ * or an async function:
+ *
+ * @example
+ * '''ts
+ * async function* googleSlowly() {
+ *   return yield* call(async function() {
+ *     await new Promise(resolve => setTimeout(resolve, 2000));
+ *     return await fetch("https://google.com");
+ *   });
+ * }
+ * ``'
+ *
+ * It can be used to run an operation in a separate scope to ensure that any
+ * resources allocated:
+ *
+ * @example
+ * ```js
+ * yield* call(function*() {
+ *   let socket = yield* useSocket();
+ *   return yield* socket.read();
+ * }); //=> socket is destroyed before returning
+ * ```
+ *
+ * Because `call()` runs within its own {@link Scope}, it can also be used to
+ * establish {@link  * establish error boundarieshttps://frontside.com/effection/docs/errors | error boundaries}.
+ *
+ * @param operator the operation, promise, async function, or generator funnction to call as part of this operation
+ */
+export function call<T>(operator: () => Operation<T>): Operation<T>;
+export function call<T>(operator: () => Promise<T>): Operation<T>;
+export function call<T>(operator: Operation<T>): Operation<T>;
+export function call<T>(operator: Promise<T>): Operation<T>;
+export function call<T>(operator: Operator<T>): Operation<T> {
   return action(function* (resolve, reject) {
     try {
-      resolve(yield* fn());
+      let op = typeof operator === "function" ? operator() : operator;
+      if (typeof (op as Operation<T>)[Symbol.iterator] === "function") {
+        resolve(yield* op);
+      } else {
+        //@ts-expect-error this is because we monkey-patch the tests
+        resolve(yield* expect(op));
+      }
     } catch (error) {
       reject(error);
     }
   });
 }
+
+function expect<T>(promise: Promise<T>): Operation<T> {
+  return pause((resolve, reject) => {
+    promise.then(resolve, reject);
+    return () => {};
+  });
+}
+
+type Operator<T> =
+  | Operation<T>
+  | Promise<T>
+  | (() => Operation<T>)
+  | (() => Promise<T>);

--- a/test/call.test.ts
+++ b/test/call.test.ts
@@ -3,13 +3,33 @@ import { describe, expect, it } from "./suite.ts";
 import { call, run, spawn, suspend } from "../mod.ts";
 
 describe("call", () => {
-  it("invokes an operation", async () => {
+  it("evaluates an operation function", async () => {
     await run(function* () {
       let result = yield* call(function* () {
         return 10;
       });
       expect(result).toEqual(10);
     });
+  });
+
+  it("evaluates an operation directly", async () => {
+    await expect(run(() =>
+      call({
+        *[Symbol.iterator]() {
+          return 42;
+        },
+      })
+    )).resolves.toEqual(42);
+  });
+
+  it("evaluates a no-arg async function", async () => {
+    await expect(run(() => call(() => Promise.resolve(42)))).resolves.toEqual(
+      42,
+    );
+  });
+
+  it("evaluates a promise directly", async () => {
+    await expect(run(() => call(Promise.resolve(42)))).resolves.toEqual(42);
   });
 
   it("can be used as an error boundary", async () => {

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -1,5 +1,5 @@
 import { blowUp, createNumber, describe, expect, it } from "./suite.ts";
-import { expect as $expect, run, sleep, spawn, suspend } from "../mod.ts";
+import { run, sleep, spawn, suspend } from "../mod.ts";
 import type { Task } from "../mod.ts";
 
 describe("run()", () => {
@@ -8,10 +8,11 @@ describe("run()", () => {
       return "hello";
     })).resolves.toEqual("hello");
   });
+
   it("can compose multiple promises via generator", async () => {
     let result = await run(function* () {
-      let one = yield* $expect(Promise.resolve(12));
-      let two = yield* $expect(Promise.resolve(55));
+      let one = yield* Promise.resolve(12);
+      let two = yield* Promise.resolve(55);
       return one + two;
     });
     expect(result).toEqual(67);
@@ -46,16 +47,16 @@ describe("run()", () => {
   it("can recover from errors in promise", async () => {
     let error = new Error("boom");
     let task = run(function* () {
-      let one = yield* $expect(Promise.resolve(12));
+      let one = yield* Promise.resolve(12);
       let two;
       try {
-        yield* $expect(Promise.reject(error));
+        yield* Promise.reject(error);
         two = 9;
       } catch (_) {
         // swallow error and yield in catch block
-        two = yield* $expect(Promise.resolve(8));
+        two = yield* Promise.resolve(8);
       }
-      let three = yield* $expect(Promise.resolve(55));
+      let three = yield* Promise.resolve(55);
       return one + two + three;
     });
     await expect(task).resolves.toEqual(75);
@@ -63,16 +64,16 @@ describe("run()", () => {
 
   it("can recover from errors in operation", async () => {
     let task = run(function* () {
-      let one = yield* $expect(Promise.resolve(12));
+      let one = yield* Promise.resolve(12);
       let two;
       try {
         yield* blowUp();
         two = 9;
       } catch (_e) {
         // swallow error and yield in catch block
-        two = yield* $expect(Promise.resolve(8));
+        two = yield* Promise.resolve(8);
       }
-      let three = yield* $expect(Promise.resolve(55));
+      let three = yield* Promise.resolve(55);
       return one + two + three;
     });
     await expect(task).resolves.toEqual(75);
@@ -263,7 +264,7 @@ describe("run()", () => {
   it("propagates errors from promises", async () => {
     try {
       await run(function* () {
-        yield* $expect(Promise.reject(new Error("boom")));
+        yield* Promise.reject(new Error("boom"));
       });
       throw new Error("expected error to propagate");
     } catch (error) {

--- a/test/spawn.test.ts
+++ b/test/spawn.test.ts
@@ -1,19 +1,12 @@
 import { describe, expect, it } from "./suite.ts";
-import {
-  action,
-  expect as $expect,
-  run,
-  sleep,
-  spawn,
-  suspend,
-} from "../mod.ts";
+import { action, run, sleep, spawn, suspend } from "../mod.ts";
 
 describe("spawn", () => {
   it("can spawn a new child task", async () => {
     let root = run(function* () {
       let child = yield* spawn(function* () {
-        let one = yield* $expect(Promise.resolve(12));
-        let two = yield* $expect(Promise.resolve(55));
+        let one = yield* Promise.resolve(12);
+        let two = yield* Promise.resolve(55);
 
         return one + two;
       });

--- a/test/suite.ts
+++ b/test/suite.ts
@@ -2,7 +2,14 @@ export * from "https://deno.land/std@0.163.0/testing/bdd.ts";
 export { expect, mock } from "https://deno.land/x/expect@v0.3.0/mod.ts";
 export { expectType } from "https://esm.sh/ts-expect@1.3.0?pin=v123";
 
-import { expect, type Operation, resource, sleep, spawn } from "../mod.ts";
+import {
+  action,
+  call,
+  type Operation,
+  resource,
+  sleep,
+  spawn,
+} from "../mod.ts";
 
 declare global {
   // deno-lint-ignore no-empty-interface
@@ -14,6 +21,12 @@ Object.defineProperty(Promise.prototype, Symbol.iterator, {
     return expect(this)[Symbol.iterator];
   },
 });
+
+function expect<T>(promise: Promise<T>): Operation<T> {
+  return action(function* (resolve, reject) {
+    promise.then(resolve, reject);
+  });
+}
 
 export function* createNumber(value: number): Operation<number> {
   yield* sleep(1);
@@ -76,7 +89,7 @@ export function useCommand(
     } finally {
       try {
         process.kill("SIGINT");
-        yield* process.status;
+        yield* call(process.status);
       } catch (error) {
         // if the process already quit, then this error is expected.
         // unfortunately there is no way (I know of) to check this


### PR DESCRIPTION
## Motivation

resolve #798 

## Approach

This adds the following variations

```ts
// promise
call(Promise.resolve("hello"));
call(async () => "hello");

// Operation
call({ *[Symbol.iterator]() { return "hello" } } );
call(function*() { return "hello" });
```

However, it does not add the variation for constant values because they could include arrays and strings which are themselves iterable and so difficult to tell if they are an Operation or not.
