### PR TITLE
If an uncaught error happens in Scope.run(), crash the scope.

### DIFF
--- a/lib/run/frame.ts
+++ b/lib/run/frame.ts
@@ -122,6 +122,8 @@ export function createFrame<T>(options: FrameOptions<T>): Frame<T> {
       thunk = thunks.pop()!;
     }
 
+    frame.exited = true;
+
     let result = thunk.value;
 
     let exit: Exit<T>;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -298,6 +298,7 @@ import type { FrameResult } from "./run/types.ts";
 export interface Frame<T = unknown> extends Computation<FrameResult<T>> {
   id: number;
   context: Record<string, unknown>;
+  exited?: true;
   aborted?: boolean;
   getTask(): Task<T>;
   createChild<C>(operation: () => Operation<C>): Frame<C>;


### PR DESCRIPTION
## Motivation

> #836 
Right now, you can drop errors on the floor if you call `scope.run()` and the operation fails. The error will just dissappear, which goes against the foundations of structured concurrency.

Instead, we want to force folks to deal with the error one way or the other if they don't want it to crash their stack.

## Approach
This makes `scope.run()` behave more like `spawn()` where if the error is not caught it crashes its parent.

Because scopes can now crash and become totally invalid, calling `Scope.run()` when the scope is inactive is now an error.