### PR TITLE
Publish to JSR

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ permissions:
   id-token: write
 
 jobs:
-  release:
+  publish-npm:
     runs-on: ubuntu-latest
 
     steps:
@@ -41,8 +41,25 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}
 
+  publish-jsr:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: setup deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Get Version
+        id: vars
+        run: echo ::set-output name=version::$(echo ${{github.ref_name}} | sed 's/^effection-v//')
+
       - name: Build JSR
         run: deno task build:jsr ${{steps.vars.outputs.version}}
 
       - name: Publish JSR
         run: npx jsr publish --allow-dirty
+      

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,4 +62,3 @@ jobs:
 
       - name: Publish JSR
         run: npx jsr publish --allow-dirty
-      

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,4 +45,4 @@ jobs:
         run: deno task build:jsr ${{steps.vars.outputs.version}}
 
       - name: Publish JSR
-        run: npx jsr publish
+        run: npx jsr publish --allow-dirty

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,12 +32,6 @@ jobs:
           node-version: 18.x
           registry-url: https://registry.npmjs.com
 
-      - name: Build JSR
-        run: deno task build:jsr ${{steps.vars.outputs.version}}
-          
-      - name: Publish JSR
-        run: npx jsr publish
-          
       - name: Build NPM
         run: deno task build:npm ${{steps.vars.outputs.version}}
 
@@ -46,3 +40,9 @@ jobs:
         working-directory: ./build/npm
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}
+
+      - name: Build JSR
+        run: deno task build:jsr ${{steps.vars.outputs.version}}
+
+      - name: Publish JSR
+        run: npx jsr publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,4 @@
-# This workflow will install Deno then run Deno lint and test.
-# For more information see: https://github.com/denoland/setup-deno
-
-name: Release to NPM
+name: Publish
 
 on:
   push:
@@ -10,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   release:
@@ -29,17 +27,21 @@ jobs:
         run: echo ::set-output name=version::$(echo ${{github.ref_name}} | sed 's/^effection-v//')
 
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4.1.0
         with:
-          node-version: 14.x
+          node-version: 18.x
           registry-url: https://registry.npmjs.com
 
-      - name: Build
-        run: deno task build:npm $NPM_VERSION
-        env:
-          NPM_VERSION: ${{steps.vars.outputs.version}}
+      - name: Build JSR
+        run: deno task build:jsr ${{steps.vars.outputs.version}}
+          
+      - name: Publish JSR
+        run: npx jsr publish
+          
+      - name: Build NPM
+        run: deno task build:npm ${{steps.vars.outputs.version}}
 
-      - name: Publish
+      - name: Publish NPM
         run: npm publish --access=public
         working-directory: ./build/npm
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,3 @@
 # Local Netlify folder
 .netlify
 /build/
-
-# We generate jsr.json before publishing
-jsr.json

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 # Local Netlify folder
 .netlify
 /build/
+
+# We generate jsr.json before publishing
+jsr.json

--- a/deno.json
+++ b/deno.json
@@ -1,4 +1,10 @@
 {
+  "name": "@effection/effection",
+  "exports": "./mod.ts",
+  "license": "ISC",
+  "publish": {
+    "include": ["lib", "mod.ts", "README.md"]
+  },
   "lock": false,
   "tasks": {
     "test": "deno test --allow-run=deno",

--- a/deno.json
+++ b/deno.json
@@ -3,6 +3,7 @@
   "tasks": {
     "test": "deno test --allow-run=deno",
     "test:node": "deno task build:npm 0.0.0 && node test/main/node.mjs hello world",
+    "build:jsr": "deno run -A tasks/build-jsr.ts",
     "build:npm": "deno run -A tasks/build-npm.ts"
   },
   "lint": {

--- a/lib/deps.ts
+++ b/lib/deps.ts
@@ -1,2 +1,2 @@
-export { assert } from "https://deno.land/std@0.158.0/testing/asserts.ts";
-export * from "https://deno.land/x/continuation@0.1.5/mod.ts";
+export { assert } from "jsr:@std/assert@1.0.10";
+export * from "jsr:@frontside/continuation@0.1.6";

--- a/lib/each.ts
+++ b/lib/each.ts
@@ -65,7 +65,7 @@ export function each<T>(stream: Stream<T, unknown>): Operation<Iterable<T>> {
   };
 }
 
-each.next = function next() {
+each.next = function next(): Operation<void> {
   return {
     name: "each.next()",
     *[Symbol.iterator]() {

--- a/lib/ensure.ts
+++ b/lib/ensure.ts
@@ -1,4 +1,4 @@
-import { Operation } from "./types.ts";
+import type { Operation } from "./types.ts";
 import { resource } from "./instructions.ts";
 
 /**

--- a/lib/lift.ts
+++ b/lib/lift.ts
@@ -1,5 +1,5 @@
 import { shift } from "./deps.ts";
-import { type Operation } from "./types.ts";
+import type { Operation } from "./types.ts";
 
 /**
  * Convert a simple function into an {@link Operation}

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -1,5 +1,5 @@
 import { createContext } from "./context.ts";
-import { type Operation } from "./types.ts";
+import type { Operation } from "./types.ts";
 import { action } from "./instructions.ts";
 import { run } from "./run.ts";
 import { call } from "./call.ts";

--- a/lib/run/value.ts
+++ b/lib/run/value.ts
@@ -1,5 +1,5 @@
 import { type Computation, reset } from "../deps.ts";
-import { type Resolve } from "../types.ts";
+import type { Resolve } from "../types.ts";
 import { shiftSync } from "../shift-sync.ts";
 
 export function* createValue<T>(): Computation<[Resolve<T>, Computation<T>]> {

--- a/lib/signal.ts
+++ b/lib/signal.ts
@@ -3,6 +3,7 @@ import type { Stream, Subscription } from "./types.ts";
 import { createQueue, type Queue } from "./queue.ts";
 import { resource } from "./instructions.ts";
 import { createContext } from "./context.ts";
+import { type Context } from "./types.ts";
 
 /**
  * Convert plain JavaScript function calls into a {@link Stream} that can
@@ -81,7 +82,7 @@ export interface Signal<T, TClose> extends Stream<T, TClose> {
  * }
  * ```
  */
-export const SignalQueueFactory = createContext(
+export const SignalQueueFactory: Context<typeof createQueue> = createContext(
   "Signal.createQueue",
   createQueue,
 );

--- a/lib/signal.ts
+++ b/lib/signal.ts
@@ -3,7 +3,7 @@ import type { Stream, Subscription } from "./types.ts";
 import { createQueue, type Queue } from "./queue.ts";
 import { resource } from "./instructions.ts";
 import { createContext } from "./context.ts";
-import { type Context } from "./types.ts";
+import type { Context } from "./types.ts";
 
 /**
  * Convert plain JavaScript function calls into a {@link Stream} that can

--- a/tasks/build-jsr.ts
+++ b/tasks/build-jsr.ts
@@ -1,0 +1,9 @@
+await Deno.writeTextFile(
+  "jsr.json",
+  JSON.stringify({
+    name: "@effection/effection",
+    version: Deno.env.get('VERSION'),
+    exports: "./mod.ts",
+    include: ["lib", "mod.ts", "README.md"],
+  }),
+);

--- a/tasks/build-jsr.ts
+++ b/tasks/build-jsr.ts
@@ -4,12 +4,6 @@ await Deno.writeTextFile(
   new URL("../deno.json", import.meta.url),
   JSON.stringify({
     ...jsonDeno,
-    name: "@effection/effection",
     version: Deno.env.get("VERSION"),
-    exports: "./mod.ts",
-    license: "ISC",
-    publish: {
-      include: ["lib", "mod.ts", "README.md"],
-    },
   }),
 );

--- a/tasks/build-jsr.ts
+++ b/tasks/build-jsr.ts
@@ -1,9 +1,14 @@
+import jsonDeno from "../deno.json" with { type: "json" };
+
 await Deno.writeTextFile(
-  "jsr.json",
+  new URL("../deno.json", import.meta.url),
   JSON.stringify({
+    ...jsonDeno,
     name: "@effection/effection",
-    version: Deno.env.get('VERSION'),
+    version: Deno.env.get("VERSION"),
     exports: "./mod.ts",
-    include: ["lib", "mod.ts", "README.md"],
+    publish: {
+      include: ["lib", "mod.ts", "README.md"],
+    },
   }),
 );

--- a/tasks/build-jsr.ts
+++ b/tasks/build-jsr.ts
@@ -7,6 +7,7 @@ await Deno.writeTextFile(
     name: "@effection/effection",
     version: Deno.env.get("VERSION"),
     exports: "./mod.ts",
+    license: "ISC",
     publish: {
       include: ["lib", "mod.ts", "README.md"],
     },

--- a/tasks/build-npm.ts
+++ b/tasks/build-npm.ts
@@ -1,7 +1,7 @@
 import {
   build,
   emptyDir,
-} from "https://deno.land/x/dnt@0.36.0/mod.ts?pin=v123";
+} from "jsr:@deno/dnt@0.41.3";
 
 const outDir = "./build/npm";
 
@@ -21,7 +21,7 @@ await build({
   test: false,
   typeCheck: false,
   compilerOptions: {
-    lib: ["esnext", "dom"],
+    lib: ["ESNext", "DOM"],
     target: "ES2020",
     sourceMap: true,
   },
@@ -31,8 +31,8 @@ await build({
     version,
     description: "Structured concurrency and effects for JavaScript",
     license: "ISC",
+    author: "engineering@frontside.com",
     repository: {
-      author: "engineering@frontside.com",
       type: "git",
       url: "git+https://github.com/thefrontside/effection.git",
     },

--- a/tasks/build-npm.ts
+++ b/tasks/build-npm.ts
@@ -1,7 +1,4 @@
-import {
-  build,
-  emptyDir,
-} from "jsr:@deno/dnt@0.41.3";
+import { build, emptyDir } from "jsr:@deno/dnt@0.41.3";
 
 const outDir = "./build/npm";
 

--- a/test/resource.test.ts
+++ b/test/resource.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "./suite.ts";
-import { type Operation, resource, run, sleep, spawn, suspend } from "../mod.ts";
+import {
+  type Operation,
+  resource,
+  run,
+  sleep,
+  spawn,
+  suspend,
+} from "../mod.ts";
 
 type State = { status: string };
 

--- a/test/resource.test.ts
+++ b/test/resource.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "./suite.ts";
-import { Operation, resource, run, sleep, spawn, suspend } from "../mod.ts";
+import { type Operation, resource, run, sleep, spawn, suspend } from "../mod.ts";
 
 type State = { status: string };
 


### PR DESCRIPTION
## Motivation

I want to update revolution and such to e4, but I'd like to consume it from JSR. 

## Approach

1. Since we're not tracking version in deno.json, so I created a script that adds the version and other needed properties to deno.json before running `npx jsr publish`.
2. I changed `https://` imports to jsr since JSR doesn't allow these.
3. I added explicit types to eliminate "slow types"
4. I had to add `--allow-dirty` to `jsr publish` because deno.json becomes dirty after changes.
5. Upgraded dnt
