### PR TITLE
Allow yielding a chain of `then` on `Task`

### DIFF
--- a/lib/run/task.ts
+++ b/lib/run/task.ts
@@ -115,7 +115,6 @@ export function createTask<T>(
             });
           }
         },
-        // then: (...args) => getHaltPromise().then(...args),
         then: async <Result1=void, Result2=never>(onfulfilled?: ThenFulfilledType<void, Result1>, onrejected?: CatchType<Result2>) => {
           type NewResult = Result1 | Result2;
           const newPromise = getHaltPromise().then(onfulfilled, onrejected);

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -53,7 +53,30 @@ export interface Operation<T> {
  * things, if the operation resolves synchronously, it will continue within the
  * same tick of the run loop.
  */
-export interface Future<T> extends Promise<T>, Operation<T> {}
+export interface Future<T> extends Promise<T>, Operation<T> {
+  /**
+   * Attaches callbacks for the resolution and/or rejection of the Promise.
+   * @param onfulfilled The callback to execute when the Promise is resolved.
+   * @param onrejected The callback to execute when the Promise is rejected.
+   * @returns A Promise for the completion of which ever callback is executed.
+   */
+  then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): Future<TResult1 | TResult2>;
+
+  /**
+   * Attaches a callback for only the rejection of the Promise.
+   * @param onrejected The callback to execute when the Promise is rejected.
+   * @returns A Promise for the completion of the callback.
+   */
+  catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): Future<T | TResult>;
+
+  /**
+   * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
+   * resolved value cannot be modified from the callback.
+   * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
+   * @returns A Promise for the completion of the callback.
+   */
+  finally(onfinally?: (() => void) | undefined | null): Future<T>;
+}
 
 /**
  * A handle to a concurrently running operation that lets you either use the
@@ -139,7 +162,7 @@ export interface Task<T> extends Future<T> {
    * children.
    *
    * Any errors raised by the `halt()` operation only represent problems that
-   * occured during the teardown of the task. In other words, `halt()` can
+   * occurred during the teardown of the task. In other words, `halt()` can
    * succeed even if the task failed.
    *
    * @returns a future that only resolves when all shutdown associated with this

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -27,6 +27,24 @@ describe("run()", () => {
     expect(result).toEqual(67);
   });
 
+  it("can await a task 'then'", () => {
+    let result = run(function* () {
+      return yield* Promise.resolve(12);
+    });
+    const plusOne = result.then((value) => value + 1);
+    expect(plusOne).resolves.toEqual(13);
+  });
+
+  it("can yield a task 'then'", async () => {
+    let result = run(function* () {
+      return yield* Promise.resolve(12);
+    });
+    const plusOne = result.then((value) => value + 1);
+    await expect(run(function* () {
+      return yield* plusOne;
+    })).resolves.toEqual(13);
+  });
+
   it("rejects generator if subtask promise fails", async () => {
     let error = new Error("boom");
     let task = run(function* () {


### PR DESCRIPTION
## Motivation

There are cases where you need to do the following steps:
1. Create a `Task` (using `run`)
2. Do some computation on the `Task` using `then`
3. `yield` the result of the task

example that shows how this can be used to:
- implement #946 without requiring to use `async/await` explicitly anywhere
- easily chain things without having to awkwardly wrap results with `call` as in #944  
```ts
class Foo {
    task: Future<number>;
    
    constructor() {
       this.task = run(() => ...).then(val => val+1);
    }

    *doWork() {
        yield* this.task;
    }
}
```

This was a bit tedious to do previously (see #944), and this PR simplifies this case a bit by making that calling `then` on a `Task` returns a `Future` (which you can yield) instead of just a `Promise`

## Approach & Alternate Designs

You can find some background in #944  and inline comments in this PR

### TODOs and Open Questions

- [ ] Do we want to make creating `Future`s more easier in general? This has a chance of overlapping conceptually with the `pipe` concept that was recently removed, and also overlaps with the idea of `call` (although `call` returns an `Operation` instead of a `Future`)
- [ ] Is there a way to make that `then` returns a `Task` instead of a `Future`? I tried this initially, but ran into some complications: https://github.com/thefrontside/effection/issues/944#issuecomment-2564596508