### PR TITLE
✨Introduce Do() operation

### DIFF
--- a/lib/context.ts
+++ b/lib/context.ts
@@ -1,25 +1,17 @@
 import { Context, Effect, Operation, Scope } from "./types.ts";
 import { Ok } from "./result.ts";
-import { useScope } from "./scope.ts";
+import { Do } from "./do.ts";
 
 export function createContext<T>(name: string, defaultValue?: T): Context<T> {
   let context: Context<T> = {
     name,
     defaultValue,
-    *get(): Operation<T | undefined> {
-      return (yield Get(context)) as T | undefined;
-    },
-    *set(value: T): Operation<T> {
-      return (yield Set(context, value)) as T;
-    },
-    *expect(): Operation<T> {
-      return (yield Expect(context)) as T;
-    },
-    *delete(): Operation<boolean> {
-      return (yield Delete(context)) as boolean;
-    },
+    get: () => Do(Get(context)),
+    set: (value) => Do(Set(context, value)),
+    expect: () => Do(Expect(context)),
+    delete: () => Do(Delete(context)),
     *with<R>(value: T, operation: (value: T) => Operation<R>): Operation<R> {
-      let scope = yield* useScope();
+      let scope = yield* Do(UseScope((scope) => scope, "useScope()"));
       let original = scope.hasOwn(context) ? scope.get(context) : undefined;
       try {
         return yield* operation(scope.set(context, value));
@@ -46,7 +38,7 @@ const Set = <T>(context: Context<T>, value: T) =>
 const Expect = <T>(context: Context<T>) =>
   UseScope((scope) => scope.expect(context), `expect(${context.name})`);
 const Delete = <T>(context: Context<T>) =>
-  UseScope((scope) => scope.expect(context), `delete(${context.name})`);
+  UseScope((scope) => scope.delete(context), `delete(${context.name})`);
 
 function UseScope<T>(fn: (scope: Scope) => T, description: string): Effect<T> {
   return {

--- a/lib/do.ts
+++ b/lib/do.ts
@@ -1,0 +1,35 @@
+import { Result } from "./result.ts";
+import { Effect, Operation } from "./types.ts";
+
+/**
+ * Perform a single Effect as an Operation
+ */
+export function Do<T>(effect: Effect<T>): Operation<T> {
+  return {
+    [Symbol.iterator]() {
+      let result: Result<T> | undefined = undefined;
+      let perform: Effect<T> = {
+        description: `do <${effect.description}>`,
+        enter(resolve, routine) {
+          return effect.enter((r) => {
+            resolve(result = r);
+          }, routine);
+        },
+      };
+
+      return {
+        next() {
+          if (result) {
+            if (result.ok) {
+              return { done: true, value: result.value };
+            } else {
+              throw result.error;
+            }
+          } else {
+            return { done: false, value: perform };
+          }
+        },
+      };
+    },
+  };
+}


### PR DESCRIPTION
## Motivation

Many of the Operations are comprised of a single Effect, and very often a synchronous Effect at that. There is no need to pay any of the overhead for creating a generator when we could just make a simple iterator.

## Approach

This introduces a `Do()` function which takes any effect and converts it automatically into an operation (an effect iterator) so that it can be used anywhere that an operation can be used. The iterator just returns a wrapping effect that captures its result, and then the next time it is called, it returns that result. This gives us better performance and also solves the circular dependency problem inside `context.ts`
