### PR TITLE
Moved useScope to own file to eliminate circular dependency

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -28,7 +28,6 @@ jobs:
         id: vars
         run: echo ::set-output name=version::$(echo ${{github.ref_name}} | sed 's/^effection-v//')
 
-
       - name: Setup Node
         uses: actions/setup-node@v2
         with:

--- a/lib/context.ts
+++ b/lib/context.ts
@@ -1,6 +1,6 @@
 import { Context, Effect, Operation, Scope } from "./types.ts";
 import { Ok } from "./result.ts";
-import { useScope } from "./scope.ts";
+import { useScope } from "./use-scope.ts";
 
 export function createContext<T>(name: string, defaultValue?: T): Context<T> {
   let context: Context<T> = {

--- a/lib/each.ts
+++ b/lib/each.ts
@@ -3,7 +3,7 @@ import { createContext } from "./context.ts";
 import { race } from "./race.ts";
 import { resource } from "./resource.ts";
 import { withResolvers } from "./with-resolvers.ts";
-import { useScope } from "./scope.ts";
+import { useScope } from "./use-scope.ts";
 
 /**
  * Consume an effection stream using a simple for-of loop.

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -2,7 +2,7 @@ import { createContext } from "./context.ts";
 import { type Operation } from "./types.ts";
 import { callcc } from "./callcc.ts";
 import { run } from "./run.ts";
-import { useScope } from "./scope.ts";
+import { useScope } from "./use-scope.ts";
 import process from "node:process";
 
 /**

--- a/lib/mod.ts
+++ b/lib/mod.ts
@@ -2,6 +2,7 @@ export * from "./types.ts";
 export * from "./action.ts";
 export * from "./context.ts";
 export * from "./scope.ts";
+export * from "./use-scope.ts";
 export * from "./suspend.ts";
 export * from "./sleep.ts";
 export * from "./run.ts";

--- a/lib/scope.ts
+++ b/lib/scope.ts
@@ -1,5 +1,5 @@
 import { Children, Generation } from "./contexts.ts";
-import { Context, Effect, Future, Operation, Scope, Task } from "./types.ts";
+import { Context, Future, Operation, Scope, Task } from "./types.ts";
 import { Err, Ok, unbox } from "./result.ts";
 import { createTask } from "./task.ts";
 
@@ -94,12 +94,3 @@ export interface ScopeInternal extends Scope {
   ensure(op: () => Operation<void>): () => void;
 }
 
-export function* useScope(): Operation<Scope> {
-  return (yield {
-    description: `useScope()`,
-    enter(resolve, { scope }) {
-      resolve(Ok(scope));
-      return (resolve) => resolve(Ok());
-    },
-  } as Effect<Scope>) as Scope;
-}

--- a/lib/scope.ts
+++ b/lib/scope.ts
@@ -93,4 +93,3 @@ export interface ScopeInternal extends Scope {
   contexts: Record<string, unknown>;
   ensure(op: () => Operation<void>): () => void;
 }
-

--- a/lib/use-scope.ts
+++ b/lib/use-scope.ts
@@ -1,6 +1,5 @@
 import { Ok } from "./result.ts";
-import { Operation, Scope, Effect } from "./types.ts";
-
+import { Effect, Operation, Scope } from "./types.ts";
 
 export function* useScope(): Operation<Scope> {
   return (yield {

--- a/lib/use-scope.ts
+++ b/lib/use-scope.ts
@@ -1,0 +1,13 @@
+import { Ok } from "./result.ts";
+import { Operation, Scope, Effect } from "./types.ts";
+
+
+export function* useScope(): Operation<Scope> {
+  return (yield {
+    description: `useScope()`,
+    enter(resolve, { scope }) {
+      resolve(Ok(scope));
+      return (resolve) => resolve(Ok());
+    },
+  } as Effect<Scope>) as Scope;
+}


### PR DESCRIPTION
## Motivation

I was encountering the following error.

![image](https://github.com/user-attachments/assets/3503096f-6283-4bc4-ba72-3ef1cbf4da28)

A circular dependency caused it

1. scope.ts imports Children, Generation from contexts.ts
2. contexts.ts imports createContext from context.ts
3. context.ts import useScope from scope.ts

## Approach

Moved `useScope` to own file and import from that file.

The result is

1. scope.ts imports Children, Generation from contexts.ts
2. contexts.ts imports createContext from context.ts
3. context.ts import useScope from use-scope.ts
