### PR TITLE
📝 fix variable examples in async rosetta stone

### DIFF
--- a/www/docs/async-rosetta-stone.mdx
+++ b/www/docs/async-rosetta-stone.mdx
@@ -105,13 +105,13 @@ value has been computed.
 To use a promise:
 
 ```js
-let promise = await promise;
+let result = await promise;
 ```
 
 To use an operation:
 
 ```js
-let operation = yield* operation;
+let result = yield* operation;
 ```
 
 To convert from a promise to an operation, use [`call()`][call]


### PR DESCRIPTION
## Motivation
In the section for promises and operations, we were re-assigning the variables to the value of the evaluated promise/operation.

While syntactically acceptable, it is a bad idea and nobody would ever write code like that.
## Approach

Use `result` in both cases.