### PR TITLE
Add Contrib link to the header

### DIFF
--- a/www/routes/index-route.tsx
+++ b/www/routes/index-route.tsx
@@ -26,6 +26,7 @@ export function indexRoute(): SitemapRoute<JSXElement> {
           navLinks={[
             <a href="/docs/installation">Guides</a>,
             <a href="https://deno.land/x/effection/mod.ts">API</a>,
+            <a href="/contrib">Contrib</a>,
             <a
               class="flex flex-row"
               href="https://github.com/thefrontside/effection"


### PR DESCRIPTION
## Motivation

I forgot to include a link to the contrib page in #948 

## Approach

Add missing link to the header
