### PR TITLE
Parallelize documentation loading

### DIFF
--- a/www/deno.json
+++ b/www/deno.json
@@ -19,7 +19,7 @@
   "imports": {
     "effection": "../mod.ts",
     "freejack/": "./lib/",
-    "hastx/": "https://deno.land/x/hastx@0.0.5/",
+    "hastx/": "https://deno.land/x/hastx@0.0.8/",
     "hastx/jsx-runtime": "https://deno.land/x/hastx@v0.0.5/jsx-runtime.ts"
   }
 }

--- a/www/deno.lock
+++ b/www/deno.lock
@@ -1651,6 +1651,12 @@
     "https://deno.land/std@0.203.0/path/extname.ts": "62c4b376300795342fe1e4746c0de518b4dc9c4b0b4617bfee62a2973a9555cf",
     "https://deno.land/std@0.203.0/path/join.ts": "31c5419f23d91655b08ec7aec403f4e4cd1a63d39e28f6e42642ea207c2734f8",
     "https://deno.land/std@0.203.0/streams/read_all.ts": "3b20a50af87d1bfebefa9c2dbda49e2b214d8ab0382ffdcc8ce858af80a912be",
+    "https://deno.land/std@0.205.0/path/_common/assert_path.ts": "061e4d093d4ba5aebceb2c4da3318bfe3289e868570e9d3a8e327d91c2958946",
+    "https://deno.land/std@0.205.0/path/_common/basename.ts": "0d978ff818f339cd3b1d09dc914881f4d15617432ae519c1b8fdc09ff8d3789a",
+    "https://deno.land/std@0.205.0/path/_common/constants.ts": "e49961f6f4f48039c0dfed3c3f93e963ca3d92791c9d478ac5b43183413136e0",
+    "https://deno.land/std@0.205.0/path/_common/strip_trailing_separators.ts": "7ffc7c287e97bdeeee31b155828686967f222cd73f9e5780bfe7dfb1b58c6c65",
+    "https://deno.land/std@0.205.0/path/posix/_util.ts": "ecf49560fedd7dd376c6156cc5565cad97c1abe9824f4417adebc7acc36c93e5",
+    "https://deno.land/std@0.205.0/path/posix/basename.ts": "a630aeb8fd8e27356b1823b9dedd505e30085015407caa3396332752f6b8406a",
     "https://deno.land/x/continuation@0.1.5/mod.ts": "690def2735046367b3e1b4bc6e51b5912f2ed09c41c7df7a55c060f23720ad33",
     "https://deno.land/x/hastx@v0.0.5/jsx-runtime.ts": "5e1db59ceea4834b8d248a018a5adfc73a09922d8dcdaa3a3bb228c884da0f6c"
   }

--- a/www/docs/actions.mdx
+++ b/www/docs/actions.mdx
@@ -1,5 +1,4 @@
 ---
-id: actions
 title: Actions and Suspensions
 ---
 

--- a/www/docs/collections.mdx
+++ b/www/docs/collections.mdx
@@ -1,5 +1,4 @@
 ---
-id: collections
 title: Streams and Subscriptions
 ---
 

--- a/www/docs/errors.mdx
+++ b/www/docs/errors.mdx
@@ -1,5 +1,4 @@
 ---
-id: errors
 title: Errors
 ---
 

--- a/www/docs/events.mdx
+++ b/www/docs/events.mdx
@@ -1,5 +1,4 @@
 ---
-id: events
 title: Events
 ---
 

--- a/www/docs/inspector.mdx
+++ b/www/docs/inspector.mdx
@@ -1,5 +1,4 @@
 ---
-id: inspector
 title: Inspector
 ---
 

--- a/www/docs/introduction.mdx
+++ b/www/docs/introduction.mdx
@@ -1,5 +1,4 @@
 ---
-id: introduction
 title: Introduction
 ---
 

--- a/www/docs/operations.mdx
+++ b/www/docs/operations.mdx
@@ -1,5 +1,4 @@
 ---
-id: operations
 title: Operations
 ---
 

--- a/www/docs/processes.mdx
+++ b/www/docs/processes.mdx
@@ -1,5 +1,4 @@
 ---
-id: processes
 title: Spawning processes
 ---
 

--- a/www/docs/resources.mdx
+++ b/www/docs/resources.mdx
@@ -1,5 +1,4 @@
 ---
-id: resources
 title: Resources
 ---
 

--- a/www/docs/scope.mdx
+++ b/www/docs/scope.mdx
@@ -1,5 +1,4 @@
 ---
-id: scope
 title: Scope
 ---
 

--- a/www/docs/spawn.mdx
+++ b/www/docs/spawn.mdx
@@ -1,5 +1,4 @@
 ---
-id: spawn
 title: Spawn
 ---
 

--- a/www/docs/testing.mdx
+++ b/www/docs/testing.mdx
@@ -1,5 +1,4 @@
 ---
-id: testing
 title: Testing
 ---
 

--- a/www/docs/typescript.mdx
+++ b/www/docs/typescript.mdx
@@ -1,5 +1,4 @@
 ---
-id: typescript
 title: TypeScript
 ---
 

--- a/www/html/document.html.tsx
+++ b/www/html/document.html.tsx
@@ -11,7 +11,9 @@ import rehypeToc from "npm:@jsdevtools/rehype-toc@3.0.2";
 
 export default function* (doc: Doc): Operation<JSX.Element> {
   let docs = yield* useDocs();
-  let topics = docs.getTopics();
+  let topics = yield* docs.getTopics();
+  let next = yield* docs.getDoc(doc.nextId);
+  let prev = yield* docs.getDoc(doc.previousId);
 
   return (
     <section class="mx-auto md:pt-8 w-full justify-items-normal md:grid md:grid-cols-[225px_auto] lg:grid-cols-[225px_auto_200px] md:gap-4">
@@ -114,38 +116,38 @@ export default function* (doc: Doc): Operation<JSX.Element> {
           >
             <doc.MDXContent />
           </Rehype>
-          <NextPrevLinks doc={doc} />
+          <NextPrevLinks prev={prev} next={next} />
         </article>
       </Transform>
     </section>
   );
 }
 
-function NextPrevLinks({ doc }: { doc: Doc }): JSX.Element {
+function NextPrevLinks({ next, prev }: { next?: Doc, prev?: Doc }): JSX.Element {
   return (
     <menu class="grid grid-cols-2 my-10 gap-x-2 xl:gap-x-20 2xl:gap-x-40 text-lg">
-      {doc.previous
+      {prev
         ? (
           <li class="col-start-1 text-left font-light border-1 rounded-lg p-4">
             Previous
             <a
               class="py-2 block text-xl font-bold text-blue-primary no-underline tracking-wide leading-5 before:content-['«&nbsp;'] before:font-normal"
-              href={`/docs/${doc.previous.id}`}
+              href={`/docs/${prev.id}`}
             >
-              {doc.previous.title}
+              {prev.title}
             </a>
           </li>
         )
         : <li />}
-      {doc.next
+      {next
         ? (
           <li class="col-start-2 text-right font-light border-1 rounded-lg p-4">
             Next
             <a
               class="py-2 block text-xl font-bold text-blue-primary no-underline tracking-wide leading-5 after:content-['&nbsp;»'] after:font-normal"
-              href={`/docs/${doc.next.id}`}
+              href={`/docs/${next.id}`}
             >
-              {doc.next.title}
+              {next.title}
             </a>
           </li>
         )

--- a/www/server.ts
+++ b/www/server.ts
@@ -1,7 +1,7 @@
 import { serve } from "freejack/server.ts";
 import { html } from "freejack/html.ts";
 import { render } from "freejack/view.ts";
-import { Docs, loadDocs, useDocs } from "./docs/docs.ts";
+import { Docs, loadDocs } from "./docs/docs.ts";
 import { useV2Docs } from "./hooks/use-v2-docs.ts";
 
 import { AppHtml, DocumentHtml, IndexHtml } from "./html/templates.ts";
@@ -9,7 +9,7 @@ import { AppHtml, DocumentHtml, IndexHtml } from "./html/templates.ts";
 export default function* start() {
   let v2docs = yield* useV2Docs({
     fetchEagerly: !!Deno.env.get("V2_DOCS_FETCH_EAGERLY"),
-    revision: Number(Deno.env.get("V2_DOCS_REVISION")) ?? 4,
+    revision: Number(Deno.env.get("V2_DOCS_REVISION") ?? 4),
   });
 
   let docs = yield* loadDocs();
@@ -24,9 +24,8 @@ export default function* start() {
     }),
 
     "/docs/:id": html.get(function* ({ id }) {
-      let docs = yield* useDocs();
 
-      let doc = docs.getDoc(id);
+      let doc = yield* docs.getDoc(id);
 
       if (!doc) {
         return { name: "h1", attrs: {}, children: ["Not Found"] };


### PR DESCRIPTION
## Motivation

We were noticing very long isolate startup times for the Effection site. Upon inspection it became clear that the docs were being all loaded up front before you could even serve a single request. The following shows a performance snapshot on how long it took to load the documents.

```shellsession
$ deno run -A main.ts
load docs: 294.138709
www -> http://0.0.0.0:8000
```

This changes the `loadDocs()` operation to spawn the file read and parse in parallel. In order to facilitate this, the id of the route is determined _not_ by the MDX frontmatter, but instead by the name of the file. As a result, the startup time is reduced by over 100x

```shellsession
$ deno run -A main.ts
load docs: 2.495749999999987
www -> http://0.0.0.0:8000
```

## Approach

1. Load and parse documentation pages asynchronously which required changing where the ID comes from. Before, it was part of the document which required parsing the document to get the ID. Now, we're treating the file name as the ID which allows us to remove id from all of the documents.
2. Docs are now stored as operations so we yield each operation when we retrieve the doc
