### PR TITLE
Retry backoff example

### DIFF
--- a/examples/retry-backoff.test.ts
+++ b/examples/retry-backoff.test.ts
@@ -1,0 +1,44 @@
+import { Task, run } from "../mod.ts";
+import { beforeEach, describe, expect, it } from "../test/suite.ts";
+import { CustomError, retryBackoffExample } from "./retry-backoff.ts";
+/**
+ * Requirements:
+ *  * only retry if the error matches specific error/s (otherwise fail)
+ *  * begin with a delay of startDelay ms between retries
+ *  * double the delay each retry attempt up to a max of maxDelay ms
+ *  * retry a maximum of 5 times
+ * Source: https://discord.com/channels/795981131316985866/1125094089281511474/1189299794145988748
+ */
+describe("retry-backoff", () => {
+  it("fails for unknown errors", () => {
+    expect(run(function* () {
+      yield* retryBackoffExample(function* () {
+        throw new Error('RandomError');
+      });
+    })).rejects.toMatch(/RandomError/)
+  });
+
+  describe("retries", () => {
+    describe("known errors", () => {
+      let task: Task<void>;
+      let retries: number;
+      beforeEach(() => {
+        retries = 0;
+        task = run(function* () {
+          yield* retryBackoffExample(function*() {
+            retries++;
+            throw new CustomError('LockTimeout');
+          });
+        });
+      });
+      it("rejects to a known error", () => {
+        expect(task).rejects.toEqual({
+          _tag: 'LockTimeout'
+        });
+      });
+      it("5 times", () => {
+        expect(retries).toBe(5);
+      });
+    });
+  })
+})

--- a/examples/retry-backoff.test.ts
+++ b/examples/retry-backoff.test.ts
@@ -1,4 +1,4 @@
-import { Task, run, sleep } from "../mod.ts";
+import { run, sleep, Task } from "../mod.ts";
 import { afterEach, beforeEach, describe, expect, it } from "../test/suite.ts";
 import { CustomError, retryBackoffExample } from "./retry-backoff.ts";
 /**
@@ -13,9 +13,9 @@ describe("retry-backoff-example", () => {
   it("fails for unknown errors", () => {
     expect(run(function* () {
       yield* retryBackoffExample(function* () {
-        throw new Error('RandomError');
+        throw new Error("RandomError");
       });
-    })).rejects.toMatch(/RandomError/)
+    })).rejects.toMatch(/RandomError/);
   });
 
   describe("retries", () => {
@@ -25,18 +25,18 @@ describe("retry-backoff-example", () => {
       beforeEach(async () => {
         retries = -1;
         task = run(function* () {
-          yield* retryBackoffExample(function*() {
+          yield* retryBackoffExample(function* () {
             retries++;
-            throw new CustomError('LockTimeout');
+            throw new CustomError("LockTimeout");
           });
         });
         try {
           await task;
         } catch {}
       });
-      it("rejects to a known error", async() => {
+      it("rejects to a known error", async () => {
         await expect(task).rejects.toEqual({
-          _tag: 'LockTimeout'
+          _tag: "LockTimeout",
         });
       });
       it("5 times", () => {
@@ -79,18 +79,18 @@ describe("retry-backoff-example", () => {
               yield* sleep(200);
             }
             retry++;
-            throw new CustomError('ConflictDetected');
+            throw new CustomError("ConflictDetected");
           }, { maxDelay: 100 });
         });
         try {
           await task;
-        } catch (e) { 
-          console.log(e)
+        } catch (e) {
+          console.log(e);
         }
       });
       it("throws an error", async () => {
-        await expect(task).rejects.toMatch(/Timeout/)
-      })
-    })
-  })
-})
+        await expect(task).rejects.toMatch(/Timeout/);
+      });
+    });
+  });
+});

--- a/examples/retry-backoff.ts
+++ b/examples/retry-backoff.ts
@@ -20,7 +20,7 @@ export function* retryBackoffExample<T>(
   { attempts = 5, startDelay = 5, maxDelay = 200 } = {},
 ): Operation<T | undefined> {
   try {
-    // This is the initial operation, 
+    // This is the initial operation,
     // if it succeeds then the operation will be complete
     return yield* op();
   } catch (e) {
@@ -30,7 +30,7 @@ export function* retryBackoffExample<T>(
       throw e;
     }
   }
-  
+
   // we're here because we encountered a known issue,
   // we want to run the retry logic attempting up to 5 attempts
   // pause between each attempt and double the delay with each attempt
@@ -38,7 +38,7 @@ export function* retryBackoffExample<T>(
   // we do this by setting up a race between retry logic and
   // the timeout. If retry logic succeeds, timeout will be halted
   // automatically. If timeout reaches the throw, it'll interrupt the
-  // retry logic automatically. 
+  // retry logic automatically.
 
   let lastError: Error;
   function* retry() {
@@ -64,7 +64,7 @@ export function* retryBackoffExample<T>(
   function* timeout(): Operation<undefined> {
     yield* sleep(maxDelay);
 
-    throw lastError || new Error('Timeout');
+    throw lastError || new Error("Timeout");
   }
 
   return yield* race([retry(), timeout()]);

--- a/examples/retry-backoff.ts
+++ b/examples/retry-backoff.ts
@@ -1,4 +1,4 @@
-import type { Operation } from "../mod.ts";
+import { type Operation, race, sleep } from "../mod.ts";
 
 export class CustomError extends Error {
   public _tag: string;
@@ -9,23 +9,50 @@ export class CustomError extends Error {
   }
 }
 
-const KNOWN_ERRORS = ["LockTimeout", "ConflictDetected", "TransactionNotFound"];
+const isKnownError = (e: Error): e is CustomError =>
+  !!((e as CustomError)._tag) &&
+  ["LockTimeout", "ConflictDetected", "TransactionNotFound"].includes(
+    (e as CustomError)._tag,
+  );
 
-export function* retryBackoffExample(
-  op: () => Operation<void>,
-  { maxRetries = 5 } = {},
-) {
-  for (let attempt = 0; attempt < maxRetries; attempt++) {
-    try {
-      yield* op();
-    } catch (e) {
-      if (e._tag && KNOWN_ERRORS.includes(e._tag)) {
-        if (attempt + 1 === maxRetries) {
-          throw e;
-        }
-        continue;
-      }
+export function* retryBackoffExample<T>(
+  op: () => Operation<T>,
+  { attempts = 5, startDelay = 5, maxDelay = 200 } = {},
+): Operation<T | undefined> {
+  try {
+    return yield* op();
+  } catch (e) {
+    if (!isKnownError(e)) {
       throw e;
     }
   }
+  
+  let lastError: Error;
+  function* retry() {
+    let delay = startDelay;
+    for (let attempt = 0; attempt < attempts; attempt++) {
+      yield* sleep(delay);
+      delay = delay * 2;
+
+      try {
+        return yield* op();
+      } catch (e) {
+        if (isKnownError(e)) {
+          lastError = e;
+          if (attempt + 1 < attempts) {
+            continue;
+          }
+        }
+        throw e;
+      }
+    }
+  }
+
+  function* timeout(): Operation<undefined> {
+    yield* sleep(maxDelay);
+
+    throw lastError || new Error('Timeout');
+  }
+
+  return yield* race([retry(), timeout()]);
 }

--- a/examples/retry-backoff.ts
+++ b/examples/retry-backoff.ts
@@ -20,13 +20,26 @@ export function* retryBackoffExample<T>(
   { attempts = 5, startDelay = 5, maxDelay = 200 } = {},
 ): Operation<T | undefined> {
   try {
+    // This is the initial operation, 
+    // if it succeeds then the operation will be complete
     return yield* op();
   } catch (e) {
+    // if we encounter error that we're not expecting then throw
+    // and do not proceed any further
     if (!isKnownError(e)) {
       throw e;
     }
   }
   
+  // we're here because we encountered a known issue,
+  // we want to run the retry logic attempting up to 5 attempts
+  // pause between each attempt and double the delay with each attempt
+  // trigger a timeout if we reach maxDelay
+  // we do this by setting up a race between retry logic and
+  // the timeout. If retry logic succeeds, timeout will be halted
+  // automatically. If timeout reaches the throw, it'll interrupt the
+  // retry logic automatically. 
+
   let lastError: Error;
   function* retry() {
     let delay = startDelay;

--- a/examples/retry-backoff.ts
+++ b/examples/retry-backoff.ts
@@ -1,0 +1,31 @@
+import type { Operation } from "../mod.ts";
+
+export class CustomError extends Error {
+  public _tag: string;
+
+  constructor(_tag: string) {
+    super(_tag);
+    this._tag = _tag;
+  }
+}
+
+const KNOWN_ERRORS = ["LockTimeout", "ConflictDetected", "TransactionNotFound"];
+
+export function* retryBackoffExample(
+  op: () => Operation<void>,
+  { maxRetries = 5 } = {},
+) {
+  for (let attempt = 0; attempt < maxRetries; attempt++) {
+    try {
+      yield* op();
+    } catch (e) {
+      if (e._tag && KNOWN_ERRORS.includes(e._tag)) {
+        if (attempt + 1 === maxRetries) {
+          throw e;
+        }
+        continue;
+      }
+      throw e;
+    }
+  }
+}


### PR DESCRIPTION
## Motivation

As part of #869, I wanted to convert an example by [@thr1ve. in Discord](https://discord.com/channels/795981131316985866/1125094089281511474/1189299794145988748) to Structured Concurrency with Effection.

> * only retry if the error matches specific error/s (otherwise fail)
> * begin with a delay of startDelay ms between retries
> * double the delay each retry attempt up to a max of maxDelay ms
> * retry a maximum of 5 times

This is what it looks like in Effect.ts

```ts
const startDelay = 200
const maxDelay = 500

export const retryPolicy = pipe(
  Schedule.intersect(
    Schedule.linear(startDelay).pipe(Schedule.union(Schedule.spaced(maxDelay))),
    Schedule.recurs(5)
  ),
  Schedule.whileInput(
    (error: ParsedArangoError) =>
      error._tag === 'LockTimeout' ||
      error._tag === 'ConflictDetected' ||
      error._tag === 'TransactionNotFound'
  )
);
```

<img width="573" alt="image" src="https://github.com/thefrontside/effection/assets/74687/c0cc5726-ada0-4588-88f0-19d467715053">

It was pretty straightforward and fun to implement in Effection. 

The logic is this:
1. call the operation, if we get an unknown error then throw which will stop the operation
2. otherwise, start retrying up to 5 times. After every attempt, double the delay before the next attempt. 
3. To add a maxDelay, I created a timeout function that I'm racing against the retry mechanism.

This is what it looks like in Effection

```ts
export function* retryBackoffExample<T>(
  op: () => Operation<T>,
  { attempts = 5, startDelay = 5, maxDelay = 200 } = {},
): Operation<T | undefined> {
  try {
    return yield* op();
  } catch (e) {
    if (!isKnownError(e)) {
      throw e;
    }
  }
  
  let lastError: Error;
  function* retry() {
    let delay = startDelay;
    for (let attempt = 0; attempt < attempts; attempt++) {
      yield* sleep(delay);
      delay = delay * 2;

      try {
        return yield* op();
      } catch (e) {
        if (isKnownError(e)) {
          lastError = e;
          if (attempt + 1 < attempts) {
            continue;
          }
        }
        throw e;
      }
    }
  }

  function* timeout(): Operation<undefined> {
    yield* sleep(maxDelay);

    throw lastError || new Error('Timeout');
  }

  return yield* race([retry(), timeout()]);
}
```

It's longer, but it doesn't require tears.


## Approach

1. Created examples directory with `retry-backoff.ts` example. 
2. Created a test file

## TODO:

* [ ] I don't know how to test the backoff mechanism without module stubbing which I really don't want to do.
