### PR TITLE
Listen for SIGTERM too

### DIFF
--- a/lib/main.ts
+++ b/lib/main.ts
@@ -78,9 +78,11 @@ export async function main(
             hardexit = (status) => Deno.exit(status);
             try {
               Deno.addSignalListener("SIGINT", interrupt);
+              Deno.addSignalListener("SIGTERM", interrupt);
               yield* body(Deno.args.slice());
             } finally {
               Deno.removeSignalListener("SIGINT", interrupt);
+              Deno.removeSignalListener("SIGTERM", interrupt);
             }
           },
           *node() {
@@ -90,10 +92,14 @@ export async function main(
               //@ts-expect-error type-checked by Deno, run on Node
               process.on("SIGINT", interrupt);
               //@ts-expect-error type-checked by Deno, run on Node
+              process.on("SIGTERM", interrupt);
+              //@ts-expect-error type-checked by Deno, run on Node
               yield* body(global.process.argv.slice(2));
             } finally {
               //@ts-expect-error this runs on Node
               process.off("SIGINT", interrupt);
+              //@ts-expect-error this runs on Node
+              process.off("SIGTERM", interrupt);
             }
           },
           *browser() {

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -72,17 +72,21 @@ export async function main(
       let interval = setInterval(() => {}, Math.pow(2, 30));
 
       try {
-        let interrupt = () => resolve({ status: 130, signal: "SIGINT" });
+        let interrupt = {
+          SIGINT: () => resolve({ status: 130, signal: "SIGINT" }),
+          SIGTERM: () => resolve({ status: 143, signal: "SIGTERM" }),
+        };
+
         yield* withHost({
           *deno() {
             hardexit = (status) => Deno.exit(status);
             try {
-              Deno.addSignalListener("SIGINT", interrupt);
-              Deno.addSignalListener("SIGTERM", interrupt);
+              Deno.addSignalListener("SIGINT", interrupt.SIGINT);
+              Deno.addSignalListener("SIGTERM", interrupt.SIGTERM);
               yield* body(Deno.args.slice());
             } finally {
-              Deno.removeSignalListener("SIGINT", interrupt);
-              Deno.removeSignalListener("SIGTERM", interrupt);
+              Deno.removeSignalListener("SIGINT", interrupt.SIGINT);
+              Deno.removeSignalListener("SIGTERM", interrupt.SIGTERM);
             }
           },
           *node() {
@@ -90,24 +94,24 @@ export async function main(
             hardexit = (status) => global.process.exit(status);
             try {
               //@ts-expect-error type-checked by Deno, run on Node
-              process.on("SIGINT", interrupt);
+              process.on("SIGINT", interrupt.SIGINT);
               //@ts-expect-error type-checked by Deno, run on Node
-              process.on("SIGTERM", interrupt);
+              process.on("SIGTERM", interrupt.SIGTERM);
               //@ts-expect-error type-checked by Deno, run on Node
               yield* body(global.process.argv.slice(2));
             } finally {
               //@ts-expect-error this runs on Node
-              process.off("SIGINT", interrupt);
+              process.off("SIGINT", interrupt.SIGINT);
               //@ts-expect-error this runs on Node
-              process.off("SIGTERM", interrupt);
+              process.off("SIGTERM", interrupt.SIGINT);
             }
           },
           *browser() {
             try {
-              self.addEventListener("unload", interrupt);
+              self.addEventListener("unload", interrupt.SIGINT);
               yield* body([]);
             } finally {
-              self.removeEventListener("unload", interrupt);
+              self.removeEventListener("unload", interrupt.SIGINT);
             }
           },
         });

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -21,6 +21,25 @@ describe("main", () => {
     });
   });
 
+  it("gracefully shuts down on SIGTERM", async () => {
+    await run(function* () {
+      let daemon = yield* useCommand("deno", {
+        stdout: "piped",
+        args: ["run", "test/main/ok.daemon.ts"],
+      });
+      let stdout = yield* buffer(daemon.stdout);
+      yield* detect(stdout, "started");
+
+      daemon.kill("SIGTERM");
+
+      let status = yield* daemon.status;
+
+      expect(status.code).toBe(143);
+
+      yield* detect(stdout, "gracefully stopped");
+    });
+  });
+
   it("exits gracefully on explicit exit()", async () => {
     await run(function* () {
       let cmd = yield* useCommand("deno", {


### PR DESCRIPTION
Install interrupt handler for `SIGTERM` events, as commonly used by watchers/supervisors.

@TODO: the interrupt fn always reports that the signal received was `SIGINT` even if `SIGTERM` was used. Parameterize `interrupt` to correct report received signal?

## Motivation

The dev-mode supervision tool `tsx` sends a `SIGTERM` to the child process when a change is detected; it would be nice for Effection to catch these too.

## Approach

Simply install the `interrupt` handler in response to `SIGTERM` events just like `SIGINT` 

### Alternate Designs

I've currently got the following baked into my Node app, which works, but would be nice to omit:

```typescript
/**
 * Shuts down Effection when SIGTERM is received.
 * @TODO Raise PR to bake this into Effection's `main` implementation
 */
function* useSigTerm() {
  const { run } = yield* useScope();
  const handler = () =>
    run(function* () {
      yield* exit(130);
    });

  process.on("SIGTERM", handler);

  yield* ensure(() => {
    process.off("SIGTERM", handler);
  });
}

await main(function* () {
  yield* useSigTerm();
  /* ... */
```

### Possible Drawbacks or Risks

Maybe downstream users have custom behaviour bound to `SIGTERM`.

### TODOs and Open Questions

- [x] the interrupt fn always reports that the signal received was `SIGINT` even if `SIGTERM` was used. Parameterize `interrupt` to correct report received signal?