### PR TITLE
Fix website vi async iterator adapter

### DIFF
--- a/lib/async.ts
+++ b/lib/async.ts
@@ -14,7 +14,7 @@ export function expect<T>(promise: Promise<T>): Operation<T> {
 
 export function subscribe<T, R>(iter: AsyncIterator<T, R>): Subscription<T, R> {
   return {
-    next: () => call(iter.next),
+    next: () => call(() => iter.next()),
   };
 }
 


### PR DESCRIPTION
## Motivation
One of the unstable, undocumented APIs to convert async iterators into subscriptions, was using the bare `iter.next` in a point-free style. However, that loses the `this` binding for the iterator it is traversing; not a problem for many iterators, but it is for some.

## Approach

This always preserves the `this` context by explicitly invoking it on the object it was first found with. Also, there was some breakage with the file watcher due to the `Subscription` api migration that needed to be updated.
