### PR TITLE
✨Add `scoped()` higher order operation

### DIFF
--- a/lib/mod.ts
+++ b/lib/mod.ts
@@ -22,3 +22,4 @@ export * from "./abort-signal.ts";
 export * from "./main.ts";
 export * from "./with-resolvers.ts";
 export * from "./async.ts";
+export * from "./scoped.ts";

--- a/lib/scoped.ts
+++ b/lib/scoped.ts
@@ -1,0 +1,31 @@
+import type { Operation } from "./types.ts";
+import { trap } from "./task.ts";
+import { createScopeInternal } from "./scope.ts";
+import { useCoroutine } from "./coroutine.ts";
+
+/**
+ * Encapsulate an operation so that no effects will persist outside of
+ * it. All active effects such as concurrent tasks and resources will be
+ * shut down, and all contexts will be restored to their values outside
+ * of the scope.
+ *
+ * @param operation - the operation to be encapsulated
+ *
+ * @returns the scoped operation
+ */
+export function scoped<T>(operation: () => Operation<T>): Operation<T> {
+  return {
+    *[Symbol.iterator]() {
+      let routine = yield* useCoroutine();
+      let original = routine.scope;
+      let [scope, destroy] = createScopeInternal(original);
+      try {
+        routine.scope = scope;
+        return yield* trap(operation);
+      } finally {
+        routine.scope = original;
+        yield* destroy();
+      }
+    },
+  };
+}

--- a/test/scoped.test.ts
+++ b/test/scoped.test.ts
@@ -1,0 +1,158 @@
+import {
+  createContext,
+  resource,
+  run,
+  scoped,
+  sleep,
+  spawn,
+  suspend,
+} from "../mod.ts";
+import { describe, expect, it } from "./suite.ts";
+
+describe("scoped", () => {
+  describe("task", () => {
+    it("shuts down after completion", () =>
+      run(function* () {
+        let didEnter = false;
+        let didExit = false;
+
+        yield* scoped(function* () {
+          yield* spawn(function* () {
+            try {
+              didEnter = true;
+              yield* suspend();
+            } finally {
+              didExit = true;
+            }
+          });
+          yield* sleep(0);
+        });
+
+        expect(didEnter).toBe(true);
+        expect(didExit).toBe(true);
+      }));
+
+    it("shuts down after error", () =>
+      run(function* () {
+        let didEnter = false;
+        let didExit = false;
+
+        try {
+          yield* scoped(function* () {
+            yield* spawn(function* () {
+              try {
+                didEnter = true;
+                yield* suspend();
+              } finally {
+                didExit = true;
+              }
+            });
+            yield* sleep(0);
+            throw new Error("boom!");
+          });
+        } catch (error) {
+          expect(error).toMatchObject({ message: "boom!" });
+          expect(didEnter).toBe(true);
+          expect(didExit).toBe(true);
+        }
+      }));
+
+    it("delimits error boundaries", () =>
+      run(function* () {
+        try {
+          yield* scoped(function* () {
+            yield* spawn(function* () {
+              throw new Error("boom!");
+            });
+            yield* suspend();
+          });
+        } catch (error) {
+          expect(error).toMatchObject({ message: "boom!" });
+        }
+      }));
+  });
+  describe("resource", () => {
+    it("shuts down after completion", () =>
+      run(function* () {
+        let status = "pending";
+        yield* scoped(function* () {
+          yield* resource<void>(function* (provide) {
+            try {
+              status = "open";
+              yield* provide();
+            } finally {
+              status = "closed";
+            }
+          });
+          yield* sleep(0);
+          expect(status).toEqual("open");
+        });
+        expect(status).toEqual("closed");
+      }));
+
+    it("shuts down after error", () =>
+      run(function* () {
+        let status = "pending";
+        try {
+          yield* scoped(function* () {
+            yield* resource<void>(function* (provide) {
+              try {
+                status = "open";
+                yield* provide();
+              } finally {
+                status = "closed";
+              }
+            });
+            yield* sleep(0);
+            expect(status).toEqual("open");
+            throw new Error("boom!");
+          });
+        } catch (error) {
+          expect((error as Error).message).toEqual("boom!");
+          expect(status).toEqual("closed");
+        }
+      }));
+
+    it("delimits error boundaries", () =>
+      run(function* () {
+        try {
+          yield* scoped(function* () {
+            yield* resource<void>(function* (provide) {
+              yield* spawn(function* () {
+                yield* sleep(0);
+                throw new Error("boom!");
+              });
+              yield* provide();
+            });
+            yield* suspend();
+          });
+        } catch (error) {
+          expect(error).toMatchObject({ message: "boom!" });
+        }
+      }));
+  });
+  describe("context", () => {
+    let context = createContext<string>("greetting", "hi");
+    it("is restored after exiting scope", () =>
+      run(function* () {
+        yield* scoped(function* () {
+          yield* context.set("hola");
+        });
+        expect(yield* context.get()).toEqual("hi");
+      }));
+
+    it("is restored after erroring", () =>
+      run(function* () {
+        try {
+          yield* scoped(function* () {
+            yield* context.set("hola");
+            throw new Error("boom!");
+          });
+        } catch (error) {
+          expect(error).toMatchObject({ message: "boom!" });
+        } finally {
+          expect(yield* context.get()).toEqual("hi");
+        }
+      }));
+  });
+});


### PR DESCRIPTION
## Motivation

One of the many overlapping concerns of `action()` and `call()` were to establish context boundaries, error boundaries, and concurency boundaries, but this was problematic because it required the creation of a new frame and thus a new iterator every time you wanted to do one of those things, so stack traces were lost. It also was problematic because sometimes you would use `call()` for an aysnc function, other times, you wanted to use it to encapsulate an operation, so when reading code you never knew why exactly `call()`/`action()` etc. were being used.

However v4 has the ability to separate all these concerns: error handling, concurrency delimiting, and context delimiting, but they are all separate functions and a lot to teach. Instead, we want a single function that we can use for encapsulating all effects.

## Approach

This introduces the `scoped()` operation which takes any operation, traps errors that may emit from it, and wraps a new internal scope around it to prevent any effects from leaking out of it.