### PR TITLE
Export type Result and constructors Ok(), Err()

### DIFF
--- a/lib/mod.ts
+++ b/lib/mod.ts
@@ -1,4 +1,5 @@
 export * from "./types.ts";
+export * from "./result.ts";
 export * from "./action.ts";
 export * from "./context.ts";
 export * from "./scope.ts";


### PR DESCRIPTION
## Motivation

While not in the official public API, this was exported by v3 and generally useful, so we should keep it.
