### PR TITLE
📃 Fix example to work better with deno doc and lsp

### DIFF
--- a/lib/abort-signal.ts
+++ b/lib/abort-signal.ts
@@ -21,7 +21,7 @@ import { resource } from "./instructions.ts";
  * lifetime of the HTTP request to the lifetime of the current task.
  *
  * @example
- * ```js
+ * ```javascript
  * function* request() {
  *   let signal = yield* useAbortSignal();
  *   return yield* fetch('/some/url', { signal });

--- a/lib/call.ts
+++ b/lib/call.ts
@@ -12,7 +12,7 @@ import { pause } from "./pause.ts";
  * APIs that accept `Callable` values allow end developers to pass simple
  * functions without necessarily needing to know anything about Operations.
  *
- * @example
+ * ```javascript
  * function hello(to: Callable<string>): Operation<string> {
  *   return function*() {
  *     return `hello ${yield* call(to)}`;
@@ -22,6 +22,7 @@ import { pause } from "./pause.ts";
  * await run(() => hello(() => "world!")); // => "hello world!"
  * await run(() => hello(async () => "world!")); // => "hello world!"
  * await run(() => hello(function*() { return "world!" })); "hello world!";
+ * ```
  */
 export type Callable<T> =
   | Operation<T>
@@ -42,14 +43,14 @@ export type Callable<T> =
  * It can be used to treat a promise as an operation:
  *
  * @example
- * ```js
+ * ```javascript
  * let response = yield* call(fetch('https://google.com'));
  * ```
  *
  * or an async function:
  *
  * @example
- * ```ts
+ * ```typescript
  * async function* googleSlowly() {
  *   return yield* call(async function() {
  *     await new Promise(resolve => setTimeout(resolve, 2000));
@@ -62,7 +63,7 @@ export type Callable<T> =
  * resources allocated will be cleaned up:
  *
  * @example
- * ```js
+ * ```javascript
  * yield* call(function*() {
  *   let socket = yield* useSocket();
  *   return yield* socket.read();
@@ -72,7 +73,7 @@ export type Callable<T> =
  * It can be used to run a plain function:
  *
  * @example
- * ```js
+ * ```javascript
  * yield* call(() => "a string");
  * ```
  *
@@ -80,7 +81,7 @@ export type Callable<T> =
  * establish {@link  * establish error boundaries https://frontside.com/effection/docs/errors | error boundaries}.
  *
  * @example
- * ```js
+ * ```javascript
  * function* myop() {
  *   let task = yield* spawn(function*() {
  *     throw new Error("boom!");

--- a/lib/ensure.ts
+++ b/lib/ensure.ts
@@ -6,7 +6,7 @@ import { resource } from "./instructions.ts";
  * shuts down. This is equivalent to running the function or operation
  * in a `finally {}` block, but it can help you avoid rightward drift.
  *
- * @example <caption>using a function</caption>
+ * @example
  *
  * ```javascript
  * import { main, ensure } from 'effection';
@@ -21,7 +21,7 @@ import { resource } from "./instructions.ts";
  * Note that you should wrap the function body in braces, so the function
  * returns `undefined`.
  *
- * @example <caption>using operation</caption>
+ * @example
  *
  * ```javascript
  * import { main, ensure, once } from 'effection';

--- a/lib/instructions.ts
+++ b/lib/instructions.ts
@@ -218,7 +218,7 @@ export function spawn<T>(operation: () => Operation<T>): Operation<Task<T>> {
  * scope.
  *
  * @example
- * ```js
+ * ```javascript
  * function useWebSocket(url) {
  *   return resource(function*(provide) {
  *     let socket = new WebSocket(url);

--- a/lib/lift.ts
+++ b/lib/lift.ts
@@ -4,7 +4,7 @@ import { type Operation } from "./types.ts";
  * Convert a simple function into an {@link Operation}
  *
  * @example
- * ```js
+ * ```javascript
  * let log = lift((message) => console.log(message));
  *
  * export function* run() {

--- a/lib/run.ts
+++ b/lib/run.ts
@@ -10,7 +10,7 @@ export * from "./run/scope.ts";
  * whole program using Effection, you should prefer {@link main}.
  *
  * @example
- * ```
+ * ```javascript
  * import { run, useAbortSignal } from 'effection';
  *
  * async function fetchExample() {

--- a/lib/run/scope.ts
+++ b/lib/run/scope.ts
@@ -24,7 +24,7 @@ export function* useScope(): Operation<Scope> {
  * the creator of the new scope to destroy it when it is no longer needed.
  *
  * @example
- * ```js
+ * ```javascript
  * let [scope, destroy] = createScope();
  * let task = scope.run(function*() {
  *   //do some long running work

--- a/lib/signal.ts
+++ b/lib/signal.ts
@@ -12,7 +12,7 @@ import { createContext } from "./context.ts";
  * Signals are particularly suited to be installed as event listeners.
  *
  * @example
- * ```ts
+ * ```typescript
  * import { createSignal, each } from "effection";
  *
  * export function* logClicks(function*(button) {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -13,7 +13,7 @@ import type { Computation } from "./deps.ts";
  * to other operations:
  *
  * @example
- * ```js
+ * ```javascript
  * import { sleep } from "effection";
 
  * function* slow5(seconds) {
@@ -26,7 +26,7 @@ import type { Computation } from "./deps.ts";
  * operation is the same as above:
  *
  * @example
- * ```js
+ * ```javascript
  * import { sleep } from "effection";
  *
  * const slow5 = (seconds) => ({


### PR DESCRIPTION
## Motivation

The examples in the docs were not rendering properly on the deno doc site, and also inside the LSP for a number of reasons.

Borked language highlighting:

![image](https://github.com/thefrontside/effection/assets/4205/78979816-e486-4151-a6ed-88bd23c08e67)


Captions don't seem to work

![image](https://github.com/thefrontside/effection/assets/4205/d26074dd-a00f-4c5c-a0a3-3447d4170205)


## Approach

This normalizes how examples are identified:

- use fully qualified language name. I.e. "javascript" instead of "js"
- remove any captions