### PR TITLE
feat: `call` accepts plain functions

### DIFF
--- a/test/call.test.ts
+++ b/test/call.test.ts
@@ -5,9 +5,10 @@ import { call, run, spawn, suspend } from "../mod.ts";
 describe("call", () => {
   it("evaluates an operation function", async () => {
     await run(function* () {
-      let result = yield* call(function* () {
+      function* fn() {
         return 10;
-      });
+      }
+      let result = yield* call(fn);
       expect(result).toEqual(10);
     });
   });
@@ -18,6 +19,15 @@ describe("call", () => {
         *[Symbol.iterator]() {
           return 42;
         },
+      })
+    )).resolves.toEqual(42);
+  });
+
+  it("evaluates an async function", async () => {
+    await expect(run(() =>
+      call(async function () {
+        await Promise.resolve();
+        return 42;
       })
     )).resolves.toEqual(42);
   });
@@ -47,5 +57,39 @@ describe("call", () => {
       }
     });
     expect(result).toEqual(error);
+  });
+
+  it("evaluates a vanilla function", async () => {
+    await expect(run(() => call(() => 42))).resolves.toEqual(42);
+  });
+
+  it("evaluates a vanilla function that returns an iterable string", async () => {
+    await expect(run(() => call(() => "123"))).resolves.toEqual("123");
+  });
+
+  it("evaluates a vanilla function that returns an iterable array", async () => {
+    await expect(run(() => call(() => [1, 2, 3]))).resolves.toEqual([1, 2, 3]);
+  });
+
+  it("evaluates a vanilla function that returns an iterable map", async () => {
+    let map = new Map();
+    map.set("1", 1);
+    map.set("2", 2);
+    map.set("3", 3);
+    await expect(run(() => call(() => map))).resolves.toEqual(map);
+  });
+
+  it("evaluates a vanilla function that returns an iterable set", async () => {
+    let arr = new Set([1, 2, 3]);
+    await expect(run(() => call(() => arr))).resolves.toEqual(arr);
+  });
+
+  it("evaluates a vanilla function that returns an iterator", async () => {
+    function* eq() {
+      return "value";
+    }
+    await expect(run(function* () {
+      return yield* call(() => eq);
+    })).resolves.toEqual(eq);
   });
 });


### PR DESCRIPTION
## Motivation

As library developers, we might want to require the user to understand delimited continuations or any of the constructs created by `effection`.  Sometimes we want to let the end-user provide anything reasonable we `call()` knows how to reflect what was passed into the function and it will handle it automatically.  The most obvious example is `Promise`.  We don't have to require the user to convert a `Promise` into an `Operation`.

Being able to pass a vanilla function into `call()` would also be nice since it is trivial for us to detect and accept.

So in summary, we want to support the following variables to `call()`:

```ts
call(() => thing);
call(async () => thing);
call(function*() {});
```

## Approach

We try to inspect the type of the variables passed into `call()` and figure out how to evaluate it.