### PR TITLE
Lift a simple function into an operation safely.

### DIFF
--- a/test/lift.test.ts
+++ b/test/lift.test.ts
@@ -1,0 +1,23 @@
+import { createSignal, each, lift, run, sleep, spawn } from "../mod.ts";
+import { describe, expect, it } from "./suite.ts";
+
+describe("lift", () => {
+  it("safely does not continue if the call stops the operation", async () => {
+    let reached = false;
+
+    await run(function* () {
+      let signal = createSignal<void, void>();
+
+      yield* spawn(function* () {
+        yield* sleep(0);
+        yield* lift(signal.close)();
+
+        reached = true;
+      });
+
+      for (let _ of yield* each(signal));
+    });
+
+    expect(reached).toBe(false);
+  });
+});


### PR DESCRIPTION
## Motivation

There is the potential for a function, if it is a continuation, to cause the scope in which it is called to be destroyed. In this case, nothing after that function should ever be called. However, because of the way `lift()` is currently implemented, this will not be the case.

## Approach

This unpacks the `lift()` function just a bit to return an operation with a single instruction that immediately returns the result of invoking the function. However, because there is a `yield` point in the computation, it is an opportunity to not continue which will happen if corresponding frame is closed as a result of calling the function.

You can see in the test case how when the spawned producer closes the signal, it cause its parent to finish up and return, meaning that the producer should shut down immediately and not continue executing.

At the same time, it removes the named types since they don't really add much clarity when you look at them from your language server.

