### PR TITLE
Bring all() types closer to Promise.all()

### DIFF
--- a/lib/all.ts
+++ b/lib/all.ts
@@ -1,4 +1,3 @@
-// deno-lint-ignore-file no-explicit-any
 import type { Operation, Task } from "./types.ts";
 import { spawn } from "./instructions.ts";
 import { call } from "./call.ts";
@@ -28,25 +27,37 @@ import { call } from "./call.ts";
  * @param ops a list of operations to wait for
  * @returns the list of values that the operations evaluate to, in the order they were given
  */
-export function all<T extends Operation<any>[]>(ops: T): Operation<All<T>> {
-  return call<All<T>>(function* () {
-    let tasks: Task<T>[] = [];
+export function all<T extends readonly Operation<unknown>[] | []>(
+  ops: T,
+): Operation<All<T>> {
+  return call(function* () {
+    let tasks: Task<unknown>[] = [];
     for (let operation of ops) {
       tasks.push(yield* spawn(() => operation));
     }
-    let results = [] as All<T>;
+    let results = [];
     for (let task of tasks) {
       results.push(yield* task);
     }
-    return results;
+    return results as All<T>;
   });
 }
 
 /**
  * This type allows you to infer heterogenous operation types.
  * e.g. `all([sleep(0), expect(fetch("https://google.com")])`
- * will have a type of `Operation<Array<void | Request>>`
+ * will have a type of `Operation<[void, Request]>`
  */
-type All<T extends Operation<any>[]> = {
-  [P in keyof T]: T[P] extends Operation<infer TArg> ? TArg : never;
+
+type All<T extends readonly Operation<unknown>[] | []> = {
+  -readonly [P in keyof T]: Yielded<T[P]>;
 };
+
+/**
+ * Unwrap the type of an `Operation`.
+ *
+ * Yielded<Operation<T>> === T
+ */
+type Yielded<T extends Operation<unknown>> = T extends Operation<infer TYield>
+  ? TYield
+  : never;

--- a/test/all.test.ts
+++ b/test/all.test.ts
@@ -4,12 +4,13 @@ import {
   asyncResource,
   describe,
   expect,
+  expectType,
   it,
   syncReject,
   syncResolve,
 } from "./suite.ts";
 
-import { all, run, sleep } from "../mod.ts";
+import { all, call, type Operation, run, sleep } from "../mod.ts";
 
 describe("all()", () => {
   it("resolves when the given list is empty", async () => {
@@ -91,5 +92,16 @@ describe("all()", () => {
       yield* sleep(40);
       expect(fooStatus.status).toEqual("pending");
     });
+  });
+
+  it("has a type signature equivalent to Promise.all()", () => {
+    let resolve = <T>(value: T) => call(() => value);
+
+    expectType<Operation<[string, number, string]>>(
+      all([resolve("hello"), resolve(42), resolve("world")]),
+    );
+    expectType<Operation<[string, number]>>(
+      all([resolve("hello"), resolve(42)]),
+    );
   });
 });


### PR DESCRIPTION
## Motivation

#870 

### Non-goals

1. It does not need to support non-operation types like primitives, null, or undefined; unlike Promise.all() which can receive non-Promise values.
2. Does not (currently) need to support iterables. This will come later.

## Approach

I used the [typings for `Promise.all()`](https://github.com/microsoft/TypeScript/blob/main/src/lib/es2015.promise.d.ts#L21) as a basis for the typings for `all()`. The only thing missing was that we needed an equivalent to the [`Awaited`](https://www.typescriptlang.org/docs/handbook/utility-types.html#awaitedtype) type, so this includes a `Yielded<T>` type which can be used to unwrap the type of an Operation. For example:

```ts
Yielded<Operation<string>> // => string
Yielded<Operation<number>> // => number
```

The `Yielded` type is not exported, but probably should be at some point.