### PR TITLE
Fix lint errors using deno lint --fix

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -20,12 +20,12 @@ jobs:
       - name: setup deno
         uses: denoland/setup-deno@v1
         with:
-          deno-version: v1.x
+          deno-version: v1.46.x
 
       - name: Setup Node
         uses: actions/setup-node@v2
         with:
-          node-version: 18.x
+          node-version: 20.x
           registry-url: https://registry.npmjs.com
 
       - name: format

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -2,6 +2,7 @@ import { createContext } from "./context.ts";
 import { type Operation } from "./types.ts";
 import { action } from "./instructions.ts";
 import { run } from "./run.ts";
+import process from "node:process";
 
 /**
  * Halt process execution immediately and initiate shutdown. If a message is
@@ -90,19 +91,13 @@ export async function main(
             }
           },
           *node() {
-            //@ts-expect-error type-checked by Deno, run on Node
-            hardexit = (status) => global.process.exit(status);
+            hardexit = (status) => process.exit(status);
             try {
-              //@ts-expect-error type-checked by Deno, run on Node
               process.on("SIGINT", interrupt.SIGINT);
-              //@ts-expect-error type-checked by Deno, run on Node
               process.on("SIGTERM", interrupt.SIGTERM);
-              //@ts-expect-error type-checked by Deno, run on Node
-              yield* body(global.process.argv.slice(2));
+              yield* body(process.argv.slice(2));
             } finally {
-              //@ts-expect-error this runs on Node
               process.off("SIGINT", interrupt.SIGINT);
-              //@ts-expect-error this runs on Node
               process.off("SIGTERM", interrupt.SIGINT);
             }
           },
@@ -160,10 +155,10 @@ function* withHost<T>(op: HostOperation<T>): Operation<T> {
 
   if (typeof global.Deno !== "undefined") {
     return yield* op.deno();
-    // this snippet is from the node-detect npm package
+    // this snippet is from the detect-node npm package
+    // @see https://github.com/iliakan/detect-node/blob/master/index.js
   } else if (
     Object.prototype.toString.call(
-      //@ts-expect-error dev env is deno, but this is safe to run.
       typeof process !== "undefined" ? process : 0,
     ) === "[object process]"
   ) {


### PR DESCRIPTION
## Motivation

#905 is blocked because of lint errors, so I will fix them here and then rebase.

## Approach

1. Ran `deno lint --fix`
2. Using `npm:process` instead of `globalThis.process`
3. Pinned to 1.46.x in CI