### PR TITLE
Tag v3 releases as `v3` (not latest)

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -41,7 +41,7 @@ jobs:
           NPM_VERSION: ${{steps.vars.outputs.version}}
 
       - name: Publish
-        run: npm publish --access=public
+        run: npm publish --access=public --tag v3
         working-directory: ./build/npm
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}


### PR DESCRIPTION
## Motivation
We're in a game of whack-a-mole, where every time we publish from the `v3` branch, that npm package becomes `latest`, and whenever we publish from the `v2` branch, _that_ package becomes latest.

## Approach

This explicitly sets the tag used to the `v3`, that way it will not use `latest`.

Correspondingly, the `v2` tag should be set along with the `latest` tag. Then, once v3.0.0 is released, it will receive both `v3` and `latest` and `v2` will only receive `v2`
