### PR TITLE
feat(signal): allow custom `Queue` impl when creating a `Signal`

### DIFF
--- a/test/signal.test.ts
+++ b/test/signal.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "./suite.ts";
+import {
+  createQueue,
+  createScope,
+  createSignal,
+  each,
+  run,
+  SignalQueueFactory,
+  spawn,
+} from "../mod.ts";
+
+describe("createSignal", () => {
+  it("should send and receive messages", async () => {
+    let msgs: string[] = [];
+    let signal = createSignal<string, void>();
+    let root = run(function* () {
+      let task = yield* spawn(function* () {
+        for (let msg of yield* each(signal)) {
+          msgs.push(msg);
+          yield* each.next();
+        }
+      });
+
+      signal.send("msg1");
+      signal.send("msg2");
+      signal.close();
+      yield* task;
+    });
+
+    await root;
+
+    expect(msgs).toEqual(["msg1", "msg2"]);
+  });
+
+  it("should use custom Queue impl", async () => {
+    // drop every other message
+    function createDropQueue() {
+      let counter = 0;
+      let queue = createQueue<string, void>();
+      return {
+        ...queue,
+        add(value: string) {
+          counter += 1;
+          if (counter % 2 === 0) {
+            return;
+          }
+
+          queue.add(value);
+        },
+      };
+    }
+
+    let msgs: string[] = [];
+    let [scope] = createScope();
+    scope.set(SignalQueueFactory, createDropQueue);
+    let signal = createSignal<string, void>();
+
+    let root = scope.run(function* () {
+      let task = yield* spawn(function* () {
+        for (let msg of yield* each(signal)) {
+          msgs.push(msg);
+          yield* each.next();
+        }
+      });
+
+      signal.send("msg1");
+      signal.send("msg2");
+      signal.send("msg3");
+      signal.send("msg4");
+      signal.send("msg5");
+      signal.close();
+      yield* task;
+    });
+
+    await root;
+
+    expect(msgs).toEqual(["msg1", "msg3", "msg5"]);
+  });
+});


### PR DESCRIPTION
## Motivation

`starfx` needs a way to customize the implementation for a `Signal`'s `Queue` so we can control how actions are dispatched and subscribed to, primarily for performance reasons.

It is not uncommon for a FE app to have hundreds of listeners on the action `Stream` so this is a hot path that is causing performance issues for [app-ui](https://github.com/aptible/app-ui).

## Approach

We need a way to allow users to customize the `Queue` implementation to support features like buffering, dropping messages, filtering messages, etc.  Ideally, we would be able to implement these downstream of a `Stream` but we are noticing performance implications with that implementation.  

So this is not ideal, but until we dig into why there's such a big performance impact for sending and listening to a lot of messages, we opted to allow users to monkey-patch `Queue` with something custom.  As a result, we decided to create `Context` object that defaults to `createQueue` but can be overridden when necessary.

See discussion: https://discord.com/channels/700803887132704931/1169297115609059411

### Alternate Designs

 <!-- OPTIONAL
   Explain what other alternatives you considered and why you chose this option.
 -->

### Possible Drawbacks or Risks

The biggest drawback here is we are not really solving the root issue with performance, instead we came up with a solution that doesn't change the API contract while still letting end-users monkey-patch `Queue`.

### TODOs and Open Questions

- Why is the performance poor when having a lot of subscribers on a `Signal`?

## Learning

<!-- OPTIONAL
  Share any blog posts, patterns, libraries, or documentation that helped you.
-->

## Screenshots

Listed below are screenshots from a production FE application using `effection` and `starfx`.  As you can see, this PR removes all "slow tasks" in the profiler.

### BEFORE
![Screenshot 2023-11-09 at 10 50 31 AM](https://github.com/thefrontside/effection/assets/1940365/acf99397-377e-41a3-ab73-2a5747daa0b2)

### AFTER
![Screenshot 2023-11-09 at 10 46 35 AM](https://github.com/thefrontside/effection/assets/1940365/ce92632a-4d5e-4199-b722-c1e57a93f8b6)

