### PR TITLE
Fix markdown validation error in Yielded jsdoc

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -280,7 +280,7 @@ export interface Context<T> extends Operation<T> {
 /**
  * Unwrap the type of an `Operation`.
  * Analogous to the built in [`Awaited`](https://www.typescriptlang.org/docs/handbook/utility-types.html#awaitedtype) type.
- * Yielded<Operation<T>> === T
+ * `Yielded<Operation<T>> === T`
  */
 export type Yielded<T extends Operation<unknown>> = T extends
   Operation<infer TYield> ? TYield


### PR DESCRIPTION
## Motivation

I spent too much time figuring out how to work around this downstream. The correct thing to do is to fix the markdown here so I don't have to deal with it in the new website.

## Approach

```diff
- Yielded<Operation<T>> === T
+ `Yielded<Operation<T>> === T`
```
