### PR TITLE
Task.halt() always succeeds as long as teardown succeeds.

### DIFF
--- a/lib/run/frame.ts
+++ b/lib/run/frame.ts
@@ -148,19 +148,19 @@ export function createFrame<T>(options: FrameOptions<T>): Frame<T> {
     }
 
     if (!destruction.ok) {
-      setResults({ ok: false, error: destruction.error, exit });
+      setResults({ ok: false, error: destruction.error, exit, destruction });
     } else {
       if (exit.type === "aborted") {
-        setResults({ ok: true, value: void 0, exit });
+        setResults({ ok: true, value: void 0, exit, destruction });
       } else if (exit.type === "result") {
         let { result } = exit;
         if (result.ok) {
-          setResults({ ok: true, value: void 0, exit });
+          setResults({ ok: true, value: void 0, exit, destruction });
         } else {
-          setResults({ ok: false, error: result.error, exit });
+          setResults({ ok: false, error: result.error, exit, destruction });
         }
       } else {
-        setResults({ ok: false, error: exit.error, exit });
+        setResults({ ok: false, error: exit.error, exit, destruction });
       }
     }
   });

--- a/lib/run/task.ts
+++ b/lib/run/task.ts
@@ -63,11 +63,11 @@ export function createTask<T>(
       };
       let awaitHaltResult = (resolve: Resolve<void>, reject: Reject) => {
         evaluate(function* () {
-          let result = yield* frame;
-          if (result.ok) {
-            resolve(result.value);
+          let { destruction } = yield* frame;
+          if (destruction.ok) {
+            resolve();
           } else {
-            reject(result.error);
+            reject(destruction.error);
           }
         });
       };

--- a/lib/run/types.ts
+++ b/lib/run/types.ts
@@ -15,4 +15,5 @@ export type Exit<T> = {
  */
 export type FrameResult<T> = Result<void> & {
   exit: Exit<T>;
+  destruction: Result<void>;
 };

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -271,4 +271,13 @@ describe("run()", () => {
       expect(error.message).toEqual("boom");
     }
   });
+
+  it("successfully halts when task fails, but shutdown succeeds ", async () => {
+    let task = run(function* () {
+      throw new Error("boom!");
+    });
+
+    await expect(task).rejects.toHaveProperty("message", "boom!");
+    await expect(task.halt()).resolves.toBe(undefined);
+  });
 });


### PR DESCRIPTION
## Motivation

There are two distinct ways in which a task can fail. It can straight up fail if there is an error during its execution, or it can fail after it has already completed its execution and somewhere in the teardown process an error occurs. So for example, a task whose execution succeeds but whose teardown fails will be considered a failure.

It is also possible to have a task whose execution fails, but whose teardown succeeds. However, we don't represent this when evaluating the `Task.halt()` operation. Instead, we always fail if the task execution has failed. This is a not ideal because if a user awaits or yields to `Task.halt()` they haven't asked for the result of the task itself, only for the result of _halting_ it. This makes meta-level apis like wait groups more difficult because you have to have separate logic for errored tasks and for successful tasks, when really in some cases, you want to treat them all as something that just needs to be halted.

### current behavior

```ts
let task = run(function*() { throw new Error('boom!'); });
await task.halt(); //=> Error boom!
```

### desired behavior

```ts
let task = run(function*() { throw new Error('boom!'); });
await task.halt(); //=> void
```

## Approach

Luckily, we are already tracking the success or failure of frame destruction internally, so this just adds that information to the `FrameResult`, so now with every frame, you can not only read both how its execution went (error, success, abort), but also how went its destruction.
