### PR TITLE
✨Add benchmarks

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -3,7 +3,8 @@
   "tasks": {
     "test": "deno test --allow-run=deno",
     "test:node": "deno task build:npm 0.0.0 && node test/main/node.mjs hello world",
-    "build:npm": "deno run -A tasks/build-npm.ts"
+    "build:npm": "deno run -A tasks/build-npm.ts",
+    "bench": "deno run -A tasks/bench.ts"
   },
   "lint": {
     "rules": {

--- a/tasks/bench.ts
+++ b/tasks/bench.ts
@@ -1,0 +1,158 @@
+import { parser } from "npm:zod-opts";
+import { z } from "npm:zod";
+import {
+  all,
+  createQueue,
+  each,
+  main,
+  Operation,
+  spawn,
+  Task,
+  withResolvers,
+} from "../mod.ts";
+import { useWorker } from "./bench/worker.ts";
+import scenarios from "./bench/scenarios.ts";
+import {
+  BenchmarkDoneEvent,
+  BenchmarkOptions,
+  BenchmarkWorkerEvent,
+  WorkerCommand,
+} from "./bench/types.ts";
+import { Ok } from "../lib/result.ts";
+
+import { Cell, Row, Table } from "jsr:@cliffy/table@1.0.0-rc.7";
+
+await main(function* (args) {
+  let options = parser()
+    .name("bench")
+    .description(
+      "Run Effection benchmarks",
+    )
+    .version("0.0.0")
+    .options({
+      include: {
+        type: z.string().optional(),
+        description: "include only scenarios matching REGEXP",
+      },
+      exclude: {
+        type: z.string().optional(),
+        description: "exclude all scenanios matching REGEXP",
+      },
+      repeat: {
+        type: z.number().positive().default(10),
+        description: "number of times to repeat",
+        alias: "n",
+      },
+      depth: {
+        type: z.number().positive().default(100),
+        description: "number of levels of recursion to run",
+        alias: "d",
+      },
+    })
+    .parse(args);
+
+  let { include, exclude } = options;
+
+  let tasks: Task<BenchmarkDoneEvent>[] = [];
+
+  for (let scenario of filter(scenarios, { include, exclude })) {
+    tasks.push(
+      yield* spawn(() =>
+        runBenchmark(scenario, { ...options, type: "benchmark" })
+      ),
+    );
+  }
+
+  let results = yield* all(tasks);
+
+  let events = results.filter((result) => result.name.match("events"));
+  let recursion = results.filter((result) => result.name.match("recursion"));
+
+  if (events.length == 0 && recursion.length === 0) {
+    console.log("no benchmarks run");
+    return;
+  }
+
+  let rows = [];
+
+  if (recursion.length > 0) {
+    rows.push(Row.from([new Cell("Basic Recursion").colSpan(2).border()]));
+    rows.push(Row.from<Cell | string>(["Library", "Avg (ms)"]).border());
+    rows.push(...recursion.map((event) => Row.from(toTableRow(event))));
+  }
+
+  if (events.length > 0) {
+    rows.push(Row.from([new Cell("Recursive Events").colSpan(2).border()]));
+    rows.push(Row.from<Cell | string>(["Library", "Avg (ms)"]).border());
+    rows.push(...events.map((event) => Row.from(toTableRow(event))));
+  }
+
+  Table.from(rows).render();
+});
+
+function* runBenchmark(
+  scenario: string,
+  options: BenchmarkOptions,
+): Operation<BenchmarkDoneEvent> {
+  let results = createQueue<BenchmarkDoneEvent, never>();
+  let closed = withResolvers<void>();
+  let worker = yield* useWorker<WorkerCommand, BenchmarkWorkerEvent>(scenario);
+
+  yield* spawn(function* () {
+    for (let event of yield* each(worker.errors)) {
+      event.preventDefault();
+      throw event.error;
+    }
+  });
+
+  yield* spawn(function* () {
+    for (let event of yield* each(worker.messages)) {
+      if (event.data.type === "done") {
+        results.add(event.data);
+      } else if (event.data.type === "close") {
+        console.log(event.data);
+        if (!event.data.result.ok) {
+          throw event.data.result.error;
+        } else {
+          closed.resolve();
+        }
+      }
+      yield* each.next();
+    }
+  });
+
+  try {
+    yield* worker.postMessage(options);
+    let value = (yield* results.next()).value;
+    return value;
+  } finally {
+    yield* worker.postMessage({ type: "close", result: Ok() });
+  }
+}
+
+import { basename } from "jsr:@std/path";
+
+function filter(
+  strings: string[],
+  options: { include?: string; exclude?: string },
+): string[] {
+  let { include, exclude } = options;
+  let result = strings;
+  if (include) {
+    result = result.filter((s) => basename(s).match(new RegExp(include)));
+  }
+  if (exclude) {
+    result = result.filter((s) => !basename(s).match(new RegExp(exclude)));
+  }
+  return result;
+}
+
+function toTableRow(event: BenchmarkDoneEvent): string[] {
+  let [name = event.name] = event.name.split(".");
+  if (event.result.ok) {
+    let { avgTime } = event.result.value;
+    return [name, String(avgTime)];
+  } else {
+    return [name, "❌"];
+  }
+}

--- a/tasks/bench/scenarios.ts
+++ b/tasks/bench/scenarios.ts
@@ -1,0 +1,9 @@
+export default [
+  "./scenarios/effection.recursion.ts",
+  "./scenarios/rxjs.recursion.ts",
+  "./scenarios/co.recursion.ts",
+  "./scenarios/async+await.recursion.ts",
+  "./scenarios/effection.events.ts",
+  "./scenarios/rxjs.events.ts",
+  "./scenarios/add-event-listener.events.ts",
+].map((mod) => import.meta.resolve(mod));

--- a/tasks/bench/scenarios/add-event-listener.events.ts
+++ b/tasks/bench/scenarios/add-event-listener.events.ts
@@ -1,0 +1,52 @@
+import { call } from "../../../mod.ts";
+import { scenario } from "./scenario.ts";
+
+await scenario("add-event-listener.events", (depth) => call(() => run(depth)));
+
+export async function run(depth: number): Promise<void> {
+  const target = new EventTarget();
+  const c = new AbortController();
+  const promised = recurse(target, c.signal, depth);
+  for (let i = 0; i < 100; i++) {
+    await Promise.resolve();
+    target.dispatchEvent(new Event("foo"));
+  }
+  await Promise.resolve();
+  c.abort();
+  await promised;
+}
+
+async function recurse(
+  target: EventTarget,
+  signal: AbortSignal,
+  depth: number,
+): Promise<void> {
+  let abort: (() => void) | undefined;
+  let handler: (() => void) | undefined;
+  let resolve: (() => void) | undefined;
+  let promise: Promise<void> | undefined;
+  function finalize() {
+    abort && (signal.removeEventListener("abort", abort), abort = undefined);
+    handler &&
+      (target.removeEventListener("foo", handler), handler = undefined);
+    resolve && (resolve(), resolve = undefined);
+  }
+  if (depth > 0) {
+    const subTarget = new EventTarget();
+    const subPromise = recurse(subTarget, signal, depth - 1);
+    handler = function handler() {
+      subTarget.dispatchEvent(new Event("foo"));
+    };
+    target.addEventListener("foo", handler);
+    await subPromise;
+  } else {
+    promise = new Promise<void>((r) => resolve = r);
+    abort = finalize;
+    handler = function handler() {
+      //probeMemory("bottom");
+    };
+    target.addEventListener("foo", handler);
+    signal.addEventListener("abort", abort);
+    await promise;
+  }
+}

--- a/tasks/bench/scenarios/async+await.recursion.ts
+++ b/tasks/bench/scenarios/async+await.recursion.ts
@@ -1,0 +1,14 @@
+import { call } from "../../../mod.ts";
+import { scenario } from "./scenario.ts";
+
+await scenario("async+await.recursion", (depth) => call(() => recurse(depth)));
+
+async function recurse(depth: number): Promise<void> {
+  if (depth > 1) {
+    await recurse(depth - 1);
+  } else {
+    for (let i = 0; i < 100; i++) {
+      await Promise.resolve();
+    }
+  }
+}

--- a/tasks/bench/scenarios/co.recursion.ts
+++ b/tasks/bench/scenarios/co.recursion.ts
@@ -1,0 +1,15 @@
+import { call } from "../../../mod.ts";
+import { scenario } from "./scenario.ts";
+import co from "npm:co";
+
+await scenario("co.recursion", (depth) => call(() => co(recurse, depth)));
+
+function* recurse(depth: number): Generator<unknown, void> {
+  if (depth > 1) {
+    yield recurse(depth - 1);
+  } else {
+    for (let i = 0; i < 100; i++) {
+      yield Promise.resolve();
+    }
+  }
+}

--- a/tasks/bench/scenarios/effection.events.ts
+++ b/tasks/bench/scenarios/effection.events.ts
@@ -1,0 +1,31 @@
+import { scenario } from "./scenario.ts";
+import { each, on, Operation, sleep, spawn } from "../../../mod.ts";
+
+await scenario("effection.events", start);
+
+export function* start(depth: number): Operation<void> {
+  const target = new EventTarget();
+  const task = yield* spawn(() => recurse(target, depth));
+  for (let i = 0; i < 100; i++) {
+    yield* sleep(0);
+    target.dispatchEvent(new Event("foo"));
+  }
+  yield* sleep(0);
+  yield* task.halt();
+}
+
+function* recurse(target: EventTarget, depth: number): Operation<void> {
+  const eventStream = on(target, "foo");
+  if (depth > 1) {
+    const subTarget = new EventTarget();
+    yield* spawn(() => recurse(subTarget, depth - 1));
+    for (const _ of yield* each(eventStream)) {
+      subTarget.dispatchEvent(new Event("foo"));
+      yield* each.next();
+    }
+  } else {
+    for (const _ of yield* each(eventStream)) {
+      yield* each.next();
+    }
+  }
+}

--- a/tasks/bench/scenarios/effection.recursion.ts
+++ b/tasks/bench/scenarios/effection.recursion.ts
@@ -1,0 +1,14 @@
+import { call, Operation } from "../../../mod.ts";
+import { scenario } from "./scenario.ts";
+
+await scenario("effection.recursion", recurse);
+
+function* recurse(depth: number): Operation<void> {
+  if (depth > 1) {
+    yield* recurse(depth - 1);
+  } else {
+    for (let i = 0; i < 100; i++) {
+      yield* call(() => Promise.resolve());
+    }
+  }
+}

--- a/tasks/bench/scenarios/rxjs.events.ts
+++ b/tasks/bench/scenarios/rxjs.events.ts
@@ -1,0 +1,50 @@
+import { fromEvent, Observable, Subject, takeUntil } from "npm:rxjs";
+import { scenario } from "./scenario.ts";
+import { action, Operation, sleep, spawn } from "../../../mod.ts";
+
+await scenario("rxjs.events", run);
+
+function* run(depth: number): Operation<void> {
+  const target = new EventTarget();
+  const abort = new Subject<void>();
+  const promised = yield* spawn(() =>
+    action<void>((resolve) => {
+      let observable = recurse(target, depth)
+        .pipe(takeUntil(abort))
+        .subscribe({
+          complete() {
+            resolve();
+          },
+        });
+      return () => observable.unsubscribe();
+    })
+  );
+  for (let i = 0; i < 100; i++) {
+    yield* sleep(0);
+    target.dispatchEvent(new Event("foo"));
+  }
+  yield* sleep(0);
+  abort.next();
+  yield* promised;
+}
+
+function recurse(target: EventTarget, depth: number): Observable<void> {
+  return new Observable<void>((subscriber) => {
+    const o = fromEvent(target, "foo");
+    if (depth > 1) {
+      const subTarget = new EventTarget();
+      subscriber.add(
+        o.subscribe(() => {
+          subTarget.dispatchEvent(new Event("foo"));
+        }),
+      );
+      subscriber.add(recurse(subTarget, depth - 1).subscribe());
+    } else {
+      subscriber.add(
+        o.subscribe(() => {
+          //                    probeMemory("bottom");
+        }),
+      );
+    }
+  });
+}

--- a/tasks/bench/scenarios/rxjs.recursion.ts
+++ b/tasks/bench/scenarios/rxjs.recursion.ts
@@ -1,0 +1,41 @@
+import { defer, from, Observable, repeat } from "npm:rxjs";
+import { scenario } from "./scenario.ts";
+import { action, Operation } from "../../../mod.ts";
+
+await scenario("rxjs.recursion", run);
+
+function run(depth: number): Operation<void> {
+  return action((resolve) => {
+    let observable = recurse(depth)
+      .subscribe({
+        complete() {
+          resolve();
+        },
+      });
+    return () => observable.unsubscribe();
+  });
+}
+
+function recurse(depth: number): Observable<void> {
+  return new Observable<void>((subscriber) => {
+    if (depth > 1) {
+      subscriber.add(
+        recurse(depth - 1).subscribe({
+          complete() {
+            subscriber.complete();
+          },
+        }),
+      );
+    } else {
+      subscriber.add(
+        defer(() => from(Promise.resolve()))
+          .pipe(repeat(100))
+          .subscribe({
+            complete() {
+              subscriber.complete();
+            },
+          }),
+      );
+    }
+  });
+}

--- a/tasks/bench/scenarios/scenario.ts
+++ b/tasks/bench/scenarios/scenario.ts
@@ -1,0 +1,64 @@
+import { callcc } from "../../../lib/callcc.ts";
+import { Err, Ok } from "../../../lib/result.ts";
+import { encapsulate } from "../../../lib/task.ts";
+import { createChannel, each, main, Operation, spawn } from "../../../mod.ts";
+import {
+  BenchmarkOptions,
+  BenchmarkWorkerEvent,
+  WorkerCommand,
+} from "../types.ts";
+import { messages } from "../worker.ts";
+
+const commands = messages<WorkerCommand>();
+
+const send = (event: BenchmarkWorkerEvent) => self.postMessage(event);
+
+export function scenario(
+  name: string,
+  perform: (depth: number) => Operation<void>,
+) {
+  return main(function* () {
+    try {
+      yield* encapsulate(() =>
+        callcc<void>(function* (exit) {
+          let work = createChannel<BenchmarkOptions, never>();
+          yield* spawn(function* () {
+            for (let command of yield* each(commands)) {
+              if (command.type === "close") {
+                yield* exit();
+              } else {
+                yield* work.send(command);
+              }
+              yield* each.next();
+            }
+          });
+
+          for (let options of yield* each(work)) {
+            let times: number[] = [];
+            for (let i = 0; i < options.repeat; i++) {
+              let start = performance.now();
+
+              yield* encapsulate(() => perform(options.depth));
+
+              let time = performance.now() - start;
+              send({ type: "repeat", name, time, rep: i + 1 });
+              times.push(time);
+            }
+
+            let total = times.reduce((sum, time) => sum + time, 0);
+            let avgTime = total / times.length;
+            let result = Ok({ avgTime, reps: options.repeat });
+
+            send({ type: "done", name, result });
+
+            yield* each.next();
+          }
+        })
+      );
+    } catch (error) {
+      send({ type: "done", name, result: Err(error as Error) });
+    } finally {
+      send({ type: "close", result: Ok() });
+    }
+  });
+}

--- a/tasks/bench/types.ts
+++ b/tasks/bench/types.ts
@@ -1,0 +1,35 @@
+import { Result } from "../../lib/result.ts";
+
+export type WorkerCommand = BenchmarkOptions | Close;
+
+export interface BenchmarkOptions {
+  type: "benchmark";
+  repeat: number;
+  depth: number;
+}
+
+export interface Close {
+  type: "close";
+  result: Result<void>;
+}
+
+export type BenchmarkWorkerEvent =
+  | BenchmarkRepeatEvent
+  | BenchmarkDoneEvent
+  | Close;
+
+export interface BenchmarkRepeatEvent {
+  type: "repeat";
+  name: string;
+  rep: number;
+  time: number;
+}
+
+export interface BenchmarkDoneEvent {
+  type: "done";
+  name: string;
+  result: Result<{
+    reps: number;
+    avgTime: number;
+  }>;
+}

--- a/tasks/bench/worker.ts
+++ b/tasks/bench/worker.ts
@@ -1,0 +1,51 @@
+import {
+  createQueue,
+  each,
+  on,
+  Operation,
+  resource,
+  spawn,
+  Stream,
+} from "../../mod.ts";
+
+export interface WorkerResource<TSend, TRecv> {
+  errors: Stream<ErrorEvent, never>;
+  messageerrors: Stream<MessageEvent, never>;
+  messages: Stream<MessageEvent<TRecv>, never>;
+  postMessage(message: TSend): Operation<void>;
+}
+
+export function useWorker<TSend, TRecv>(
+  url: string,
+): Operation<WorkerResource<TSend, TRecv>> {
+  return resource(function* (provide) {
+    let worker = new Worker(url, { type: "module" });
+    try {
+      yield* provide({
+        errors: on(worker, "error"),
+        messageerrors: on(worker, "messageerror"),
+        messages: on(worker, "message"),
+        *postMessage(value) {
+          worker.postMessage(value);
+        },
+      });
+    } finally {
+      worker.terminate();
+    }
+  });
+}
+
+export function messages<T>(): Stream<T, never> {
+  return resource(function* (provide) {
+    let queue = createQueue<T, never>();
+
+    yield* spawn(function* () {
+      for (let event of yield* each(on(self, "message"))) {
+        queue.add(event.data);
+        yield* each.next();
+      }
+    });
+
+    yield* provide(queue);
+  });
+}


### PR DESCRIPTION
## Motivation

In order to maintain performance guarantees in Effection we need to have a standard by which to measure. It will not only help us improve performance, but also help to make sure we don't regress any gains that we've made.

## Approach

This adapts the [async-benchmark](https://github.com/rixtox/async-benchmark) suite developed by @rixtox for inclusion directly into the effection repository. While the content of the benchmark examples is mostly the same, it does not measure memory usage (yet). Also, instead of using a spawned process in a separate file it uses a `Worker`. This makes it easy to cancel if you want to ctrl-c for any reason.

We've wrapped Deno and a CLI around it:

```
% deno task bench --help
Task bench deno run -A tasks/bench.ts "--help"
Usage: bench [options]

Run Effection benchmarks

Options:
  -h, --help              Show help
  -V, --version           Show version
      --include <string>  include only scenarios matching REGEXP
      --exclude <string>  exclude all scenanios matching REGEXP
  -n, --repeat <number>   number of times to repeat (default: 10)
  -d, --depth <number>    number of levels of recursion to run (default: 100)
```

To run with a recursive depth of 500, do the following:

```
% deno task bench --depth 500
Task bench deno run -A tasks/bench.ts "--depth" "500"
┌──────────────────────────────────────────┐
│ Basic Recursion                          │
├────────────────────┬─────────────────────┤
│ Library            │ Avg (ms)            │
└────────────────────┴─────────────────────┘
  effection            1.956070900000001

  rxjs                 0.7305832999999993

  co                   0.4338708999999998

  async+await          0.16547500000000018
┌──────────────────────────────────────────┐
│ Recursive Events                         │
├────────────────────┬─────────────────────┤
│ Library            │ Avg (ms)            │
└────────────────────┴─────────────────────┘
  effection            489.69844580000006

  rxjs                 135.5726289

  add-event-listener   13.211841899999996
```

You can adjust the number of times that it repeats and the depth of the recursion. Each scenario is named by a file, and you can filter with the `--include` and `--exclude` regexp flags. For example, to include only the effection and rxjs, you can say:

```
% deno task bench --include '(effection|rxjs)'
Task bench deno run -A tasks/bench.ts "--include" "(effection|rxjs)"
┌─────────────────────────────────┐
│ Basic Recursion                 │
├───────────┬─────────────────────┤
│ Library   │ Avg (ms)            │
└───────────┴─────────────────────┘
  effection   0.7081123999999995

  rxjs        0.37000859999999847
┌─────────────────────────────────┐
│ Recursive Events                │
├───────────┬─────────────────────┤
│ Library   │ Avg (ms)            │
└───────────┴─────────────────────┘
  effection   158.8061377

  rxjs        120.2107459
```

run everything but the rxjs recursion scenario

```
% deno task bench --exclude rxjs.recursion
Task bench deno run -A tasks/bench.ts "--exclude" "rxjs.recursion"
┌──────────────────────────────────────────┐
│ Basic Recursion                          │
├────────────────────┬─────────────────────┤
│ Library            │ Avg (ms)            │
└────────────────────┴─────────────────────┘
  effection            0.7624042000000006

  co                   0.18677059999999948

  async+await          0.09880399999999981
┌──────────────────────────────────────────┐
│ Recursive Events                         │
├────────────────────┬─────────────────────┤
│ Library            │ Avg (ms)            │
└────────────────────┴─────────────────────┘
  effection            158.6162375

  rxjs                 120.17651679999999

  add-event-listener   3.8213539999999995
````

