### PR TITLE
🐛 Consume a task as an operation.

### DIFF
--- a/lib/task.ts
+++ b/lib/task.ts
@@ -6,14 +6,8 @@ import { lazyPromise, lazyPromiseWithResolvers } from "./lazy-promise.ts";
 import { Just, Maybe, Nothing } from "./maybe.ts";
 import { Err, Ok, Result, unbox } from "./result.ts";
 import { createScopeInternal, type ScopeInternal } from "./scope.ts";
-import type {
-  Coroutine,
-  Future,
-  Operation,
-  Resolve,
-  Scope,
-  Task,
-} from "./types.ts";
+import type { Coroutine, Operation, Resolve, Scope, Task } from "./types.ts";
+import { withResolvers } from "./with-resolvers.ts";
 
 export interface TaskOptions<T> {
   owner: ScopeInternal;
@@ -38,7 +32,18 @@ export function createTask<T>(options: TaskOptions<T>): NewTask<T> {
     operation: () => trapset(() => after(operation, destroy)),
   });
 
-  let { promise, resolve, reject } = lazyPromiseWithResolvers<T>();
+  let promise = lazyPromiseWithResolvers<T>();
+  let future = withResolvers<T>();
+
+  let resolve = (value: T) => {
+    promise.resolve(value);
+    future.resolve(value);
+  };
+
+  let reject = (error: Error) => {
+    promise.reject(error);
+    future.reject(error);
+  };
 
   let initiateHalt = (resolve: Resolve<Result<void>>) => {
     if (scope.hasOwn(TrapContext)) {
@@ -84,9 +89,19 @@ export function createTask<T>(options: TaskOptions<T>): NewTask<T> {
     },
   });
 
-  let task = Object.defineProperty(promise, "halt", {
-    enumerable: false,
-    value: () => halt as Future<void>,
+  let task = Object.defineProperties(promise.promise, {
+    [Symbol.toStringTag]: {
+      enumerable: false,
+      value: "Task",
+    },
+    [Symbol.iterator]: {
+      enumerable: false,
+      value: future.operation[Symbol.iterator],
+    },
+    halt: {
+      enumerable: false,
+      value: () => halt,
+    },
   }) as Task<T>;
 
   let group = TaskGroup.ensureOwn(owner);

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, useCommand } from "./suite.ts";
+import { $await, describe, expect, it, useCommand } from "./suite.ts";
 import { type Operation, resource, run, sleep, spawn } from "../mod.ts";
 
 describe("main", () => {
@@ -13,7 +13,7 @@ describe("main", () => {
 
       daemon.kill("SIGINT");
 
-      let status = yield* daemon.status;
+      let status = yield* $await(daemon.status);
 
       expect(status.code).toBe(130);
 
@@ -32,7 +32,7 @@ describe("main", () => {
 
       daemon.kill("SIGTERM");
 
-      let status = yield* daemon.status;
+      let status = yield* $await(daemon.status);
 
       expect(status.code).toBe(143);
 
@@ -61,7 +61,7 @@ describe("main", () => {
       });
 
       let stdout = yield* buffer(cmd.stdout);
-      let status = yield* cmd.status;
+      let status = yield* $await(cmd.status);
 
       yield* detect(stdout, "goodbye.");
       expect(status.code).toEqual(0);
@@ -77,7 +77,7 @@ describe("main", () => {
       });
       let stdout = yield* buffer(cmd.stdout);
       let stderr = yield* buffer(cmd.stderr);
-      let status = yield* cmd.status;
+      let status = yield* $await(cmd.status);
 
       yield* detect(stdout, "graceful goodbye");
       yield* detect(stderr, "It all went horribly wrong");
@@ -95,7 +95,7 @@ describe("main", () => {
 
       let stdout = yield* buffer(cmd.stdout);
       let stderr = yield* buffer(cmd.stderr);
-      let status = yield* cmd.status;
+      let status = yield* $await(cmd.status);
 
       yield* detect(stdout, "graceful goodbye");
       yield* detect(stderr, "Error: moo");
@@ -114,7 +114,7 @@ describe("main", () => {
 
       process.kill("SIGINT");
 
-      let status = yield* process.status;
+      let status = yield* $await(process.status);
 
       expect(status.code).toBe(130);
 
@@ -135,13 +135,13 @@ function buffer(stream: ReadableStream<Uint8Array>): Operation<Buffer> {
       let reader = stream.getReader();
 
       try {
-        let next = yield* reader.read();
+        let next = yield* $await(reader.read());
         while (!next.done) {
           buff.content += decoder.decode(next.value);
-          next = yield* reader.read();
+          next = yield* $await(reader.read());
         }
       } finally {
-        yield* reader.cancel();
+        yield* $await(reader.cancel());
       }
     });
 

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -1,5 +1,5 @@
 // deno-lint-ignore-file no-unsafe-finally
-import { blowUp, createNumber, describe, expect, it } from "./suite.ts";
+import { $await, blowUp, createNumber, describe, expect, it } from "./suite.ts";
 import { action, run, sleep, spawn, suspend, type Task } from "../mod.ts";
 
 describe("run()", () => {
@@ -11,8 +11,8 @@ describe("run()", () => {
 
   it("can compose multiple promises via generator", async () => {
     let result = await run(function* () {
-      let one = yield* Promise.resolve(12);
-      let two = yield* Promise.resolve(55);
+      let one = yield* $await(Promise.resolve(12));
+      let two = yield* $await(Promise.resolve(55));
       return one + two;
     });
     expect(result).toEqual(67);
@@ -49,16 +49,16 @@ describe("run()", () => {
   it("can recover from errors in promise", async () => {
     let error = new Error("boom");
     let task = run(function* () {
-      let one = yield* Promise.resolve(12);
+      let one = yield* $await(Promise.resolve(12));
       let two;
       try {
-        yield* Promise.reject(error);
+        yield* $await(Promise.reject(error));
         two = 9;
       } catch (_) {
         // swallow error and yield in catch block
-        two = yield* Promise.resolve(8);
+        two = yield* $await(Promise.resolve(8));
       }
-      let three = yield* Promise.resolve(55);
+      let three = yield* $await(Promise.resolve(55));
       return one + two + three;
     });
     await expect(task).resolves.toEqual(75);
@@ -66,16 +66,16 @@ describe("run()", () => {
 
   it("can recover from errors in operation", async () => {
     let task = run(function* () {
-      let one = yield* Promise.resolve(12);
+      let one = yield* $await(Promise.resolve(12));
       let two;
       try {
         yield* blowUp();
         two = 9;
       } catch (_e) {
         // swallow error and yield in catch block
-        two = yield* Promise.resolve(8);
+        two = yield* $await(Promise.resolve(8));
       }
-      let three = yield* Promise.resolve(55);
+      let three = yield* $await(Promise.resolve(55));
       return one + two + three;
     });
     await expect(task).resolves.toEqual(75);
@@ -308,7 +308,7 @@ describe("run()", () => {
   it("propagates errors from promises", async () => {
     try {
       await run(function* () {
-        yield* Promise.reject(new Error("boom"));
+        yield* $await(Promise.reject(new Error("boom")));
       });
       throw new Error("expected error to propagate");
     } catch (error) {

--- a/test/spawn.test.ts
+++ b/test/spawn.test.ts
@@ -1,13 +1,13 @@
 // deno-lint-ignore-file no-unsafe-finally
-import { describe, expect, it } from "./suite.ts";
+import { $await, describe, expect, it } from "./suite.ts";
 import { run, sleep, spawn, suspend } from "../mod.ts";
 
 describe("spawn", () => {
   it("can spawn a new child task", async () => {
     let root = run(function* root() {
       let child = yield* spawn(function* child() {
-        let one = yield* Promise.resolve(12);
-        let two = yield* Promise.resolve(55);
+        let one = yield* $await(Promise.resolve(12));
+        let two = yield* $await(Promise.resolve(55));
         return one + two;
       });
       return yield* child;

--- a/test/suite.ts
+++ b/test/suite.ts
@@ -1,4 +1,4 @@
-import { action, call, resource, sleep, spawn } from "../mod.ts";
+import { call, resource, sleep, spawn } from "../mod.ts";
 
 import { Operation } from "../lib/types.ts";
 
@@ -11,6 +11,10 @@ export {
 export { expect } from "jsr:@std/expect";
 export { expectType } from "npm:ts-expect@1.3.0";
 
+export function $await<T>(promise: Promise<T>): Operation<T> {
+  return call(() => promise);
+}
+
 export function* createNumber(value: number): Operation<number> {
   yield* sleep(1);
   return value;
@@ -20,21 +24,6 @@ export function* blowUp<T>(): Operation<T> {
   yield* sleep(1);
   throw new Error("boom");
 }
-
-declare global {
-  interface Promise<T> extends Operation<T> {}
-}
-
-Object.defineProperty(Promise.prototype, Symbol.iterator, {
-  get<T>(this: Promise<T>) {
-    let then = this.then.bind(this);
-    let suspense = action<T>(function wait(resolve, reject) {
-      then(resolve, reject);
-      return () => {};
-    });
-    return suspense[Symbol.iterator];
-  },
-});
 
 export function* asyncResolve(
   duration: number,


### PR DESCRIPTION
## Motivation

Tasks are supposed to be both operations _and_ promises. However, I had forgotten to make the task consumaeble as an operation, and only a promise. However, because we were monkey-patching `Promise.prototype`, it was actually hiding the gap because everywher we needed to consume a task as an operation, it just used the promise as operation route.

## Approach

I added back the operation functionality, but at the same time, I actually removed the monkey-patch of `Promise.prototype` for our test suite so that we are forced to follow the operation pathway explicitly. That way, we won't risk regressing back to non-functioning operation tasks. It does make the tests a little more verbose, but the added safety is worth it.