### PR TITLE
Workflows for creating releases with docs

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -36,12 +36,12 @@ jobs:
         env:
           VERSION: ${{steps.vars.outputs.version}}
           
-      - run: tar cfv docs.tar -C docs .
+      - run: tar cfvz api-docs.tgz -C docs .
 
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
-          files: docs.tar
+          files: api-docs.tgz
           name: ${{steps.vars.outputs.version}}
 
       

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -31,8 +31,6 @@ jobs:
         id: vars
         run: echo ::set-output name=version::$(echo ${{github.ref_name}} | sed 's/^effection-v//')
 
-      - run: sed -i '/docs/d' .gitignore
-
       - name: Generate Docs
         run: deno doc --html --name=effection@$VERSION mod.ts
         env:
@@ -44,6 +42,6 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: docs.tar
-          token: ${{ github.token }}
+          name: ${{steps.vars.outputs.version}}
 
       

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -21,7 +21,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{github.ref}}
-          fetch-depth: 0 
 
       - name: setup deno
         uses: denoland/setup-deno@v1
@@ -38,15 +37,13 @@ jobs:
         run: deno doc --html --name=effection@$VERSION mod.ts
         env:
           VERSION: ${{steps.vars.outputs.version}}
+          
+      - run: tar cfv docs.tar -C docs .
 
-      - run: |
-          git config user.name "GitHub Actions"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add .gitignore docs
-          git commit -m "Add docs"
-          git push --force origin tags/${{github.ref_name}}
-        env:
-          GITHUB_TOKEN: ${{github.token}}
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: docs.tar
+          token: ${{ github.token }}
 
-      
       

--- a/.github/workflows/push-docs.yml
+++ b/.github/workflows/push-docs.yml
@@ -12,13 +12,12 @@ jobs:
   release:
     runs-on: ubuntu-latest
 
-   permissions:
-      # Give the default GITHUB_TOKEN write permission to commit and push the
-      # added or changed files to the repository.
-      contents: write
-    
+    permissions:
+        # Give the default GITHUB_TOKEN write permission to commit and push the
+        # added or changed files to the repository.
+        contents: write
+
     steps:
-      - name: checkout
       - uses: actions/checkout@v4
 
       - name: setup deno

--- a/.github/workflows/push-docs.yml
+++ b/.github/workflows/push-docs.yml
@@ -13,12 +13,14 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-        # Give the default GITHUB_TOKEN write permission to commit and push the
-        # added or changed files to the repository.
-        contents: write
+      # Give the default GITHUB_TOKEN write permission to commit and push the
+      # added or changed files to the repository.
+      contents: write
 
     steps:
       - uses: actions/checkout@v4
+
+      - run: git status
 
       - name: setup deno
         uses: denoland/setup-deno@v1
@@ -36,7 +38,7 @@ jobs:
 
       - uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          commit_message: "[skip ci] Add docs"
+          commit_message: Add docs
           file_pattern: "docs"
 
       

--- a/.github/workflows/push-docs.yml
+++ b/.github/workflows/push-docs.yml
@@ -31,9 +31,9 @@ jobs:
         run: echo ::set-output name=version::$(echo ${{github.ref_name}} | sed 's/^effection-v//')
 
       - name: Generate Docs
-        run: deno doc --html --name=effection@$NPM_VERSION mod.ts
+        run: deno doc --html --name=effection@$VERSION mod.ts
         env:
-          NPM_VERSION: ${{steps.vars.outputs.version}}
+          VERSION: ${{steps.vars.outputs.version}}
 
       - uses: stefanzweifel/git-auto-commit-action@v5
         with:

--- a/.github/workflows/push-docs.yml
+++ b/.github/workflows/push-docs.yml
@@ -19,8 +19,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
-      - run: git status
+        with:
+          ref: ${{github.ref}}
+          fetch-depth: 0 
 
       - name: setup deno
         uses: denoland/setup-deno@v1
@@ -31,15 +32,19 @@ jobs:
         id: vars
         run: echo ::set-output name=version::$(echo ${{github.ref_name}} | sed 's/^effection-v//')
 
+      - run: sed -i '/docs/d' .gitignore
+
       - name: Generate Docs
         run: deno doc --html --name=effection@$VERSION mod.ts
         env:
           VERSION: ${{steps.vars.outputs.version}}
 
-      - uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          commit_message: Add docs
-          file_pattern: "docs"
+      - run: |
+          git config user.name "GitHub Actions"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .gitignore docs
+          git commit -m "Add docs"
+          git push --force origin :${{github.ref}}
 
       
       

--- a/.github/workflows/push-docs.yml
+++ b/.github/workflows/push-docs.yml
@@ -44,7 +44,9 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add .gitignore docs
           git commit -m "Add docs"
-          git push --force origin :${{github.ref}}
+          git push --force origin tags/${{github.ref_name}}
+        env:
+          GITHUB_TOKEN: ${{github.token}}
 
       
       

--- a/.github/workflows/push-docs.yml
+++ b/.github/workflows/push-docs.yml
@@ -1,0 +1,44 @@
+# This workflow will install Deno then run Deno lint and test.
+# For more information see: https://github.com/denoland/setup-deno
+
+name: Push to Docs
+
+on:
+  push:
+    tags:
+      - "effection-v*"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+   permissions:
+      # Give the default GITHUB_TOKEN write permission to commit and push the
+      # added or changed files to the repository.
+      contents: write
+    
+    steps:
+      - name: checkout
+      - uses: actions/checkout@v4
+
+      - name: setup deno
+        uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.x
+
+      - name: Get Version
+        id: vars
+        run: echo ::set-output name=version::$(echo ${{github.ref_name}} | sed 's/^effection-v//')
+
+      - name: Generate Docs
+        run: deno doc --html --name=effection@$NPM_VERSION mod.ts
+        env:
+          NPM_VERSION: ${{steps.vars.outputs.version}}
+
+      - uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "[skip ci] Add docs"
+          file_pattern: "docs"
+
+      
+      

--- a/.github/workflows/rebuild-releases.yml
+++ b/.github/workflows/rebuild-releases.yml
@@ -58,12 +58,12 @@ jobs:
         env:
           VERSION: ${{steps.vars.outputs.version}}
           
-      - run: tar cfv docs.tar -C docs .
+      - run: tar cfvz api-docs.tgz -C docs .
 
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
-          files: docs.tar
+          files: api-docs.tgz
           name: ${{steps.vars.outputs.version}}
           tag_name: "refs/tags/${{ matrix.tag }}"
         env:

--- a/.github/workflows/rebuild-releases.yml
+++ b/.github/workflows/rebuild-releases.yml
@@ -18,7 +18,7 @@ jobs:
                   owner: 'thefrontside',
                   repo: 'effection',
               },
-              (response) => response.data.filter(({ name }) => /effection-v3.0.0/.test(name))
+              (response) => response.data.filter(({ name }) => /^effection-v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/.test(name))
             );
 
             core.setOutput('tags', JSON.stringify(tags.map(tag => tag.name)));
@@ -33,12 +33,12 @@ jobs:
       matrix:
         tag: ${{fromJSON(needs.setup.outputs.tags)}}
       max-parallel: 4
-  
+
     permissions:
       # Give the default GITHUB_TOKEN write permission to commit and push the
       # added or changed files to the repository.
       contents: write
-    
+
     steps:
       - uses: actions/checkout@v4
         with:
@@ -57,7 +57,7 @@ jobs:
         run: deno doc --html --name=effection@$VERSION mod.ts
         env:
           VERSION: ${{steps.vars.outputs.version}}
-          
+
       - run: tar cfvz api-docs.tgz -C docs .
 
       - name: Create Release

--- a/.github/workflows/rebuild-releases.yml
+++ b/.github/workflows/rebuild-releases.yml
@@ -1,0 +1,70 @@
+name: Push to Docs
+
+on:
+  workflow_dispatch:
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      tags: ${{steps.output-tags.outputs.tags}}
+    steps:
+      - uses: actions/github-script@v7
+        id: output-tags
+        with:
+          script: |
+            const tags = await github.paginate(
+              'GET /repos/{owner}/{repo}/tags', {
+                  owner: 'thefrontside',
+                  repo: 'effection',
+              },
+              (response) => response.data.filter(({ name }) => /effection-v3.0.0/.test(name))
+            );
+
+            core.setOutput('tags', JSON.stringify(tags.map(tag => tag.name)));
+        env:
+          GITHUB_TOKEN: ${{github.token}}
+
+  rebuild:
+    runs-on: ubuntu-latest
+    needs: setup
+    if: "join(fromJSON(needs.setup.outputs.tags), '') != ''"
+    strategy:
+      matrix:
+        tag: ${{fromJSON(needs.setup.outputs.tags)}}
+      max-parallel: 4
+  
+    permissions:
+      # Give the default GITHUB_TOKEN write permission to commit and push the
+      # added or changed files to the repository.
+      contents: write
+    
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: "refs/tags/${{ matrix.tag }}"
+
+      - name: setup deno
+        uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.x
+
+      - name: Get Version
+        id: vars
+        run: echo ::set-output name=version::$(echo ${{ matrix.tag }} | sed 's/^effection-v//')
+
+      - name: Generate Docs for ${{ matrix.tag }}
+        run: deno doc --html --name=effection@$VERSION mod.ts
+        env:
+          VERSION: ${{steps.vars.outputs.version}}
+          
+      - run: tar cfv docs.tar -C docs .
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: docs.tar
+          name: ${{steps.vars.outputs.version}}
+          tag_name: "refs/tags/${{ matrix.tag }}"
+        env:
+          GITHUB_TOKEN: ${{github.token}}


### PR DESCRIPTION
Related #890

## Motivation

This PR introduces two GitHub Actions Workflows:
* create-release.yaml
* rebuild-releases.yaml

### create-release.yaml

This workflow runs anytime a tag is created that matches "effection-v*". It'll checkout the tag, generate docs with `deno doc`, create a tarball and create a release.

### rebuild-releases.yaml

This workflow can only be triggered manually. It can be used to rebuild all of the releases. It has two jobs: _setup_ & _rebuild_. The setup job gets a list of all tags that match the "effection-v*" pattern and sticks the result into outputs. The _rebuild_ job uses outputes from _setup_ as matrix. The actual workflow is same as **create-release.yaml**

## TIL

1. GitHub has a new mechanism for managing tokens generated by users in an organization. If you want to interact with an organization's resources, you'll need to create a token specifically for that organisation. There are additional configuration options under TheFrontside github org settings
2. You can have [dynamic matrixes in GitHub Actions](https://thekevinwang.com/2021/09/19/github-actions-dynamic-matrix) at the bottom of the blog post there are good examples like [this one](https://github.com/suzuki-shunsuke/example-github-actions-dynamic-matrix/blob/master/.github/workflows/test.yml)
3. `act -s GITHUB_TOKEN="<YOUR_TOKEN>" -W .github/workflows/rebuild-releases.yml workflow_dispatch` can be used to run `rebuild-releases.yaml` on your machine

## TODO

* [x] How do I test this?
* [x] How do I run this for all existing tags?