### PR TITLE
Make it easier to contribute to www with VSCode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,6 @@
 {
-  "deno.enable": true
+  "deno.enable": true,
+  "files.exclude": {
+    "www": true,
+  }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "deno.enable": true,
   "files.exclude": {
-    "www": true,
+    "www": true
   }
 }

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ solid _at scale_, and it does all of this while feeling like normal JavaScript.
 Effection runs on all major JavaScript platforms including NodeJs, Browser, and
 Deno. It is published on both [npm][npm-effection] and [deno.land][deno-land-effection].
 
+## Contributing to Website
+
+Go to [www/README.md] to learn how to contribute to the website.
+
 ## Development
 
 [Deno][] is the primary tool used for development, testing, and packaging.

--- a/www/.vscode/settings.json
+++ b/www/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "deno.enable": true,
+}

--- a/www/README.md
+++ b/www/README.md
@@ -1,7 +1,18 @@
 ## Effection Website
 
+The Effection website contains Guides and API documentation. 
+
+### Contributing
+
+#### Using VSCode
+
+The local development workflow with VSCode was adapted to workaround a [bug in Deno VSCode plugin][vscode-bug]. 
+To get all of the VSCode niceties, you have to open the `www/www.code-workspace` using _File -> Open Workspace From File_.
+
 ### Development
 
 ```shellsession
 $ deno task dev
 ```
+
+[vscode-bug]: https://github.com/thefrontside/effection/issues/893

--- a/www/www.code-workspace
+++ b/www/www.code-workspace
@@ -1,0 +1,13 @@
+{
+	"folders": [
+		{
+			"name": "website",
+			"path": "."
+		},
+		{
+			"name": "core",
+			"path": "..",
+		},
+	],
+	"settings": {}
+}


### PR DESCRIPTION
Related #893 

## Motivation

We want it to be easy for people to contribute to the website using VSCode. 

## Approach

Due to https://github.com/denoland/vscode_deno/issues/787, imports are only read from the workspace's default _deno.json_ file. Fortunately, we can trick VSCode Deno Plugin into reading the `deno.json` file from 'www' directory by creating a `.code-workspace` file that has `www` directory as the first in the list of folders. Since the core doesn't have dependencies, this issue will not effect the core folders.

1. created `www/www.code-workspaces` file with `www` as first and main folder
2. Added `www/.vscode/settings.json` with `deno.enable: true` to activate deno when it's root
3. Added `www` directory to excludes `.vscode/settings.json` 
4. Added instructions to README.md that encourage users to read `www/README.md` for website contribution instructions
5.  Added instructions on how to use the `www/www.code-workspaces` file for contributing to the website.
