### PR TITLE
🔥Remove old `main.ts` entry point.

### DIFF
--- a/www/deno.json
+++ b/www/deno.json
@@ -1,7 +1,6 @@
 {
   "tasks": {
-    "dev": "deno run -A lib/watch.ts components docs lib middleware routes -- deno run -A --lock-write main.ts",
-    "build": "deno run -A docs/build.ts"
+    "dev": "deno run -A lib/watch.ts components docs lib middleware routes -- deno run -A --lock-write main.tsx"
   },
   "lint": {
     "exclude": ["docs/esm"],

--- a/www/main.ts
+++ b/www/main.ts
@@ -1,1 +1,0 @@
-import "./main.tsx";


### PR DESCRIPTION
## Motivation

The new entry point is `main.tsx`, but we could not get rid of the old one because `deno.com` can only have one entry point per production branch, so we needed to merge the new one, then point deno.com to use it, and now we can get rid of the old one.
