### PR TITLE
🚀 Performance improvements to docs based on Lighthouse recommendations

### DIFF
--- a/www/deno.lock
+++ b/www/deno.lock
@@ -24,19 +24,19 @@
       "@hazae41/foras@2.1.1": {
         "integrity": "sha512-iBWx2Q0UYn4IFjdL043Kv1fJCytKFZwtx7DzGHcpDeg+zuEJklsM+oQkRmnUvrJCz/kBKdPQfCjNwDZ4kCc09w==",
         "dependencies": {
-          "@hazae41/result": "@hazae41/result@1.1.4"
+          "@hazae41/result": "@hazae41/result@1.1.8"
         }
       },
-      "@hazae41/option@1.0.22": {
-        "integrity": "sha512-/cNF5CITJMDOkQdIofM0qNEVLBvD7o8ZxBi9G9ypOU9j/8tGuFx2iMlDacnc5DdxY7Xutsyk9iZ7XtVuY4F82A==",
+      "@hazae41/option@1.0.26": {
+        "integrity": "sha512-YKe27/b/vehYba524pHXPiWvDzZ5LtiZ1Prkd6L4C/Jquk34FbTMyNOSdAh09iK5NmBoW79JfY7rL+WuiG4ibQ==",
         "dependencies": {
-          "@hazae41/result": "@hazae41/result@1.1.4"
+          "@hazae41/result": "@hazae41/result@1.1.8"
         }
       },
-      "@hazae41/result@1.1.4": {
-        "integrity": "sha512-vTXpiiX8w0DLW1U8SIr195q/roK+fHet6pz46ESEdWNT+GAO7mIk1ME47nA8mEGSiuRBqR6STxJLKNelPaiTig==",
+      "@hazae41/result@1.1.8": {
+        "integrity": "sha512-UekKNYcOD2t5MYxjfhl8KqQZV+ylYuD8FreIsNSMWgqaWBrGnHL/Jy9MfnnRSTmdy/rKdqcU5jGdQZi6Gb1Pcw==",
         "dependencies": {
-          "@hazae41/option": "@hazae41/option@1.0.22"
+          "@hazae41/option": "@hazae41/option@1.0.26"
         }
       },
       "@jsdevtools/rehype-toc@3.0.2": {
@@ -46,8 +46,8 @@
       "@mdx-js/mdx@2.3.0": {
         "integrity": "sha512-jLuwRlz8DQfQNiUCJR50Y09CGPq3fLtmtUQfVrj79E0JWu3dvsVcxVIcfhR5h0iXu+/z++zDrYeiJqifRynJkA==",
         "dependencies": {
-          "@types/estree-jsx": "@types/estree-jsx@1.0.1",
-          "@types/mdx": "@types/mdx@2.0.8",
+          "@types/estree-jsx": "@types/estree-jsx@1.0.2",
+          "@types/mdx": "@types/mdx@2.0.9",
           "estree-util-build-jsx": "estree-util-build-jsx@2.2.2",
           "estree-util-is-identifier-name": "estree-util-is-identifier-name@2.1.0",
           "estree-util-to-js": "estree-util-to-js@1.2.0",
@@ -86,81 +86,81 @@
       "@types/acorn@4.0.6": {
         "integrity": "sha512-veQTnWP+1D/xbxVrPC3zHnCZRjSrKfhbMUlEA43iMZLu7EsnTtkJklIuwrCPbOi8YkvDQAiW05VQQFvvz9oieQ==",
         "dependencies": {
-          "@types/estree": "@types/estree@1.0.2"
+          "@types/estree": "@types/estree@1.0.4"
         }
       },
-      "@types/debug@4.1.9": {
-        "integrity": "sha512-8Hz50m2eoS56ldRlepxSBa6PWEVCtzUo/92HgLc2qTMnotJNIm7xP+UZhyWoYsyOdd5dxZ+NZLb24rsKyFs2ow==",
+      "@types/debug@4.1.10": {
+        "integrity": "sha512-tOSCru6s732pofZ+sMv9o4o3Zc+Sa8l3bxd/tweTQudFn06vAzb13ZX46Zi6m6EJ+RUbRTHvgQJ1gBtSgkaUYA==",
         "dependencies": {
-          "@types/ms": "@types/ms@0.7.32"
+          "@types/ms": "@types/ms@0.7.33"
         }
       },
-      "@types/estree-jsx@1.0.1": {
-        "integrity": "sha512-sHyakZlAezNFxmYRo0fopDZW+XvK6ipeZkkp5EAOLjdPfZp8VjZBJ67vSRI99RSCAoqXVmXOHS4fnWoxpuGQtQ==",
+      "@types/estree-jsx@1.0.2": {
+        "integrity": "sha512-GNBWlGBMjiiiL5TSkvPtOteuXsiVitw5MYGY1UYlrAq0SKyczsls6sCD7TZ8fsjRsvCVxml7EbyjJezPb3DrSA==",
         "dependencies": {
-          "@types/estree": "@types/estree@1.0.2"
+          "@types/estree": "@types/estree@1.0.4"
         }
       },
-      "@types/estree@1.0.2": {
-        "integrity": "sha512-VeiPZ9MMwXjO32/Xu7+OwflfmeoRwkE/qzndw42gGtgJwZopBnzy2gD//NN1+go1mADzkDcqf/KnFRSjTJ8xJA==",
+      "@types/estree@1.0.4": {
+        "integrity": "sha512-2JwWnHK9H+wUZNorf2Zr6ves96WHoWDJIftkcxPKsS7Djta6Zu519LarhRNljPXkpsZR2ZMwNCPeW7omW07BJw==",
         "dependencies": {}
       },
-      "@types/hast@2.3.6": {
-        "integrity": "sha512-47rJE80oqPmFdVDCD7IheXBrVdwuBgsYwoczFvKmwfo2Mzsnt+V9OONsYauFmICb6lQPpCuXYJWejBNs4pDJRg==",
+      "@types/hast@2.3.7": {
+        "integrity": "sha512-EVLigw5zInURhzfXUM65eixfadfsHKomGKUakToXo84t8gGIJuTcD2xooM2See7GyQ7DRtYjhCHnSUQez8JaLw==",
         "dependencies": {
-          "@types/unist": "@types/unist@2.0.8"
+          "@types/unist": "@types/unist@2.0.9"
         }
       },
-      "@types/hast@3.0.1": {
-        "integrity": "sha512-hs/iBJx2aydugBQx5ETV3ZgeSS0oIreQrFJ4bjBl0XvM4wAmDjFEALY7p0rTSLt2eL+ibjRAAs9dTPiCLtmbqQ==",
+      "@types/hast@3.0.2": {
+        "integrity": "sha512-B5hZHgHsXvfCoO3xgNJvBnX7N8p86TqQeGKXcokW4XXi+qY4vxxPSFYofytvVmpFxzPv7oxDQzjg5Un5m2/xiw==",
         "dependencies": {
-          "@types/unist": "@types/unist@3.0.0"
+          "@types/unist": "@types/unist@3.0.1"
         }
       },
-      "@types/mdast@3.0.13": {
-        "integrity": "sha512-HjiGiWedR0DVFkeNljpa6Lv4/IZU1+30VY5d747K7lBudFc3R0Ibr6yJ9lN3BE28VnZyDfLF/VB1Ql1ZIbKrmg==",
+      "@types/mdast@3.0.14": {
+        "integrity": "sha512-gVZ04PGgw1qLZKsnWnyFv4ORnaJ+DXLdHTVSFbU8yX6xZ34Bjg4Q32yPkmveUP1yItXReKfB0Aknlh/3zxTKAw==",
         "dependencies": {
-          "@types/unist": "@types/unist@2.0.8"
+          "@types/unist": "@types/unist@2.0.9"
         }
       },
-      "@types/mdast@4.0.1": {
-        "integrity": "sha512-IlKct1rUTJ1T81d8OHzyop15kGv9A/ff7Gz7IJgrk6jDb4Udw77pCJ+vq8oxZf4Ghpm+616+i1s/LNg/Vh7d+g==",
+      "@types/mdast@4.0.2": {
+        "integrity": "sha512-tYR83EignvhYO9iU3kDg8V28M0jqyh9zzp5GV+EO+AYnyUl3P5ltkTeJuTiFZQFz670FSb3EwT/6LQdX+UdKfw==",
         "dependencies": {
-          "@types/unist": "@types/unist@3.0.0"
+          "@types/unist": "@types/unist@3.0.1"
         }
       },
-      "@types/mdx@2.0.8": {
-        "integrity": "sha512-r7/zWe+f9x+zjXqGxf821qz++ld8tp6Z4jUS6qmPZUXH6tfh4riXOhAqb12tWGWAevCFtMt1goLWkQMqIJKpsA==",
+      "@types/mdx@2.0.9": {
+        "integrity": "sha512-OKMdj17y8Cs+k1r0XFyp59ChSOwf8ODGtMQ4mnpfz5eFDk1aO41yN3pSKGuvVzmWAkFp37seubY1tzOVpwfWwg==",
         "dependencies": {}
       },
-      "@types/ms@0.7.32": {
-        "integrity": "sha512-xPSg0jm4mqgEkNhowKgZFBNtwoEwF6gJ4Dhww+GFpm3IgtNseHQZ5IqdNwnquZEoANxyDAKDRAdVo4Z72VvD/g==",
+      "@types/ms@0.7.33": {
+        "integrity": "sha512-AuHIyzR5Hea7ij0P9q7vx7xu4z0C28ucwjAZC0ja7JhINyCnOw8/DnvAPQQ9TfOlCtZAmCERKQX9+o1mgQhuOQ==",
         "dependencies": {}
       },
-      "@types/prismjs@1.26.1": {
-        "integrity": "sha512-Q7jDsRbzcNHIQje15CS/piKhu6lMLb9jwjxSfEIi4KcFKXW23GoJMkwQiJ8VObyfx+VmUaDcJxXaWN+cTCjVog==",
+      "@types/prismjs@1.26.2": {
+        "integrity": "sha512-/r7Cp7iUIk7gts26mHXD66geUC+2Fo26TZYjQK6Nr4LDfi6lmdRmMqM0oPwfiMhUwoBAOFe8GstKi2pf6hZvwA==",
         "dependencies": {}
       },
-      "@types/unist@2.0.8": {
-        "integrity": "sha512-d0XxK3YTObnWVp6rZuev3c49+j4Lo8g4L1ZRm9z5L0xpoZycUPshHgczK5gsUMaZOstjVYYi09p5gYvUtfChYw==",
+      "@types/unist@2.0.9": {
+        "integrity": "sha512-zC0iXxAv1C1ERURduJueYzkzZ2zaGyc+P2c95hgkikHPr3z8EdUZOlgEQ5X0DRmwDZn+hekycQnoeiiRVrmilQ==",
         "dependencies": {}
       },
-      "@types/unist@3.0.0": {
-        "integrity": "sha512-MFETx3tbTjE7Uk6vvnWINA/1iJ7LuMdO4fcq8UfF0pRbj01aGLduVvQcRyswuACJdpnHgg8E3rQLhaRdNEJS0w==",
+      "@types/unist@3.0.1": {
+        "integrity": "sha512-ue/hDUpPjC85m+PM9OQDMZr3LywT+CT6mPsQq8OJtCLiERkGRcQUFvu9XASF5XWqyZFXbf15lvb3JFJ4dRLWPg==",
         "dependencies": {}
       },
       "@ungap/structured-clone@1.2.0": {
         "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
         "dependencies": {}
       },
-      "acorn-jsx@5.3.2_acorn@8.10.0": {
+      "acorn-jsx@5.3.2_acorn@8.11.2": {
         "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
         "dependencies": {
-          "acorn": "acorn@8.10.0"
+          "acorn": "acorn@8.11.2"
         }
       },
-      "acorn@8.10.0": {
-        "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+      "acorn@8.11.2": {
+        "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
         "dependencies": {}
       },
       "astring@1.8.6": {
@@ -264,13 +264,13 @@
       "estree-util-attach-comments@2.1.1": {
         "integrity": "sha512-+5Ba/xGGS6mnwFbXIuQiDPTbuTxuMCooq3arVv7gPZtYpjp+VXH/NkHAP35OOefPhNG/UGqU3vt/LTABwcHX0w==",
         "dependencies": {
-          "@types/estree": "@types/estree@1.0.2"
+          "@types/estree": "@types/estree@1.0.4"
         }
       },
       "estree-util-build-jsx@2.2.2": {
         "integrity": "sha512-m56vOXcOBuaF+Igpb9OPAy7f9w9OIkb5yhjsZuaPm7HoGi4oTOQi0h2+yZ+AtKklYFZ+rPC4n0wYCJCEU1ONqg==",
         "dependencies": {
-          "@types/estree-jsx": "@types/estree-jsx@1.0.1",
+          "@types/estree-jsx": "@types/estree-jsx@1.0.2",
           "estree-util-is-identifier-name": "estree-util-is-identifier-name@2.1.0",
           "estree-walker": "estree-walker@3.0.3"
         }
@@ -282,7 +282,7 @@
       "estree-util-to-js@1.2.0": {
         "integrity": "sha512-IzU74r1PK5IMMGZXUVZbmiu4A1uhiPgW5hm1GjcOfr4ZzHaMPpLNJjR7HjXiIOzi25nZDrgFTobHTkV5Q6ITjA==",
         "dependencies": {
-          "@types/estree-jsx": "@types/estree-jsx@1.0.1",
+          "@types/estree-jsx": "@types/estree-jsx@1.0.2",
           "astring": "astring@1.8.6",
           "source-map": "source-map@0.7.4"
         }
@@ -290,21 +290,21 @@
       "estree-util-value-to-estree@3.0.1": {
         "integrity": "sha512-b2tdzTurEIbwRh+mKrEcaWfu1wgb8J1hVsgREg7FFiecWwK/PhO8X0kyc+0bIcKNtD4sqxIdNoRy6/p/TvECEA==",
         "dependencies": {
-          "@types/estree": "@types/estree@1.0.2",
+          "@types/estree": "@types/estree@1.0.4",
           "is-plain-obj": "is-plain-obj@4.1.0"
         }
       },
       "estree-util-visit@1.2.1": {
         "integrity": "sha512-xbgqcrkIVbIG+lI/gzbvd9SGTJL4zqJKBFttUl5pP27KhAjtMKbX/mQXJ7qgyXpMgVy/zvpm0xoQQaGL8OloOw==",
         "dependencies": {
-          "@types/estree-jsx": "@types/estree-jsx@1.0.1",
-          "@types/unist": "@types/unist@2.0.8"
+          "@types/estree-jsx": "@types/estree-jsx@1.0.2",
+          "@types/unist": "@types/unist@2.0.9"
         }
       },
       "estree-walker@3.0.3": {
         "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
         "dependencies": {
-          "@types/estree": "@types/estree@1.0.2"
+          "@types/estree": "@types/estree@1.0.4"
         }
       },
       "extend@3.0.2": {
@@ -328,10 +328,10 @@
       "hast-util-from-parse5@7.1.2": {
         "integrity": "sha512-Nz7FfPBuljzsN3tCQ4kCBKqdNhQE2l0Tn+X1ubgKBPRoiDIu1mL08Cfw4k7q71+Duyaw7DXDN+VTAp4Vh3oCOw==",
         "dependencies": {
-          "@types/hast": "@types/hast@2.3.6",
-          "@types/unist": "@types/unist@2.0.8",
+          "@types/hast": "@types/hast@2.3.7",
+          "@types/unist": "@types/unist@2.0.9",
           "hastscript": "hastscript@7.2.0",
-          "property-information": "property-information@6.3.0",
+          "property-information": "property-information@6.4.0",
           "vfile": "vfile@5.3.7",
           "vfile-location": "vfile-location@4.1.0",
           "web-namespaces": "web-namespaces@2.0.1"
@@ -340,11 +340,11 @@
       "hast-util-from-parse5@8.0.1": {
         "integrity": "sha512-Er/Iixbc7IEa7r/XLtuG52zoqn/b3Xng/w6aZQ0xGVxzhw5xUFxcRqdPzP6yFi/4HBYRaifaI5fQ1RH8n0ZeOQ==",
         "dependencies": {
-          "@types/hast": "@types/hast@3.0.1",
-          "@types/unist": "@types/unist@3.0.0",
+          "@types/hast": "@types/hast@3.0.2",
+          "@types/unist": "@types/unist@3.0.1",
           "devlop": "devlop@1.1.0",
           "hastscript": "hastscript@8.0.0",
-          "property-information": "property-information@6.3.0",
+          "property-information": "property-information@6.4.0",
           "vfile": "vfile@6.0.1",
           "vfile-location": "vfile-location@5.0.2",
           "web-namespaces": "web-namespaces@2.0.1"
@@ -361,13 +361,13 @@
       "hast-util-has-property@3.0.0": {
         "integrity": "sha512-MNilsvEKLFpV604hwfhVStK0usFY/QmM5zX16bo7EjnAEGofr5YyI37kzopBlZJkHD4t887i+q/C8/tr5Q94cA==",
         "dependencies": {
-          "@types/hast": "@types/hast@3.0.1"
+          "@types/hast": "@types/hast@3.0.2"
         }
       },
       "hast-util-heading-rank@2.1.1": {
         "integrity": "sha512-iAuRp+ESgJoRFJbSyaqsfvJDY6zzmFoEnL1gtz1+U8gKtGGj1p0CVlysuUAUjq95qlZESHINLThwJzNGmgGZxA==",
         "dependencies": {
-          "@types/hast": "@types/hast@2.3.6"
+          "@types/hast": "@types/hast@2.3.7"
         }
       },
       "hast-util-is-element@1.1.0": {
@@ -377,27 +377,27 @@
       "hast-util-is-element@2.1.3": {
         "integrity": "sha512-O1bKah6mhgEq2WtVMk+Ta5K7pPMqsBBlmzysLdcwKVrqzZQ0CHqUPiIVspNhAG1rvxpvJjtGee17XfauZYKqVA==",
         "dependencies": {
-          "@types/hast": "@types/hast@2.3.6",
-          "@types/unist": "@types/unist@2.0.8"
+          "@types/hast": "@types/hast@2.3.7",
+          "@types/unist": "@types/unist@2.0.9"
         }
       },
       "hast-util-parse-selector@3.1.1": {
         "integrity": "sha512-jdlwBjEexy1oGz0aJ2f4GKMaVKkA9jwjr4MjAAI22E5fM/TXVZHuS5OpONtdeIkRKqAaryQ2E9xNQxijoThSZA==",
         "dependencies": {
-          "@types/hast": "@types/hast@2.3.6"
+          "@types/hast": "@types/hast@2.3.7"
         }
       },
       "hast-util-parse-selector@4.0.0": {
         "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
         "dependencies": {
-          "@types/hast": "@types/hast@3.0.1"
+          "@types/hast": "@types/hast@3.0.2"
         }
       },
       "hast-util-raw@9.0.1": {
         "integrity": "sha512-5m1gmba658Q+lO5uqL5YNGQWeh1MYWZbZmWrM5lncdcuiXuo5E2HT/CIOp0rLF8ksfSwiCVJ3twlgVRyTGThGA==",
         "dependencies": {
-          "@types/hast": "@types/hast@3.0.1",
-          "@types/unist": "@types/unist@3.0.0",
+          "@types/hast": "@types/hast@3.0.2",
+          "@types/unist": "@types/unist@3.0.1",
           "@ungap/structured-clone": "@ungap/structured-clone@1.2.0",
           "hast-util-from-parse5": "hast-util-from-parse5@8.0.1",
           "hast-util-to-parse5": "hast-util-to-parse5@8.0.0",
@@ -430,8 +430,8 @@
       "hast-util-select@6.0.1": {
         "integrity": "sha512-KPNOtLqeJCcFRyxQm9BakO3bdIQfremXraw4mh9jxsJ+L593v/VdP3G9Dfjahacl/bw8PPvIFseaXzElKOYRpA==",
         "dependencies": {
-          "@types/hast": "@types/hast@3.0.1",
-          "@types/unist": "@types/unist@3.0.0",
+          "@types/hast": "@types/hast@3.0.2",
+          "@types/unist": "@types/unist@3.0.1",
           "bcp-47-match": "bcp-47-match@2.0.3",
           "comma-separated-tokens": "comma-separated-tokens@2.0.3",
           "css-selector-parser": "css-selector-parser@2.3.2",
@@ -442,7 +442,7 @@
           "hast-util-whitespace": "hast-util-whitespace@3.0.0",
           "not": "not@0.1.0",
           "nth-check": "nth-check@2.1.1",
-          "property-information": "property-information@6.3.0",
+          "property-information": "property-information@6.4.0",
           "space-separated-tokens": "space-separated-tokens@2.0.2",
           "unist-util-visit": "unist-util-visit@5.0.0",
           "zwitch": "zwitch@2.0.4"
@@ -451,19 +451,19 @@
       "hast-util-to-estree@2.3.3": {
         "integrity": "sha512-ihhPIUPxN0v0w6M5+IiAZZrn0LH2uZomeWwhn7uP7avZC6TE7lIiEh2yBMPr5+zi1aUCXq6VoYRgs2Bw9xmycQ==",
         "dependencies": {
-          "@types/estree": "@types/estree@1.0.2",
-          "@types/estree-jsx": "@types/estree-jsx@1.0.1",
-          "@types/hast": "@types/hast@2.3.6",
-          "@types/unist": "@types/unist@2.0.8",
+          "@types/estree": "@types/estree@1.0.4",
+          "@types/estree-jsx": "@types/estree-jsx@1.0.2",
+          "@types/hast": "@types/hast@2.3.7",
+          "@types/unist": "@types/unist@2.0.9",
           "comma-separated-tokens": "comma-separated-tokens@2.0.3",
           "estree-util-attach-comments": "estree-util-attach-comments@2.1.1",
           "estree-util-is-identifier-name": "estree-util-is-identifier-name@2.1.0",
           "hast-util-whitespace": "hast-util-whitespace@2.0.1",
           "mdast-util-mdx-expression": "mdast-util-mdx-expression@1.3.2",
           "mdast-util-mdxjs-esm": "mdast-util-mdxjs-esm@1.3.1",
-          "property-information": "property-information@6.3.0",
+          "property-information": "property-information@6.4.0",
           "space-separated-tokens": "space-separated-tokens@2.0.2",
-          "style-to-object": "style-to-object@0.4.2",
+          "style-to-object": "style-to-object@0.4.4",
           "unist-util-position": "unist-util-position@4.0.4",
           "zwitch": "zwitch@2.0.4"
         }
@@ -471,15 +471,15 @@
       "hast-util-to-html@9.0.0": {
         "integrity": "sha512-IVGhNgg7vANuUA2XKrT6sOIIPgaYZnmLx3l/CCOAK0PtgfoHrZwX7jCSYyFxHTrGmC6S9q8aQQekjp4JPZF+cw==",
         "dependencies": {
-          "@types/hast": "@types/hast@3.0.1",
-          "@types/unist": "@types/unist@3.0.0",
+          "@types/hast": "@types/hast@3.0.2",
+          "@types/unist": "@types/unist@3.0.1",
           "ccount": "ccount@2.0.1",
           "comma-separated-tokens": "comma-separated-tokens@2.0.3",
           "hast-util-raw": "hast-util-raw@9.0.1",
           "hast-util-whitespace": "hast-util-whitespace@3.0.0",
           "html-void-elements": "html-void-elements@3.0.0",
           "mdast-util-to-hast": "mdast-util-to-hast@13.0.2",
-          "property-information": "property-information@6.3.0",
+          "property-information": "property-information@6.4.0",
           "space-separated-tokens": "space-separated-tokens@2.0.2",
           "stringify-entities": "stringify-entities@4.0.3",
           "zwitch": "zwitch@2.0.4"
@@ -488,10 +488,10 @@
       "hast-util-to-parse5@8.0.0": {
         "integrity": "sha512-3KKrV5ZVI8if87DVSi1vDeByYrkGzg4mEfeu4alwgmmIeARiBLKCZS2uw5Gb6nU9x9Yufyj3iudm6i7nl52PFw==",
         "dependencies": {
-          "@types/hast": "@types/hast@3.0.1",
+          "@types/hast": "@types/hast@3.0.2",
           "comma-separated-tokens": "comma-separated-tokens@2.0.3",
           "devlop": "devlop@1.1.0",
-          "property-information": "property-information@6.3.0",
+          "property-information": "property-information@6.4.0",
           "space-separated-tokens": "space-separated-tokens@2.0.2",
           "web-namespaces": "web-namespaces@2.0.1",
           "zwitch": "zwitch@2.0.4"
@@ -500,13 +500,13 @@
       "hast-util-to-string@2.0.0": {
         "integrity": "sha512-02AQ3vLhuH3FisaMM+i/9sm4OXGSq1UhOOCpTLLQtHdL3tZt7qil69r8M8iDkZYyC0HCFylcYoP+8IO7ddta1A==",
         "dependencies": {
-          "@types/hast": "@types/hast@2.3.6"
+          "@types/hast": "@types/hast@2.3.7"
         }
       },
       "hast-util-to-string@3.0.0": {
         "integrity": "sha512-OGkAxX1Ua3cbcW6EJ5pT/tslVb90uViVkcJ4ZZIMW/R33DX/AkcJcRrPebPwJkHYwlDHXz4aIwvAAaAdtrACFA==",
         "dependencies": {
-          "@types/hast": "@types/hast@3.0.1"
+          "@types/hast": "@types/hast@3.0.2"
         }
       },
       "hast-util-whitespace@1.0.4": {
@@ -520,26 +520,26 @@
       "hast-util-whitespace@3.0.0": {
         "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
         "dependencies": {
-          "@types/hast": "@types/hast@3.0.1"
+          "@types/hast": "@types/hast@3.0.2"
         }
       },
       "hastscript@7.2.0": {
         "integrity": "sha512-TtYPq24IldU8iKoJQqvZOuhi5CyCQRAbvDOX0x1eW6rsHSxa/1i2CCiptNTotGHJ3VoHRGmqiv6/D3q113ikkw==",
         "dependencies": {
-          "@types/hast": "@types/hast@2.3.6",
+          "@types/hast": "@types/hast@2.3.7",
           "comma-separated-tokens": "comma-separated-tokens@2.0.3",
           "hast-util-parse-selector": "hast-util-parse-selector@3.1.1",
-          "property-information": "property-information@6.3.0",
+          "property-information": "property-information@6.4.0",
           "space-separated-tokens": "space-separated-tokens@2.0.2"
         }
       },
       "hastscript@8.0.0": {
         "integrity": "sha512-dMOtzCEd3ABUeSIISmrETiKuyydk1w0pa+gE/uormcTpSYuaNJPbX1NU3JLyscSLjwAQM8bWMhhIlnCqnRvDTw==",
         "dependencies": {
-          "@types/hast": "@types/hast@3.0.1",
+          "@types/hast": "@types/hast@3.0.2",
           "comma-separated-tokens": "comma-separated-tokens@2.0.3",
           "hast-util-parse-selector": "hast-util-parse-selector@4.0.0",
-          "property-information": "property-information@6.3.0",
+          "property-information": "property-information@6.4.0",
           "space-separated-tokens": "space-separated-tokens@2.0.2"
         }
       },
@@ -581,7 +581,7 @@
       "is-reference@3.0.2": {
         "integrity": "sha512-v3rht/LgVcsdZa3O2Nqs+NMowLOxeOm7Ay9+/ARQ2F+qEoANRcqrjAZKGN0v8ymUetZGgkp26LTnGT7H0Qo9Pg==",
         "dependencies": {
-          "@types/estree": "@types/estree@1.0.2"
+          "@types/estree": "@types/estree@1.0.4"
         }
       },
       "kleur@4.1.5": {
@@ -603,15 +603,15 @@
       "mdast-util-definitions@5.1.2": {
         "integrity": "sha512-8SVPMuHqlPME/z3gqVwWY4zVXn8lqKv/pAhC57FuJ40ImXyBpmO5ukh98zB2v7Blql2FiHjHv9LVztSIqjY+MA==",
         "dependencies": {
-          "@types/mdast": "@types/mdast@3.0.13",
-          "@types/unist": "@types/unist@2.0.8",
+          "@types/mdast": "@types/mdast@3.0.14",
+          "@types/unist": "@types/unist@2.0.9",
           "unist-util-visit": "unist-util-visit@4.1.2"
         }
       },
       "mdast-util-find-and-replace@2.2.2": {
         "integrity": "sha512-MTtdFRz/eMDHXzeK6W3dO7mXUlF82Gom4y0oOgvHhh/HXZAGvIQDUvQ0SuUx+j2tv44b8xTHOm8K/9OoRFnXKw==",
         "dependencies": {
-          "@types/mdast": "@types/mdast@3.0.13",
+          "@types/mdast": "@types/mdast@3.0.14",
           "escape-string-regexp": "escape-string-regexp@5.0.0",
           "unist-util-is": "unist-util-is@5.2.1",
           "unist-util-visit-parents": "unist-util-visit-parents@5.1.3"
@@ -620,8 +620,8 @@
       "mdast-util-from-markdown@1.3.1": {
         "integrity": "sha512-4xTO/M8c82qBcnQc1tgpNtubGUW/Y1tBQ1B0i5CtSoelOLKFYlElIr3bvgREYYO5iRqbMY1YuqZng0GVOI8Qww==",
         "dependencies": {
-          "@types/mdast": "@types/mdast@3.0.13",
-          "@types/unist": "@types/unist@2.0.8",
+          "@types/mdast": "@types/mdast@3.0.14",
+          "@types/unist": "@types/unist@2.0.9",
           "decode-named-character-reference": "decode-named-character-reference@1.0.2",
           "mdast-util-to-string": "mdast-util-to-string@3.2.0",
           "micromark": "micromark@3.2.0",
@@ -637,7 +637,7 @@
       "mdast-util-frontmatter@1.0.1": {
         "integrity": "sha512-JjA2OjxRqAa8wEG8hloD0uTU0kdn8kbtOWpPP94NBkfAlbxn4S8gCGf/9DwFtEeGPXrDcNXdiDjVaRdUFqYokw==",
         "dependencies": {
-          "@types/mdast": "@types/mdast@3.0.13",
+          "@types/mdast": "@types/mdast@3.0.14",
           "mdast-util-to-markdown": "mdast-util-to-markdown@1.5.0",
           "micromark-extension-frontmatter": "micromark-extension-frontmatter@1.1.1"
         }
@@ -645,7 +645,7 @@
       "mdast-util-gfm-autolink-literal@1.0.3": {
         "integrity": "sha512-My8KJ57FYEy2W2LyNom4n3E7hKTuQk/0SES0u16tjA9Z3oFkF4RrC/hPAPgjlSpezsOvI8ObcXcElo92wn5IGA==",
         "dependencies": {
-          "@types/mdast": "@types/mdast@3.0.13",
+          "@types/mdast": "@types/mdast@3.0.14",
           "ccount": "ccount@2.0.1",
           "mdast-util-find-and-replace": "mdast-util-find-and-replace@2.2.2",
           "micromark-util-character": "micromark-util-character@1.2.0"
@@ -654,7 +654,7 @@
       "mdast-util-gfm-footnote@1.0.2": {
         "integrity": "sha512-56D19KOGbE00uKVj3sgIykpwKL179QsVFwx/DCW0u/0+URsryacI4MAdNJl0dh+u2PSsD9FtxPFbHCzJ78qJFQ==",
         "dependencies": {
-          "@types/mdast": "@types/mdast@3.0.13",
+          "@types/mdast": "@types/mdast@3.0.14",
           "mdast-util-to-markdown": "mdast-util-to-markdown@1.5.0",
           "micromark-util-normalize-identifier": "micromark-util-normalize-identifier@1.1.0"
         }
@@ -662,14 +662,14 @@
       "mdast-util-gfm-strikethrough@1.0.3": {
         "integrity": "sha512-DAPhYzTYrRcXdMjUtUjKvW9z/FNAMTdU0ORyMcbmkwYNbKocDpdk+PX1L1dQgOID/+vVs1uBQ7ElrBQfZ0cuiQ==",
         "dependencies": {
-          "@types/mdast": "@types/mdast@3.0.13",
+          "@types/mdast": "@types/mdast@3.0.14",
           "mdast-util-to-markdown": "mdast-util-to-markdown@1.5.0"
         }
       },
       "mdast-util-gfm-table@1.0.7": {
         "integrity": "sha512-jjcpmNnQvrmN5Vx7y7lEc2iIOEytYv7rTvu+MeyAsSHTASGCCRA79Igg2uKssgOs1i1po8s3plW0sTu1wkkLGg==",
         "dependencies": {
-          "@types/mdast": "@types/mdast@3.0.13",
+          "@types/mdast": "@types/mdast@3.0.14",
           "markdown-table": "markdown-table@3.0.3",
           "mdast-util-from-markdown": "mdast-util-from-markdown@1.3.1",
           "mdast-util-to-markdown": "mdast-util-to-markdown@1.5.0"
@@ -678,7 +678,7 @@
       "mdast-util-gfm-task-list-item@1.0.2": {
         "integrity": "sha512-PFTA1gzfp1B1UaiJVyhJZA1rm0+Tzn690frc/L8vNX1Jop4STZgOE6bxUhnzdVSB+vm2GU1tIsuQcA9bxTQpMQ==",
         "dependencies": {
-          "@types/mdast": "@types/mdast@3.0.13",
+          "@types/mdast": "@types/mdast@3.0.14",
           "mdast-util-to-markdown": "mdast-util-to-markdown@1.5.0"
         }
       },
@@ -697,9 +697,9 @@
       "mdast-util-mdx-expression@1.3.2": {
         "integrity": "sha512-xIPmR5ReJDu/DHH1OoIT1HkuybIfRGYRywC+gJtI7qHjCJp/M9jrmBEJW22O8lskDWm562BX2W8TiAwRTb0rKA==",
         "dependencies": {
-          "@types/estree-jsx": "@types/estree-jsx@1.0.1",
-          "@types/hast": "@types/hast@2.3.6",
-          "@types/mdast": "@types/mdast@3.0.13",
+          "@types/estree-jsx": "@types/estree-jsx@1.0.2",
+          "@types/hast": "@types/hast@2.3.7",
+          "@types/mdast": "@types/mdast@3.0.14",
           "mdast-util-from-markdown": "mdast-util-from-markdown@1.3.1",
           "mdast-util-to-markdown": "mdast-util-to-markdown@1.5.0"
         }
@@ -707,10 +707,10 @@
       "mdast-util-mdx-jsx@2.1.4": {
         "integrity": "sha512-DtMn9CmVhVzZx3f+optVDF8yFgQVt7FghCRNdlIaS3X5Bnym3hZwPbg/XW86vdpKjlc1PVj26SpnLGeJBXD3JA==",
         "dependencies": {
-          "@types/estree-jsx": "@types/estree-jsx@1.0.1",
-          "@types/hast": "@types/hast@2.3.6",
-          "@types/mdast": "@types/mdast@3.0.13",
-          "@types/unist": "@types/unist@2.0.8",
+          "@types/estree-jsx": "@types/estree-jsx@1.0.2",
+          "@types/hast": "@types/hast@2.3.7",
+          "@types/mdast": "@types/mdast@3.0.14",
+          "@types/unist": "@types/unist@2.0.9",
           "ccount": "ccount@2.0.1",
           "mdast-util-from-markdown": "mdast-util-from-markdown@1.3.1",
           "mdast-util-to-markdown": "mdast-util-to-markdown@1.5.0",
@@ -734,9 +734,9 @@
       "mdast-util-mdxjs-esm@1.3.1": {
         "integrity": "sha512-SXqglS0HrEvSdUEfoXFtcg7DRl7S2cwOXc7jkuusG472Mmjag34DUDeOJUZtl+BVnyeO1frIgVpHlNRWc2gk/w==",
         "dependencies": {
-          "@types/estree-jsx": "@types/estree-jsx@1.0.1",
-          "@types/hast": "@types/hast@2.3.6",
-          "@types/mdast": "@types/mdast@3.0.13",
+          "@types/estree-jsx": "@types/estree-jsx@1.0.2",
+          "@types/hast": "@types/hast@2.3.7",
+          "@types/mdast": "@types/mdast@3.0.14",
           "mdast-util-from-markdown": "mdast-util-from-markdown@1.3.1",
           "mdast-util-to-markdown": "mdast-util-to-markdown@1.5.0"
         }
@@ -744,15 +744,15 @@
       "mdast-util-phrasing@3.0.1": {
         "integrity": "sha512-WmI1gTXUBJo4/ZmSk79Wcb2HcjPJBzM1nlI/OUWA8yk2X9ik3ffNbBGsU+09BFmXaL1IBb9fiuvq6/KMiNycSg==",
         "dependencies": {
-          "@types/mdast": "@types/mdast@3.0.13",
+          "@types/mdast": "@types/mdast@3.0.14",
           "unist-util-is": "unist-util-is@5.2.1"
         }
       },
       "mdast-util-to-hast@12.3.0": {
         "integrity": "sha512-pits93r8PhnIoU4Vy9bjW39M2jJ6/tdHyja9rrot9uujkN7UTU9SDnE6WNJz/IGyQk3XHX6yNNtrBH6cQzm8Hw==",
         "dependencies": {
-          "@types/hast": "@types/hast@2.3.6",
-          "@types/mdast": "@types/mdast@3.0.13",
+          "@types/hast": "@types/hast@2.3.7",
+          "@types/mdast": "@types/mdast@3.0.14",
           "mdast-util-definitions": "mdast-util-definitions@5.1.2",
           "micromark-util-sanitize-uri": "micromark-util-sanitize-uri@1.2.0",
           "trim-lines": "trim-lines@3.0.1",
@@ -764,8 +764,8 @@
       "mdast-util-to-hast@13.0.2": {
         "integrity": "sha512-U5I+500EOOw9e3ZrclN3Is3fRpw8c19SMyNZlZ2IS+7vLsNzb2Om11VpIVOR+/0137GhZsFEF6YiKD5+0Hr2Og==",
         "dependencies": {
-          "@types/hast": "@types/hast@3.0.1",
-          "@types/mdast": "@types/mdast@4.0.1",
+          "@types/hast": "@types/hast@3.0.2",
+          "@types/mdast": "@types/mdast@4.0.2",
           "@ungap/structured-clone": "@ungap/structured-clone@1.2.0",
           "devlop": "devlop@1.1.0",
           "micromark-util-sanitize-uri": "micromark-util-sanitize-uri@2.0.0",
@@ -777,8 +777,8 @@
       "mdast-util-to-markdown@1.5.0": {
         "integrity": "sha512-bbv7TPv/WC49thZPg3jXuqzuvI45IL2EVAr/KxF0BSdHsU0ceFHOmwQn6evxAh1GaoK/6GQ1wp4R4oW2+LFL/A==",
         "dependencies": {
-          "@types/mdast": "@types/mdast@3.0.13",
-          "@types/unist": "@types/unist@2.0.8",
+          "@types/mdast": "@types/mdast@3.0.14",
+          "@types/unist": "@types/unist@2.0.9",
           "longest-streak": "longest-streak@3.1.0",
           "mdast-util-phrasing": "mdast-util-phrasing@3.0.1",
           "mdast-util-to-string": "mdast-util-to-string@3.2.0",
@@ -790,7 +790,7 @@
       "mdast-util-to-string@3.2.0": {
         "integrity": "sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==",
         "dependencies": {
-          "@types/mdast": "@types/mdast@3.0.13"
+          "@types/mdast": "@types/mdast@3.0.14"
         }
       },
       "micromark-core-commonmark@1.1.0": {
@@ -898,7 +898,7 @@
       "micromark-extension-mdx-expression@1.0.8": {
         "integrity": "sha512-zZpeQtc5wfWKdzDsHRBY003H2Smg+PUi2REhqgIhdzAa5xonhP03FcXxqFSerFiNUr5AWmHpaNPQTBVOS4lrXw==",
         "dependencies": {
-          "@types/estree": "@types/estree@1.0.2",
+          "@types/estree": "@types/estree@1.0.4",
           "micromark-factory-mdx-expression": "micromark-factory-mdx-expression@1.0.9",
           "micromark-factory-space": "micromark-factory-space@1.1.0",
           "micromark-util-character": "micromark-util-character@1.2.0",
@@ -912,7 +912,7 @@
         "integrity": "sha512-gPH+9ZdmDflbu19Xkb8+gheqEDqkSpdCEubQyxuz/Hn8DOXiXvrXeikOoBA71+e8Pfi0/UYmU3wW3H58kr7akA==",
         "dependencies": {
           "@types/acorn": "@types/acorn@4.0.6",
-          "@types/estree": "@types/estree@1.0.2",
+          "@types/estree": "@types/estree@1.0.4",
           "estree-util-is-identifier-name": "estree-util-is-identifier-name@2.1.0",
           "micromark-factory-mdx-expression": "micromark-factory-mdx-expression@1.0.9",
           "micromark-factory-space": "micromark-factory-space@1.1.0",
@@ -932,7 +932,7 @@
       "micromark-extension-mdxjs-esm@1.0.5": {
         "integrity": "sha512-xNRBw4aoURcyz/S69B19WnZAkWJMxHMT5hE36GtDAyhoyn/8TuAeqjFJQlwk+MKQsUD7b3l7kFX+vlfVWgcX1w==",
         "dependencies": {
-          "@types/estree": "@types/estree@1.0.2",
+          "@types/estree": "@types/estree@1.0.4",
           "micromark-core-commonmark": "micromark-core-commonmark@1.1.0",
           "micromark-util-character": "micromark-util-character@1.2.0",
           "micromark-util-events-to-acorn": "micromark-util-events-to-acorn@1.2.3",
@@ -943,11 +943,11 @@
           "vfile-message": "vfile-message@3.1.4"
         }
       },
-      "micromark-extension-mdxjs@1.0.1_acorn@8.10.0": {
+      "micromark-extension-mdxjs@1.0.1_acorn@8.11.2": {
         "integrity": "sha512-7YA7hF6i5eKOfFUzZ+0z6avRG52GpWR8DL+kN47y3f2KhxbBZMhmxe7auOeaTBrW2DenbbZTf1ea9tA2hDpC2Q==",
         "dependencies": {
-          "acorn": "acorn@8.10.0",
-          "acorn-jsx": "acorn-jsx@5.3.2_acorn@8.10.0",
+          "acorn": "acorn@8.11.2",
+          "acorn-jsx": "acorn-jsx@5.3.2_acorn@8.11.2",
           "micromark-extension-mdx-expression": "micromark-extension-mdx-expression@1.0.8",
           "micromark-extension-mdx-jsx": "micromark-extension-mdx-jsx@1.0.5",
           "micromark-extension-mdx-md": "micromark-extension-mdx-md@1.0.1",
@@ -976,7 +976,7 @@
       "micromark-factory-mdx-expression@1.0.9": {
         "integrity": "sha512-jGIWzSmNfdnkJq05c7b0+Wv0Kfz3NJ3N4cBjnbO4zjXIlxJr+f8lk+5ZmwFvqdAbUy2q6B5rCY//g0QAAaXDWA==",
         "dependencies": {
-          "@types/estree": "@types/estree@1.0.2",
+          "@types/estree": "@types/estree@1.0.4",
           "micromark-util-character": "micromark-util-character@1.2.0",
           "micromark-util-events-to-acorn": "micromark-util-events-to-acorn@1.2.3",
           "micromark-util-symbol": "micromark-util-symbol@1.1.0",
@@ -1073,8 +1073,8 @@
         "integrity": "sha512-ij4X7Wuc4fED6UoLWkmo0xJQhsktfNh1J0m8g4PbIMPlx+ek/4YdW5mvbye8z/aZvAPUoxgXHrwVlXAPKMRp1w==",
         "dependencies": {
           "@types/acorn": "@types/acorn@4.0.6",
-          "@types/estree": "@types/estree@1.0.2",
-          "@types/unist": "@types/unist@2.0.8",
+          "@types/estree": "@types/estree@1.0.4",
+          "@types/unist": "@types/unist@2.0.9",
           "estree-util-visit": "estree-util-visit@1.2.1",
           "micromark-util-symbol": "micromark-util-symbol@1.1.0",
           "micromark-util-types": "micromark-util-types@1.1.0",
@@ -1142,7 +1142,7 @@
       "micromark@3.2.0": {
         "integrity": "sha512-uD66tJj54JLYq0De10AhWycZWGQNUvDI55xPgk2sQM5kn1JYlhbCMTtEeT27+vAhW2FBQxLlOmS3pmA7/2z4aA==",
         "dependencies": {
-          "@types/debug": "@types/debug@4.1.9",
+          "@types/debug": "@types/debug@4.1.10",
           "debug": "debug@4.3.4",
           "decode-named-character-reference": "decode-named-character-reference@1.0.2",
           "micromark-core-commonmark": "micromark-core-commonmark@1.1.0",
@@ -1188,7 +1188,7 @@
       "parse-entities@4.0.1": {
         "integrity": "sha512-SWzvYcSJh4d/SGLIOQfZ/CoNv6BTlI6YEQ7Nj82oDVnRpwe/Z/F1EMx42x3JAOwGBlCjeCH0BRJQbQ/opHL17w==",
         "dependencies": {
-          "@types/unist": "@types/unist@2.0.8",
+          "@types/unist": "@types/unist@2.0.9",
           "character-entities": "character-entities@2.0.2",
           "character-entities-legacy": "character-entities-legacy@3.0.0",
           "character-reference-invalid": "character-reference-invalid@2.0.1",
@@ -1215,7 +1215,7 @@
       "periscopic@3.1.0": {
         "integrity": "sha512-vKiQ8RRtkl9P+r/+oefh25C3fhybptkHKCZSPlcXiJux2tJF55GnEj3BVn4A5gKfq9NWWXXrxkHBwVPUfH0opw==",
         "dependencies": {
-          "@types/estree": "@types/estree@1.0.2",
+          "@types/estree": "@types/estree@1.0.4",
           "estree-walker": "estree-walker@3.0.3",
           "is-reference": "is-reference@3.0.2"
         }
@@ -1224,15 +1224,15 @@
         "integrity": "sha512-BKU45RMZAA+3npkQ/VxEH7EeZImQcfV6rfKH0O4HkkDz3uqqz+689dbkjiWia00vK390MY6EARPS6TzNS4tXPg==",
         "dependencies": {}
       },
-      "property-information@6.3.0": {
-        "integrity": "sha512-gVNZ74nqhRMiIUYWGQdosYetaKc83x8oT41a0LlV3AAFCAZwCpg4vmGkq8t34+cUhp3cnM4XDiU/7xlgK7HGrg==",
+      "property-information@6.4.0": {
+        "integrity": "sha512-9t5qARVofg2xQqKtytzt+lZ4d1Qvj8t5B8fEwXK6qOfgRLgH/b13QlgEyDh033NOS31nXeFbYv7CLUDG1CeifQ==",
         "dependencies": {}
       },
       "refractor@4.8.1": {
         "integrity": "sha512-/fk5sI0iTgFYlmVGYVew90AoYnNMP6pooClx/XKqyeeCQXrL0Kvgn8V0VEht5ccdljbzzF1i3Q213gcntkRExg==",
         "dependencies": {
-          "@types/hast": "@types/hast@2.3.6",
-          "@types/prismjs": "@types/prismjs@1.26.1",
+          "@types/hast": "@types/hast@2.3.7",
+          "@types/prismjs": "@types/prismjs@1.26.2",
           "hastscript": "hastscript@7.2.0",
           "parse-entities": "parse-entities@4.0.1"
         }
@@ -1246,7 +1246,7 @@
       "rehype-autolink-headings@6.1.1": {
         "integrity": "sha512-NMYzZIsHM3sA14nC5rAFuUPIOfg+DFmf9EY1YMhaNlB7+3kK/ZlE6kqPfuxr1tsJ1XWkTrMtMoyHosU70d35mA==",
         "dependencies": {
-          "@types/hast": "@types/hast@2.3.6",
+          "@types/hast": "@types/hast@2.3.7",
           "extend": "extend@3.0.2",
           "hast-util-has-property": "hast-util-has-property@2.0.1",
           "hast-util-heading-rank": "hast-util-heading-rank@2.1.1",
@@ -1258,7 +1258,7 @@
       "rehype-parse@8.0.5": {
         "integrity": "sha512-Ds3RglaY/+clEX2U2mHflt7NlMA72KspZ0JLUJgBBLpRddBcEw3H8uYZQliQriku22NZpYMfjDdSgHcjxue24A==",
         "dependencies": {
-          "@types/hast": "@types/hast@2.3.6",
+          "@types/hast": "@types/hast@2.3.7",
           "hast-util-from-parse5": "hast-util-from-parse5@7.1.2",
           "parse5": "parse5@6.0.1",
           "unified": "unified@10.1.2"
@@ -1278,7 +1278,7 @@
       "rehype-slug@5.1.0": {
         "integrity": "sha512-Gf91dJoXneiorNEnn+Phx97CO7oRMrpi+6r155tTxzGuLtm+QrI4cTwCa9e1rtePdL4i9tSO58PeSS6HWfgsiw==",
         "dependencies": {
-          "@types/hast": "@types/hast@2.3.6",
+          "@types/hast": "@types/hast@2.3.7",
           "github-slugger": "github-slugger@2.0.0",
           "hast-util-has-property": "hast-util-has-property@2.0.1",
           "hast-util-heading-rank": "hast-util-heading-rank@2.1.1",
@@ -1290,7 +1290,7 @@
       "remark-frontmatter@4.0.1": {
         "integrity": "sha512-38fJrB0KnmD3E33a5jZC/5+gGAC2WKNiPw1/fdXJvijBlhA7RCsvJklrYJakS0HedninvaCYW8lQGf9C918GfA==",
         "dependencies": {
-          "@types/mdast": "@types/mdast@3.0.13",
+          "@types/mdast": "@types/mdast@3.0.14",
           "mdast-util-frontmatter": "mdast-util-frontmatter@1.0.1",
           "micromark-extension-frontmatter": "micromark-extension-frontmatter@1.1.1",
           "unified": "unified@10.1.2"
@@ -1299,7 +1299,7 @@
       "remark-gfm@3.0.1": {
         "integrity": "sha512-lEFDoi2PICJyNrACFOfDD3JlLkuSbOa5Wd8EPt06HUdptv8Gn0bxYTdbU/XXQ3swAPkEaGxxPN9cbnMHvVu1Ig==",
         "dependencies": {
-          "@types/mdast": "@types/mdast@3.0.13",
+          "@types/mdast": "@types/mdast@3.0.14",
           "mdast-util-gfm": "mdast-util-gfm@2.0.2",
           "micromark-extension-gfm": "micromark-extension-gfm@2.0.3",
           "unified": "unified@10.1.2"
@@ -1308,25 +1308,25 @@
       "remark-mdx-frontmatter@3.0.0": {
         "integrity": "sha512-Tnkz8n/fxZGKMBaFJa5jKumJPpuTr9eZF+u+4UcnlUNmUQP3h8ZwgaTzIvkVb6QjG6QE0itsP5JjWnkEBz8IJw==",
         "dependencies": {
-          "@types/mdast": "@types/mdast@3.0.13",
+          "@types/mdast": "@types/mdast@3.0.14",
           "estree-util-is-identifier-name": "estree-util-is-identifier-name@2.1.0",
           "estree-util-value-to-estree": "estree-util-value-to-estree@3.0.1",
           "toml": "toml@3.0.0",
           "unified": "unified@10.1.2",
-          "yaml": "yaml@2.3.2"
+          "yaml": "yaml@2.3.3"
         }
       },
       "remark-mdx@2.3.0": {
         "integrity": "sha512-g53hMkpM0I98MU266IzDFMrTD980gNF3BJnkyFcmN+dD873mQeD5rdMO3Y2X+x8umQfbSE0PcoEDl7ledSA+2g==",
         "dependencies": {
           "mdast-util-mdx": "mdast-util-mdx@2.0.1",
-          "micromark-extension-mdxjs": "micromark-extension-mdxjs@1.0.1_acorn@8.10.0"
+          "micromark-extension-mdxjs": "micromark-extension-mdxjs@1.0.1_acorn@8.11.2"
         }
       },
       "remark-parse@10.0.2": {
         "integrity": "sha512-3ydxgHa/ZQzG8LvC7jTXccARYDcRld3VfcgIIFs7bI6vbRSxJJmzgLEIIoYKyrfhaY+ujuWaf/PJiMZXoiCXgw==",
         "dependencies": {
-          "@types/mdast": "@types/mdast@3.0.13",
+          "@types/mdast": "@types/mdast@3.0.14",
           "mdast-util-from-markdown": "mdast-util-from-markdown@1.3.1",
           "unified": "unified@10.1.2"
         }
@@ -1334,8 +1334,8 @@
       "remark-rehype@10.1.0": {
         "integrity": "sha512-EFmR5zppdBp0WQeDVZ/b66CWJipB2q2VLNFMabzDSGR66Z2fQii83G5gTBbgGEnEEA0QRussvrFHxk1HWGJskw==",
         "dependencies": {
-          "@types/hast": "@types/hast@2.3.6",
-          "@types/mdast": "@types/mdast@3.0.13",
+          "@types/hast": "@types/hast@2.3.7",
+          "@types/mdast": "@types/mdast@3.0.14",
           "mdast-util-to-hast": "mdast-util-to-hast@12.3.0",
           "unified": "unified@10.1.2"
         }
@@ -1369,8 +1369,8 @@
           "character-entities-legacy": "character-entities-legacy@3.0.0"
         }
       },
-      "style-to-object@0.4.2": {
-        "integrity": "sha512-1JGpfPB3lo42ZX8cuPrheZbfQ6kqPPnPHlKMyeRYtfKD+0jG+QsXgXN57O/dvJlzlB2elI6dGmrPnl5VPQFPaA==",
+      "style-to-object@0.4.4": {
+        "integrity": "sha512-HYNoHZa2GorYNyqiCaBgsxvcJIn7OHq6inEga+E6Ke3m5JkoqpQbnFssk4jwe+K7AhGa2fcha4wSOf1Kn01dMg==",
         "dependencies": {
           "inline-style-parser": "inline-style-parser@0.1.1"
         }
@@ -1390,7 +1390,7 @@
       "unified@10.1.2": {
         "integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
         "dependencies": {
-          "@types/unist": "@types/unist@2.0.8",
+          "@types/unist": "@types/unist@2.0.9",
           "bail": "bail@2.0.2",
           "extend": "extend@3.0.2",
           "is-buffer": "is-buffer@2.0.5",
@@ -1402,7 +1402,7 @@
       "unist-util-filter@4.0.1": {
         "integrity": "sha512-RynicUM/vbOSTSiUK+BnaK9XMfmQUh6gyi7L6taNgc7FIf84GukXVV3ucGzEN/PhUUkdP5hb1MmXc+3cvPUm5Q==",
         "dependencies": {
-          "@types/unist": "@types/unist@2.0.8",
+          "@types/unist": "@types/unist@2.0.9",
           "unist-util-is": "unist-util-is@5.2.1",
           "unist-util-visit-parents": "unist-util-visit-parents@5.1.3"
         }
@@ -1414,70 +1414,70 @@
       "unist-util-is@5.2.1": {
         "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
         "dependencies": {
-          "@types/unist": "@types/unist@2.0.8"
+          "@types/unist": "@types/unist@2.0.9"
         }
       },
       "unist-util-is@6.0.0": {
         "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
         "dependencies": {
-          "@types/unist": "@types/unist@3.0.0"
+          "@types/unist": "@types/unist@3.0.1"
         }
       },
       "unist-util-position-from-estree@1.1.2": {
         "integrity": "sha512-poZa0eXpS+/XpoQwGwl79UUdea4ol2ZuCYguVaJS4qzIOMDzbqz8a3erUCOmubSZkaOuGamb3tX790iwOIROww==",
         "dependencies": {
-          "@types/unist": "@types/unist@2.0.8"
+          "@types/unist": "@types/unist@2.0.9"
         }
       },
       "unist-util-position@4.0.4": {
         "integrity": "sha512-kUBE91efOWfIVBo8xzh/uZQ7p9ffYRtUbMRZBNFYwf0RK8koUMx6dGUfwylLOKmaT2cs4wSW96QoYUSXAyEtpg==",
         "dependencies": {
-          "@types/unist": "@types/unist@2.0.8"
+          "@types/unist": "@types/unist@2.0.9"
         }
       },
       "unist-util-position@5.0.0": {
         "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
         "dependencies": {
-          "@types/unist": "@types/unist@3.0.0"
+          "@types/unist": "@types/unist@3.0.1"
         }
       },
       "unist-util-remove-position@4.0.2": {
         "integrity": "sha512-TkBb0HABNmxzAcfLf4qsIbFbaPDvMO6wa3b3j4VcEzFVaw1LBKwnW4/sRJ/atSLSzoIg41JWEdnE7N6DIhGDGQ==",
         "dependencies": {
-          "@types/unist": "@types/unist@2.0.8",
+          "@types/unist": "@types/unist@2.0.9",
           "unist-util-visit": "unist-util-visit@4.1.2"
         }
       },
       "unist-util-stringify-position@3.0.3": {
         "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
         "dependencies": {
-          "@types/unist": "@types/unist@2.0.8"
+          "@types/unist": "@types/unist@2.0.9"
         }
       },
       "unist-util-stringify-position@4.0.0": {
         "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
         "dependencies": {
-          "@types/unist": "@types/unist@3.0.0"
+          "@types/unist": "@types/unist@3.0.1"
         }
       },
       "unist-util-visit-parents@5.1.3": {
         "integrity": "sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==",
         "dependencies": {
-          "@types/unist": "@types/unist@2.0.8",
+          "@types/unist": "@types/unist@2.0.9",
           "unist-util-is": "unist-util-is@5.2.1"
         }
       },
       "unist-util-visit-parents@6.0.1": {
         "integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
         "dependencies": {
-          "@types/unist": "@types/unist@3.0.0",
+          "@types/unist": "@types/unist@3.0.1",
           "unist-util-is": "unist-util-is@6.0.0"
         }
       },
       "unist-util-visit@4.1.2": {
         "integrity": "sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==",
         "dependencies": {
-          "@types/unist": "@types/unist@2.0.8",
+          "@types/unist": "@types/unist@2.0.9",
           "unist-util-is": "unist-util-is@5.2.1",
           "unist-util-visit-parents": "unist-util-visit-parents@5.1.3"
         }
@@ -1485,7 +1485,7 @@
       "unist-util-visit@5.0.0": {
         "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
         "dependencies": {
-          "@types/unist": "@types/unist@3.0.0",
+          "@types/unist": "@types/unist@3.0.1",
           "unist-util-is": "unist-util-is@6.0.0",
           "unist-util-visit-parents": "unist-util-visit-parents@6.0.1"
         }
@@ -1502,35 +1502,35 @@
       "vfile-location@4.1.0": {
         "integrity": "sha512-YF23YMyASIIJXpktBa4vIGLJ5Gs88UB/XePgqPmTa7cDA+JeO3yclbpheQYCHjVHBn/yePzrXuygIL+xbvRYHw==",
         "dependencies": {
-          "@types/unist": "@types/unist@2.0.8",
+          "@types/unist": "@types/unist@2.0.9",
           "vfile": "vfile@5.3.7"
         }
       },
       "vfile-location@5.0.2": {
         "integrity": "sha512-NXPYyxyBSH7zB5U6+3uDdd6Nybz6o6/od9rk8bp9H8GR3L+cm/fC0uUTbqBmUTnMCUDslAGBOIKNfvvb+gGlDg==",
         "dependencies": {
-          "@types/unist": "@types/unist@3.0.0",
+          "@types/unist": "@types/unist@3.0.1",
           "vfile": "vfile@6.0.1"
         }
       },
       "vfile-message@3.1.4": {
         "integrity": "sha512-fa0Z6P8HUrQN4BZaX05SIVXic+7kE3b05PWAtPuYP9QLHsLKYR7/AlLW3NtOrpXRLeawpDLMsVkmk5DG0NXgWw==",
         "dependencies": {
-          "@types/unist": "@types/unist@2.0.8",
+          "@types/unist": "@types/unist@2.0.9",
           "unist-util-stringify-position": "unist-util-stringify-position@3.0.3"
         }
       },
       "vfile-message@4.0.2": {
         "integrity": "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==",
         "dependencies": {
-          "@types/unist": "@types/unist@3.0.0",
+          "@types/unist": "@types/unist@3.0.1",
           "unist-util-stringify-position": "unist-util-stringify-position@4.0.0"
         }
       },
       "vfile@5.3.7": {
         "integrity": "sha512-r7qlzkgErKjobAmyNIkkSpizsFPYiUPuJb5pNW1RB4JcYVZhs4lIbVqk8XPk033CV/1z8ss5pkax8SuhGpcG8g==",
         "dependencies": {
-          "@types/unist": "@types/unist@2.0.8",
+          "@types/unist": "@types/unist@2.0.9",
           "is-buffer": "is-buffer@2.0.5",
           "unist-util-stringify-position": "unist-util-stringify-position@3.0.3",
           "vfile-message": "vfile-message@3.1.4"
@@ -1539,7 +1539,7 @@
       "vfile@6.0.1": {
         "integrity": "sha512-1bYqc7pt6NIADBJ98UiG0Bn/CHIVOoZ/IyEkqIruLg0mE1BKzkOXY2D6CSqQIcKqgadppE5lrxgWXJmXd7zZJw==",
         "dependencies": {
-          "@types/unist": "@types/unist@3.0.0",
+          "@types/unist": "@types/unist@3.0.1",
           "unist-util-stringify-position": "unist-util-stringify-position@4.0.0",
           "vfile-message": "vfile-message@4.0.2"
         }
@@ -1548,8 +1548,8 @@
         "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
         "dependencies": {}
       },
-      "yaml@2.3.2": {
-        "integrity": "sha512-N/lyzTPaJasoDmfV7YTrYCI0G/3ivm/9wdG0aHuheKowWQwGTsK0Eoiw6utmzAnI6pkJa0DUVygvp3spqqEKXg==",
+      "yaml@2.3.3": {
+        "integrity": "sha512-zw0VAJxgeZ6+++/su5AFoqBbZbrEakwu+X0M5HmcwUiBL7AzcuPKjj5we4xfQLp78LkEMpD0cOnUhmgOVy3KdQ==",
         "dependencies": {}
       },
       "zwitch@1.0.5": {

--- a/www/html/app.html.tsx
+++ b/www/html/app.html.tsx
@@ -105,7 +105,7 @@ export default function* AppHtml({ title }: Options): Operation<JSX.Element> {
             <h1 class="text-sm uppercase font-bold text-blue-primary mb-4">
               About
             </h1>
-            <a class="" href="https://frontside.com">
+            <a class="" href="https://frontside.com" class="text-gray-800">
               Maintained by Frontside <IconExtern />
             </a>
           </section>
@@ -113,10 +113,10 @@ export default function* AppHtml({ title }: Options): Operation<JSX.Element> {
             <h1 class="text-sm uppercase font-bold text-blue-primary mb-4">
               OSS Projects
             </h1>
-            <a href="https://frontside.com/interactors">
+            <a href="https://frontside.com/interactors" class="text-gray-800">
               Interactors <IconExtern />
             </a>
-            <a href="/V2">
+            <a href="/V2" class="text-gray-800">
               Effection<em class="align-super text-xs">v2</em> <IconExtern />
             </a>
           </section>
@@ -124,10 +124,10 @@ export default function* AppHtml({ title }: Options): Operation<JSX.Element> {
             <h1 class="text-sm uppercase font-bold text-blue-primary mb-4">
               Community
             </h1>
-            <a href="https://discord.gg/r6AvtnU">
+            <a href="https://discord.gg/r6AvtnU" class="text-gray-800">
               Discord <IconExtern />
             </a>
-            <a href="https://github.com/thefrontside/effection">
+            <a href="https://github.com/thefrontside/effection" class="text-gray-800">
               GitHub <IconExtern />
             </a>
           </section>

--- a/www/html/app.html.tsx
+++ b/www/html/app.html.tsx
@@ -64,6 +64,8 @@ export default function* AppHtml({ title }: Options): Operation<JSX.Element> {
                 <img
                   src="/assets/images/effection-logo.svg"
                   alt="Effection Logo"
+                  width="156px"
+                  height="24px"
                 />
               </a>
             </div>

--- a/www/html/app.html.tsx
+++ b/www/html/app.html.tsx
@@ -50,8 +50,12 @@ export default function* AppHtml({ title }: Options): Operation<JSX.Element> {
           href={yield* useUrl("/")}
           hreflang="x-default"
         />
-        <link rel="preload" as="style" href="/assets/prism-atom-one-dark.css" />
-        <link rel="preload" as="style" href="https://use.typekit.net/ugs0ewy.css" />
+        <link href="/assets/prism-atom-one-dark.css" rel="preload" as="style" onload="this.rel='stylesheet'" />
+        <link href="https://use.typekit.net/ugs0ewy.css" rel="preload" as="style" onload="this.rel='stylesheet'" />
+        <noscript>
+          <link rel="stylesheet" href="https://use.typekit.net/ugs0ewy.css" />
+          <link rel="stylesheet" href="/assets/prism-atom-one-dark.css" />
+        </noscript>
       </head>
       <body class="max-w-screen-2xl m-auto">
         <header class="header w-full top-0 p-6 sticky tracking-wide z-10">

--- a/www/html/app.html.tsx
+++ b/www/html/app.html.tsx
@@ -50,8 +50,8 @@ export default function* AppHtml({ title }: Options): Operation<JSX.Element> {
           href={yield* useUrl("/")}
           hreflang="x-default"
         />
-        <link rel="stylesheet" href="/assets/prism-atom-one-dark.css" />
-        <link rel="stylesheet" href="https://use.typekit.net/ugs0ewy.css" />
+        <link rel="preload" as="style" href="/assets/prism-atom-one-dark.css" />
+        <link rel="preload" as="style" href="https://use.typekit.net/ugs0ewy.css" />
       </head>
       <body class="max-w-screen-2xl m-auto">
         <header class="header w-full top-0 p-6 sticky tracking-wide z-10">

--- a/www/html/index.html.tsx
+++ b/www/html/index.html.tsx
@@ -9,6 +9,8 @@ export default function* IndexHTML(): Operation<JSX.Element> {
             class="inline min-w-[20%]"
             alt="Effection Logo"
             src="/assets/images/icon-effection.svg"
+            width="288px"
+            height="288px"
           />
           <h1 class="text-4xl font-bold leading-7">Effection</h1>
           <p class="text-sm py-4">
@@ -21,28 +23,28 @@ export default function* IndexHTML(): Operation<JSX.Element> {
             Get Started
           </a>
         </hgroup>
-        <Feature summary="👩🏻‍💻100% JavaScript">
+        <Feature summary="👩🏻‍💻 100% JavaScript">
           No build steps. No esoteric APIs, and no new odd-ball paradigms to
           learn; Effection leans into JavaScript's natural constructs at every
           turn, so code always feels intuitive.
         </Feature>
 
-        <Feature summary="🛡️Leak proof">
+        <Feature summary="🛡️ Leak proof">
           Effection code cleans up after itself, and that means never having to
           remember to manually close a resource or detach a listener.
         </Feature>
-        <Feature summary="🖐️Halt any operation">
+        <Feature summary="🖐️ Halt any operation">
           An Effection operation can be shut down at any moment which will not
           only stop it completely but also stop any other operations that it
           started.
         </Feature>
-        <Feature summary="🔒Synchronicity">
+        <Feature summary="🔒 Synchronicity">
           Unlike Promises and async/await, Effection is fundamentally
           synchronous in nature, which means you have full control over the
           event loop and operations requiring synchronous setup remain race
           condition free.
         </Feature>
-        <Feature summary="🎹Seamless composition">
+        <Feature summary="🎹 Seamless composition">
           Since all Effection code is well behaved, it clicks together easily,
           and there are no nasty surprises when fitting different pieces
           together.


### PR DESCRIPTION
## Motivation

I noticed that Effection docs site is loading slowly. 

<img width="736" alt="image" src="https://github.com/thefrontside/effection/assets/74687/ee41c82f-4bad-4caf-bb0a-2ec2e04579e6">

## Approach

### Add preload to CSS resource [as per recommendations](https://developer.chrome.com/docs/lighthouse/performance/render-blocking-resources/?utm_source=lighthouse&utm_medium=devtools#how-to-eliminate-render-blocking-scripts).

<img width="744" alt="image" src="https://github.com/thefrontside/effection/assets/74687/f4df77ac-5509-459a-bc21-01fbef1424ed">

### [Added width/height to images to prevent render jank](https://github.com/thefrontside/effection/pull/817/commits/49051b10e2ed644d3818314ea9e8cd049a1b7234)

### [Increased contracts of links in the footer](https://github.com/thefrontside/effection/pull/817/commits/78de5de7de2b9fb775b212f1f7e13a1aecb3f34a)

### [Updated dependencies](https://github.com/thefrontside/effection/pull/817/commits/a91e5ec6ab19256ed5dd26b7652981e1ae90bee5)

## Screenshots

<img width="679" alt="image" src="https://github.com/thefrontside/effection/assets/74687/8eaa885a-8748-41be-8f50-aa9a0f9187a3">
