### PR TITLE
chore: update sleep.ts example

### DIFF
--- a/lib/sleep.ts
+++ b/lib/sleep.ts
@@ -9,7 +9,7 @@ import { action, suspend } from "./instructions.ts";
  * import { main, sleep } from 'effection';
  *
  * await main(function*() {
- *   yield sleep(2000);
+ *   yield* sleep(2000);
  *   console.log("Hello lazy world!");
  * });
  * ```

--- a/www/docs/collections.mdx
+++ b/www/docs/collections.mdx
@@ -191,7 +191,7 @@ await main(function*() {
 
   yield* sleep(1000);
 
-  let { value: secondValue } = yield subscription.next();
+  let { value: secondValue } = yield* subscription.next();
   console.log(secondValue); // logs 'world'
 });
 ```

--- a/www/docs/scope.mdx
+++ b/www/docs/scope.mdx
@@ -249,7 +249,7 @@ await main(function*() {
 
   signal.addEventListener('abort', () => console.log('done!'));
 
-  yield sleep(5000);
+  yield* sleep(5000);
   // prints 'done!'
 });
 ```


### PR DESCRIPTION

## Motivation

The jsdoc `@example` snippet is probably leftover from v2 since it's using `yield` instead of `yield*`. Same goes for the [scope](https://frontside.com/effection/docs/scope) and [streams and subscriptions](https://frontside.com/effection/docs/collections) (for `subscription.next()`) docs.

