### PR TITLE
Add a stop-gap for the v3 process docs

### DIFF
--- a/www/docs/processes.mdx
+++ b/www/docs/processes.mdx
@@ -1,148 +1,90 @@
->⚠️ These docs have not been updated from version 2 of Effection, and do not
-> apply to version 3. The information you find here may be of use, but may
-> also be outdated or misleading.
+Effection 3.0 does not ship with a process library out of the box, but what it
+_does_ do is make writing resources so easy, that you can do it yourself.
 
-Effection simplifies the process of managing any kind of resource, and we've
-taken great care to provide a good experience when you want to spawn external
-processes.
+Operating system processes are a perfect candidate for modeling as a resource
+because they match [the resource criteria](./resources) which are:
 
-Processes are managed via the separate `@effection/process` package, which
-currently only works in node.
+1. They are long running
+2. We want to be able to interact with them while they are running.
 
-## Exec
+This section provides a sketch of how you might create a "command" resource for both
+Deno and Node that will run an operating system command, and then make sure that
+no matter what happens, that command is shut down properly.
 
-The main way of starting a process is using the `exec` operation. `exec` spawns
-a process and returns a handle to this process:
+```js
+// use-command
+import { action, resource, spawn, suspend, createSignal } from "effection";
+import { spawn as spawnChild} from "node:child_process";
 
-``` typescript
-import { main, spawn } from 'effection';
-import { exec } from '@effection/process';
+export function useCommand(...args) {
+  return resource(function*(provide) {
+    // spawn the OS process
+    let proc = spawnChild(...args);
 
-main(function*() {
-  let myProcess = yield exec('npm start');
+    let stdout = createSignal();
+    let stderr = createSignal();
 
-  yield spawn(myProcess.stdout.forEach((text) => console.log(text)));
 
-  let result = yield myProcess.join();
-  console.log(`terminated with exit code ${result.code}`);
-});
-```
-> Note: every process has `stdout` and `stderr`  properties which can be consumed as [effection streams](./collections)
+    // create a task that finishes the process finishes
+    let exit = yield* spawn(function*() {
+      // get the exit code
+      let code = yield* action(function*(resolve) {
+        proc.on("exit", resolve);
+        try {
+          yield* suspend();
+        } finally {
+          proc.off("exit", resolve);
+        }
+      });
 
-Processes are automatically terminated when the operation in which they were
-created completed:
+      // close stdin, stdout
+      stdout.close();
+      stderr.close();
 
-``` typescript
-import { main } from 'effection';
-import { exec } from '@effection/process';
+      // return the exitcode
+      return code;
+    })
 
-function *runNpm() {
-  yield exec('npm start');
-  // npm is terminated at the end of this operation
+    // connect stdin, stdout to signals
+    proc.stdout.on("data", stdout.send);
+    proc.stderr.on("data", stderr.send);
+
+    try {
+
+      // provide the resource handle
+      yield* provide({ exit, stdout, stderr });
+
+    } finally {
+      proc.stdout.off("data", stdout.send);
+      proc.stderr.off("data", stderr.send);
+
+      proc.kill("SIGINT");
+
+      // wait until the process is fully exited
+      yield* exit;
+    }
+  });
 }
-
-main(function*() {
-  yield runNpm();
-  // npm has already been terminated here
-});
 ```
 
-`exec` returns a [resource][] which means that if you want to create an object
-which uses an external process internally, you will have to create it as a
-resource as well.
+## using a command
 
-`exec` gives you a lot of control, including the ability to work with the
-input and output streams of an external process, and to block and wait for
-the process to complete using `myProcess.join()`.
+We can now use this command resource to create a process and stream its stdout
+to the console:
 
-Often we expect the process to complete in an orderly fashion with an exit code of `0`
-and we don't want to have to add any error handling in case the process
-exits with a non-zero error code. `expect()` is a convenient operation
-which blocks just like `join()` but throws an error on any non-zero exit code.
+```js
 
-``` typescript
-import { main, spawn } from 'effection';
-import { exec } from '@effection/process';
+import { main, each } from "effection";
+import { useCommand } from "./use-command.mjs";
 
-main(function*() {
-  let myProcess = yield exec('npm start');
+await main(function*() {
+  let ls = yield* useCommand("ls", ["-lh"]);
 
-  yield spawn(myProcess.stdout.forEach((text) => console.log(text)));
+  for (let data of yield* each(ls.stdout)) {
+    console.log(`stdout: ${data}`);
+    yield* each.next();
+  }
 
-  let result = yield myProcess.expect();
+  console.log(`exit: ${yield* ls.exit}`)
 });
 ```
-
-## Short lived processes
-
-We have seen how we can use `exec` to manage processes which run for a while,
-but sometimes we just want to run a process which completes quickly. For these
-cases there are shortcuts for both `join` and `expect`, so you don't have to
-deal with a process object:
-
-``` typescript
-import { main } from 'effection';
-import { exec } from '@effection/process';
-
-main(function*() {
-  let { stdout } = yield exec('whois frontside.com').join();
-
-  console.log(stdout);
-});
-```
-
-As you can see, when using this shorthand form, both `stdout` and `stderr` are
-strings containing the full output of the program.
-
-The same shortcut is available for `expect`:
-
-``` typescript
-import { main } from 'effection';
-import { exec } from '@effection/process';
-
-main(function*() {
-  let { stdout } = yield exec('whois frontside.com').expect();
-
-  console.log(stdout);
-});
-```
-
-## Daemon
-
-A common problem with processes is what to do if they exit too early. Often we
-want a process to live for the entire duration of the program, or in the case
-of effection for the entire duration of an operation. When using `exec`,
-effection ensures that the process cannot live *longer* than the operation, but
-it does not ensure that the process cannot live *shorter* than the operation.
-
-An example of this might be spawning a server which must keep running so that
-we can send requests to it. If the server exists for any reason, even if it
-exits successfully with an exit code of `0`, that is an unexpected condition,
-and we need to throw an error.
-
-This is where `daemon` comes in. When using `daemon`, if the process finishes
-before the operation is complete, even if it finishes with an exit code of `0`,
-an error is thrown.
-
-Here is an example of using `daemon` to spawn a server process in the
-background:
-
-``` typescript
-import { main, spawn, fetch } from 'effection';
-import { daemon } from '@effection/process';
-
-main(function*() {
-  let myProcess = yield daemon('my-server --port 3000');
-
-  yield myProcess.stdout.filter((chunk) => chunk.includes("ready")).expect();
-
-  let result = yield fetch('http://localhost:3000').json();
-
-  console.log('got result:', result);
-});
-```
-
-Since we're sending a request to the server using `fetch`, the server must be
-kept running. If it ever stops, then the operation will not be able to do its job, and so it will fail immediately.
-
-[resource]: /docs/guides/resources


### PR DESCRIPTION
## Motivation

We don't have a process package for v3, but we should have some sort of answer for it.

## Approach

This takes an example that works in both Node and Deno and shows how you might go about it.

https://effection--v3-process-docs.deno.dev/docs/processes
