### PR TITLE
Adding basic fetch docs

### DIFF
--- a/lib/fetch.ts
+++ b/lib/fetch.ts
@@ -1,0 +1,27 @@
+import { useAbortSignal } from "./abort-signal.ts";
+import { action } from './instructions.ts';
+import { call } from './call.ts';
+
+export function createFetchOperation(fetchFn: typeof fetch) {
+  return function* fetchOperation(
+    input: RequestInfo | URL,
+    init?: Omit<RequestInit, "signal">,
+  ) {
+    return yield* action<Response>(function* (resolve, reject) {
+      const signal = yield* useAbortSignal();
+
+      try {
+        let result = yield* call(
+          fetchFn(input, {
+            ...(init ?? {}),
+            signal,
+          }),
+        );
+        resolve(result);
+      } catch (e) {
+        reject(e);
+      }
+
+    });
+  };
+}

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -1,0 +1,64 @@
+import { createFetchOperation } from "../lib/fetch.ts";
+import { Operation, run, spawn } from "../mod.ts";
+import { beforeEach, describe, expect, it } from "./suite.ts";
+
+describe("createEffectionFetch", () => {
+  it("creates an operation that resolves with the result on success", async () => {
+    let result = await run(function* () {
+      let fetchOperation = createFetchOperation(() => {
+        return Promise.resolve({
+          text() {
+            return "success";
+          },
+        } as unknown as Response);
+      });
+
+      return yield* fetchOperation("example.com");
+    });
+
+    expect(result.text()).toBe("success");
+  });
+
+  it("creates an operation that receives abort controller when cancelled", async () => {
+    let _signal: AbortSignal | undefined;
+    let _recievedSignal: boolean | undefined;
+
+    let fetchOperation = createFetchOperation((_, init) => {
+      if (init && init.signal) {
+        _signal = init.signal;
+
+        return new Promise((resolve, reject) => {
+          if (_signal) {
+            _signal.addEventListener("abort", () => {
+              _recievedSignal = true;
+              reject(new Error("AbortError"));
+            });
+          }
+
+          resolve({
+            text() {
+              return "success";
+            },
+          } as unknown as Response);
+        });
+      } else {
+        return Promise.resolve({
+          text() {
+            return "this should never happen";
+          },
+        } as unknown as Response);
+      }
+    });
+
+    try {
+      await run(function* () {
+        yield* spawn(() => fetchOperation("example.com"));
+
+        throw new Error();
+      });
+    } catch {}
+
+    expect(_signal).not.toBeUndefined();
+    expect(_recievedSignal).toBe(true);
+  });
+});

--- a/www/docs/fetch.mdx
+++ b/www/docs/fetch.mdx
@@ -1,0 +1,103 @@
+---
+title: Fetch
+---
+
+Effection provides a structured concurrency aware wrapper for Fetch API. The wrapper automatically takes care of cancelling inflight fetch requests
+when the operation passed out of scope. You can use `createFetchOperation` function to wrap a fetch function provided by your environment in an operation.
+
+```ts
+import {
+  main,
+  createFetchOperation,
+} from "https://deno.land/x/effection/mod.ts";
+
+await main(function* () {
+  const effectionFetch = createFetchOperation(fetch);
+
+  const response = yield* effectionFetch(
+    "https://api.github.com/users/denoland",
+    {
+      headers: {
+        accept: "application/json",
+      },
+    }
+  );
+});
+```
+
+## Fetch Context and useFetch hook
+
+Effection provides a context reference for Fetch context appropriately called `FetchContext`. To use the `useFetch` operation, you must have `FetchContext` in your Effection scope. 
+
+Set the `FetchContext` close to the root of the operation tree to make it available to all operations.
+
+```ts
+import { main, useScope, FetchContext, createFetchOperation } from 'effection';
+
+await main(function*() {
+  const scope = useScope();
+
+  scope.set(FetchContext, createFetchOperation(fetch));
+});
+```
+
+With `FetchContext` in operation scope, you can create your own operations and use fetch with the assumption that the constructor will be provided by the context.
+
+```ts
+import { Operation, useFetch, call } from 'effection'
+
+interface User {
+  name: string;
+}
+
+function* getUser(id: string): Operation<User> {
+  const fetch = yield* useFetch();
+
+  const response = yield* fetch<User>(`https://my-app/users/${id}`);
+
+  if (response.ok) {
+    return yield* call(response.json())
+  }
+
+  throw new Error(`Failed to fetch user due to ${response.statusText}`)
+}
+```
+
+## Custom Fetch Context
+
+The Fetch Context gives you the ability to control how Fetch API is used within the scope of your application. One of the common use cases is to automatically apply an authorization token when the user is authorized.
+
+Let's asumme that your that you already have an operation that gives you a token for the current user. Let's use this operation to create a custom context
+that will automatically include the token in the Authorization header.
+
+```ts
+import { main, useScope, FetchContext, createFetchOperation } from 'effection';
+
+function* useUserToken(): Operation<string | undefined> {
+  // your application specific logic will go here
+
+  return token;
+}
+
+await main(function*() {
+  const scope = useScope();
+
+  scope.set(FetchContext, function* (url: RequestInfo | URL, init?: Omit<RequestInit, "signal") {
+    const token = yield* useUserToken();
+    const fetchOperation = createFetchOperation(fetch);
+    
+    return yield* fetchOperation(url, {
+      headers: {
+        ...(init?.headers ?? {}),
+        ...(token ? { "Authorization": `token ${token}` } : { })
+      }
+    })
+  });
+});
+```
+
+Now, anytime you use `useFetch` operation, it'll automatically include the "Authorization" header when the token is available.
+
+## Testing operations that use `useFetch` operation
+
+// TODO

--- a/www/docs/structure.json
+++ b/www/docs/structure.json
@@ -10,6 +10,9 @@
     ["errors.mdx", "Error Handling"],
     ["typescript.mdx", "TypeScript"]
   ],
+  "Standard Library": [
+    "fetch.mdx", "Fetch API"
+  ],
   "Advanced": [
     ["scope.mdx", "Scope"],
     ["testing.mdx", "Testing"],


### PR DESCRIPTION
## Motivation

As part of #833, we must provide a documented fetch alternative to update all the docs where Fetch is used incorrectly.

## Approach

Started implementing a fetch module, and wrote initial tests and documentation.

1. `createFetchOperation` takes `fetch` and returns an operation that automatically takes care of handling graceful abort.
2. Wrote tests for `createFetchOperation`
3. Added a new section to the docs called Standard Library with page for fetch
4. Wrote docs about `createFetchOperation`

## TODO

* [ ] Implement useFetch
* [ ] Provide FetchContext
* [ ] Write tests for both
* [ ] provide documentation on how to stub fetch when using `useFetch`