### PR TITLE
Add docs for the `resource()` API

### DIFF
--- a/lib/instructions.ts
+++ b/lib/instructions.ts
@@ -205,6 +205,43 @@ export function spawn<T>(operation: () => Operation<T>): Operation<Task<T>> {
   });
 }
 
+/**
+ * Define an Effection [resource](https://frontside.com/effection/docs/resources)
+ *
+ * Resources are a type of operation that passes a value back to its caller
+ * while still allowing that operation to run in the background. It does this
+ * by invoking the special `provide()` operation. The caller pauses until the
+ * resource operation invokes `provide()` at which point the caller resumes with
+ * passed value.
+ *
+ * `provide()` suspends the resource operation until the caller passes out of
+ * scope.
+ *
+ * @example
+ * ```js
+ * function useWebSocket(url) {
+ *   return resource(function*(provide) {
+ *     let socket = new WebSocket(url);
+ *     yield* once(socket, 'open');
+ *
+ *     try {
+ *       yield* provide(socket);
+ *     } finally {
+ *       socket.close();
+ *       yield* once(socket, 'close');
+ *     }
+ *   })
+ * }
+ *
+ * await main(function*() {
+ *   let socket = yield* useWebSocket("wss://example.com");
+ *   socket.send("hello world");
+ * });
+ * ```
+ *
+ * @param operation the operation defining the lifecycle of the resource
+ * @returns an operation yielding the resource
+ */
 export function resource<T>(
   operation: (provide: Provide<T>) => Operation<void>,
 ): Operation<T> {


### PR DESCRIPTION
## Motivation

Add documentation for the `resource()` function. We already have a guide, but we should have help for the IDE

## Approach

Add typedocs
