### PR TITLE
Use JSR Token instead of OIDC

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -61,4 +61,4 @@ jobs:
         run: deno task build:jsr ${{steps.vars.outputs.version}}
 
       - name: Publish JSR
-        run: npx jsr publish --allow-dirty
+        run: npx jsr publish --allow-dirty --token=${{secrets.JSR_TOKEN}}


### PR DESCRIPTION
## Motivation

OIDC is the recommended way of authenticating from GitHub Actions to JSR, but it requires that the person who triggered the workflow (i.e., the person who merged the code that triggered the workflow) be a member of the package scope in JSR. We want FrontsideJack to be the only one with scope membership, so we can't use OIDC.

## Approach

Created a token for FrontsideJack in JSR that's scoped to only publish to `effection` package, added the token as a secret to the effection repository and passing the token via `jsr publish --token`.

