### PR TITLE
Bring race() types closer to Promise.race()

### DIFF
--- a/lib/all.ts
+++ b/lib/all.ts
@@ -1,4 +1,4 @@
-import type { Operation, Task } from "./types.ts";
+import type { Operation, Task, Yielded } from "./types.ts";
 import { spawn } from "./instructions.ts";
 import { call } from "./call.ts";
 
@@ -52,12 +52,3 @@ export function all<T extends readonly Operation<unknown>[] | []>(
 type All<T extends readonly Operation<unknown>[] | []> = {
   -readonly [P in keyof T]: Yielded<T[P]>;
 };
-
-/**
- * Unwrap the type of an `Operation`.
- *
- * Yielded<Operation<T>> === T
- */
-type Yielded<T extends Operation<unknown>> = T extends Operation<infer TYield>
-  ? TYield
-  : never;

--- a/lib/race.ts
+++ b/lib/race.ts
@@ -1,4 +1,4 @@
-import type { Operation } from "./types.ts";
+import type { Operation, Yielded } from "./types.ts";
 import { action, spawn } from "./instructions.ts";
 
 /**
@@ -21,16 +21,17 @@ import { action, spawn } from "./instructions.ts";
  * });
  * ```
  *
- * @typeParam T the type of the operations that race against each other
  * @param operations a list of operations to race against each other
  * @returns the value of the fastest operation
  */
-export function race<T>(operations: Operation<T>[]): Operation<T> {
-  return action<T>(function* (resolve, reject) {
+export function race<T extends Operation<unknown>>(
+  operations: readonly T[],
+): Operation<Yielded<T>> {
+  return action<Yielded<T>>(function* (resolve, reject) {
     for (let operation of operations) {
       yield* spawn(function* () {
         try {
-          resolve(yield* operation);
+          resolve((yield* operation) as Yielded<T>);
         } catch (error) {
           reject(error);
         }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -267,6 +267,15 @@ export interface Context<T> extends Operation<T> {
   get(): Operation<T | undefined>;
 }
 
+/**
+ * Unwrap the type of an `Operation`.
+ * Analogous to the built in [`Awaited`](https://www.typescriptlang.org/docs/handbook/utility-types.html#awaitedtype) type.
+ * Yielded<Operation<T>> === T
+ */
+export type Yielded<T extends Operation<unknown>> = T extends
+  Operation<infer TYield> ? TYield
+  : never;
+
 /* low-level interface Which you probably will not need */
 
 /**
@@ -303,12 +312,3 @@ export interface Frame<T = unknown> extends Computation<FrameResult<T>> {
   crash(error: Error): Computation<Result<void>>;
   destroy(): Computation<Result<void>>;
 }
-
-/**
- * Unwrap the type of an `Operation`.
- *
- * Yielded<Operation<T>> === T
- */
-export type Yielded<T extends Operation<unknown>> = T extends
-  Operation<infer TYield> ? TYield
-  : never;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -303,3 +303,12 @@ export interface Frame<T = unknown> extends Computation<FrameResult<T>> {
   crash(error: Error): Computation<Result<void>>;
   destroy(): Computation<Result<void>>;
 }
+
+/**
+ * Unwrap the type of an `Operation`.
+ *
+ * Yielded<Operation<T>> === T
+ */
+export type Yielded<T extends Operation<unknown>> = T extends
+  Operation<infer TYield> ? TYield
+  : never;

--- a/test/race.test.ts
+++ b/test/race.test.ts
@@ -3,12 +3,13 @@ import {
   asyncResolve,
   describe,
   expect,
+  expectType,
   it,
   syncReject,
   syncResolve,
 } from "./suite.ts";
 
-import { race, run } from "../mod.ts";
+import { call, type Operation, race, run } from "../mod.ts";
 
 describe("race()", () => {
   it("resolves when one of the given operations resolves asynchronously first", async () => {
@@ -57,5 +58,19 @@ describe("race()", () => {
     );
 
     await expect(result).rejects.toHaveProperty("message", "boom: foo");
+  });
+
+  it("has a type signature equivalent to Promise.race()", () => {
+    let resolve = <T>(value: T) => call(() => value);
+
+    expectType<Operation<string | number>>(
+      race([resolve("hello"), resolve(42), resolve("world")]),
+    );
+    expectType<Operation<string | number>>(
+      race([resolve("hello"), resolve(42)]),
+    );
+    expectType<Operation<string | number | boolean>>(
+      race([resolve("hello"), resolve(42), resolve("world"), resolve(true)]),
+    );
   });
 });


### PR DESCRIPTION
## Motivation

The existing types for `race()` required that all Operations had the same return type. This should not be necessary.

## Approach

Moves the `Yielded` type that was previously added for `all()` to the global types file and updates the `race()` return type to use it. That way it will return `Operation<union type of all the individual operations>`.
