### PR TITLE
🔥Remove deprerated `expect()`

### DIFF
--- a/lib/async.ts
+++ b/lib/async.ts
@@ -1,16 +1,6 @@
-import type { Operation, Stream, Subscription } from "./types.ts";
+import type { Stream, Subscription } from "./types.ts";
 
-import { action } from "./instructions.ts";
 import { call } from "./call.ts";
-
-/**
- * @deprecated use {@link call} instead
- */
-export function expect<T>(promise: Promise<T>): Operation<T> {
-  return action(function* (resolve, reject) {
-    promise.then(resolve, reject);
-  });
-}
 
 export function subscribe<T, R>(iter: AsyncIterator<T, R>): Subscription<T, R> {
   return {


### PR DESCRIPTION
## Motivation

No need shipping a deprecated function in the 3.0 release