### PR TITLE
Cl/export async helpers

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -41,7 +41,7 @@ jobs:
           NPM_VERSION: ${{steps.vars.outputs.version}}
 
       - name: Publish
-        run: npm publish --access=public
+        run: npm publish --access=public --tag=next
         working-directory: ./build/npm
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}

--- a/lib/call.ts
+++ b/lib/call.ts
@@ -61,6 +61,15 @@ export interface Callable<
  */
 
 export function call<T, TArgs extends unknown[] = []>(
+  fn: (...args: TArgs) => Promise<T>,
+): Operation<T>;
+export function call<T, TArgs extends unknown[] = []>(
+  fn: (...args: TArgs) => T,
+): Operation<T>;
+export function call<T, TArgs extends unknown[] = []>(
+  fn: (...args: TArgs) => Operation<T>,
+): Operation<T>;
+export function call<T, TArgs extends unknown[] = []>(
   callable: Callable<T, TArgs>,
   ...args: TArgs
 ): Operation<T> {

--- a/lib/mod.ts
+++ b/lib/mod.ts
@@ -20,3 +20,4 @@ export * from "./events.ts";
 export * from "./abort-signal.ts";
 export * from "./main.ts";
 export * from "./with-resolvers.ts";
+export * from "./async.ts";


### PR DESCRIPTION
## Motivation

We weren't exporting the async integration helpers.

```
error: Uncaught SyntaxError: The requested module 'npm:effection@4.0.0-alpha.0' does not provide an export named 'stream'
```

## Approach

Add them to exports. Also, make sure to publish v4 alphas to the `next` not the `latest` tag