### PR TITLE
fix channel docs

### DIFF
--- a/lib/channel.ts
+++ b/lib/channel.ts
@@ -35,15 +35,15 @@ export interface Channel<T, TClose> extends Stream<T, TClose> {
  * import { main, createChannel } from 'effection';
  *
  * await main(function*() {
- *   let { input, output } = createChannel();
+ *   let channel = createChannel();
  *
- *   yield* input.send('too early'); // the channel has no subscribers yet!
+ *   yield* channel.send('too early'); // the channel has no subscribers yet!
  *
- *   let subscription1 = yield* channel;
- *   let subscription2 = yield* channel;
+ *   let subscription1 = yield* channel.subscribe();
+ *   let subscription2 = yield* channel.subscribe();
  *
- *   yield* input.send('hello');
- *   yield* input.send('world');
+ *   yield* channel.send('hello');
+ *   yield* channel.send('world');
  *
  *   console.log(yield* subscription1.next()); //=> { done: false, value: 'hello' }
  *   console.log(yield* subscription1.next()); //=> { done: false, value: 'world' }

--- a/www/docs/collections.mdx
+++ b/www/docs/collections.mdx
@@ -77,13 +77,13 @@ to show the difference between them:
 import { main, createChannel } from 'effection';
 
 await main(function*() {
-  let { send, subscribe} = createChannel();
+  let channel = createChannel();
 
   // the channel has no subscribers yet!
-  yield* send('too early');
+  yield* channel.send('too early');
 
-  let subscription1 = yield* subscribe();
-  let subscription2 = yield* subscribe();
+  let subscription1 = yield* channel.subscribe();
+  let subscription2 = yield* channel.subscribe();
 
   yield* send('hello');
   yield* send('world');


### PR DESCRIPTION
## Motivation
The `createChannel()` docs had gotten way out of date. Most of the docs had gotten fixed, but these didn't

## Approach

Bring up to speed on the new API.
