### PR TITLE
⬆️ Upgrate to Deno 2

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -20,14 +20,13 @@ jobs:
         uses: actions/checkout@v3
 
       - name: setup deno
-        uses: denoland/setup-deno@v1
+        uses: denoland/setup-deno@v2
         with:
-          deno-version: v1.x
+          deno-version: v2.x
 
       - name: Get Version
         id: vars
         run: echo ::set-output name=version::$(echo ${{github.ref_name}} | sed 's/^effection-v//')
-
 
       - name: Setup Node
         uses: actions/setup-node@v2

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -18,9 +18,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: setup deno
-        uses: denoland/setup-deno@v1
+        uses: denoland/setup-deno@v2
         with:
-          deno-version: v1.46.x
+          deno-version: v2.x
 
       - name: Setup Node
         uses: actions/setup-node@v2

--- a/lib/action.ts
+++ b/lib/action.ts
@@ -23,7 +23,7 @@ export function action<T>(resolver: Resolver<T>, desc?: string): Operation<T> {
               discard();
               discarded(Ok());
             } catch (error) {
-              discarded(Err(error));
+              discarded(Err(error as Error));
             }
           };
         },

--- a/lib/lift.ts
+++ b/lib/lift.ts
@@ -24,7 +24,7 @@ export function lift<TArgs extends unknown[], TReturn>(
       try {
         resolve(fn(...args));
       } catch (error) {
-        reject(error);
+        reject(error as Error);
       }
       return () => {};
     });

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -118,7 +118,7 @@ export async function main(
 
         yield* exit(0);
       } catch (error) {
-        yield* resolve({ status: 1, error });
+        yield* resolve({ status: 1, error: error as Error });
       } finally {
         clearInterval(interval);
       }

--- a/lib/race.ts
+++ b/lib/race.ts
@@ -52,7 +52,7 @@ export function* race<T extends Operation<unknown>>(
               //        transfer({ from: contestant, to: caller });
               winner.resolve(Ok(value as Yielded<T>));
             } catch (error) {
-              winner.resolve(Err(error));
+              winner.resolve(Err(error as Error));
             }
           }),
         );

--- a/lib/reducer.ts
+++ b/lib/reducer.ts
@@ -56,7 +56,7 @@ export class Reducer {
             throw result.error;
           }
         } catch (error) {
-          notify({ done: true, value: Err(error) });
+          notify({ done: true, value: Err(error as Error) });
         }
         item = queue.dequeue();
       }

--- a/lib/scope.ts
+++ b/lib/scope.ts
@@ -80,7 +80,7 @@ export function createScopeInternal(
         destructors.delete(destructor);
         yield* destructor();
       } catch (error) {
-        outcome = Err(error);
+        outcome = Err(error as Error);
       }
     }
     unbox(outcome);

--- a/lib/task.ts
+++ b/lib/task.ts
@@ -201,7 +201,7 @@ function* box<T>(op: () => Operation<T>): Operation<Result<T>> {
   try {
     return Ok(yield* op());
   } catch (error) {
-    return Err(error);
+    return Err(error as Error);
   }
 }
 
@@ -218,7 +218,7 @@ function trapset<T>(op: () => Operation<T>): Operation<Maybe<T>> {
         trap.result = Ok(Just(value));
       }
     } catch (error) {
-      trap.result = Err(error);
+      trap.result = Err(error as Error);
     } finally {
       // deno-lint-ignore no-unsafe-finally
       return unbox(trap.result) as Maybe<T>;

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -301,7 +301,7 @@ describe("run()", () => {
       });
       throw new Error("expected error to propagate");
     } catch (error) {
-      expect(error.message).toEqual("boom");
+      expect((error as Error).message).toEqual("boom");
     }
   });
 
@@ -312,7 +312,7 @@ describe("run()", () => {
       });
       throw new Error("expected error to propagate");
     } catch (error) {
-      expect(error.message).toEqual("boom");
+      expect((error as Error).message).toEqual("boom");
     }
   });
 

--- a/test/suite.ts
+++ b/test/suite.ts
@@ -84,7 +84,9 @@ export function useCommand(
 
         if (
           !!error &&
-          !error.message.includes("Child process has already terminated")
+          !(error as Error).message.includes(
+            "Child process has already terminated",
+          )
         ) {
           // deno-lint-ignore no-unsafe-finally
           throw error;


### PR DESCRIPTION
## Motivation
Deno 2 is out, and we're not going back.

## Approach
Deno 2 formats yaml files, and it uses a stricter mode of TypeScript which treat the argument to a catch clause as `unknown` rather than `any`. In general, this is a good thing, but we have been treating errors as errors thus far with little bad effect. This adds an explicit cast to each catch clause to assume that it is an `Error` like before.

It highlights the danger which is good, and we should seriously consider moving away from this assumption (although a pox upon the house of anyone who throws anything but an error). Nevertheless, now is not the time.