### PR TITLE
Use JSR link for API instead Deno.Land

### DIFF
--- a/www/docs/actions.mdx
+++ b/www/docs/actions.mdx
@@ -268,5 +268,5 @@ effects.
 [cleanup]: ./operations#cleanup
 [scope]: ./scope
 [spawn-suspend]: ./spawn#suspend
-[action]: https://deno.land/x/effection/mod.ts?s=action
-[all]: https://deno.land/x/effection/mod.ts?s=all
+[action]: https://jsr.io/@effection/effection/doc/~/action
+[all]: https://jsr.io/@effection/effection/doc/~/all

--- a/www/docs/async-rosetta-stone.mdx
+++ b/www/docs/async-rosetta-stone.mdx
@@ -236,9 +236,9 @@ To convert an `AsyncIterator` to a `Subscription`, use the
 let subscription = subscribe(asyncIterator);
 ```
 
-[call]: https://deno.land/x/effection/mod.ts?s=call
-[run]: https://deno.land/x/effection/mod.ts?s=run
-[scope-run]: https://deno.land/x/effection/mod.ts?s=Scope#method_run_0
-[each]: https://deno.land/x/effection/mod.ts?s=each
-[stream]: https://deno.land/x/effection/mod.ts?s=stream
-[subscribe]: https://deno.land/x/effection/mod.ts?s=subscribe
+[call]: https://jsr.io/@effection/effection/doc/~/call
+[run]: https://jsr.io/@effection/effection/doc/~/run
+[scope-run]: https://jsr.io/@effection/effection/doc/~/Scope#method_run_0
+[each]: https://jsr.io/@effection/effection/doc/~/each
+[stream]: https://jsr.io/@effection/effection/doc/~/stream
+[subscribe]: https://jsr.io/@effection/effection/doc/~/subscribe

--- a/www/docs/collections.mdx
+++ b/www/docs/collections.mdx
@@ -387,14 +387,14 @@ targets in the next section.
 [async-iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncIterator
 [async-iteration-protocols]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_async_iterator_and_async_iterable_protocols
 [asynchronous iterators]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of
-[operation]: https://deno.land/x/effection/mod.ts?s=Operation
-[subscription]: https://deno.land/x/effection/mod.ts?s=Subscription
-[stream]: https://deno.land/x/effection/mod.ts?s=Stream
-[channel]: https://deno.land/x/effection/mod.ts?s=Channel
-[signal]: https://deno.land/x/effection/mod.ts?s=Signal
-[createSignal]: https://deno.land/x/effection/mod.ts?s=createSignal
+[operation]: https://jsr.io/@effection/effection/doc/~/Operation
+[subscription]: https://jsr.io/@effection/effection/doc/~/Subscription
+[stream]: https://jsr.io/@effection/effection/doc/~/Stream
+[channel]: https://jsr.io/@effection/effection/doc/~/Channel
+[signal]: https://jsr.io/@effection/effection/doc/~/Signal
+[createSignal]: https://jsr.io/@effection/effection/doc/~/createSignal
 [fp-ts.pipe]: https://gcanti.github.io/fp-ts/modules/function.ts.html#pipe
 [lodash.flow]: https://lodash.com/docs/4.17.15#flow
 [close-event]: https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent
 [event-target]: https://developer.mozilla.org/en-US/docs/Web/API/EventTarget
-[on]: https://deno.land/x/effection/mod.ts?s=on
+[on]: https://jsr.io/@effection/effection/doc/~/on

--- a/www/docs/errors.mdx
+++ b/www/docs/errors.mdx
@@ -164,4 +164,4 @@ main(function*() {
 ```
 
 [Resource]: ./resources
-[task]: https://deno.land/x/effection/mod.ts?s=Task
+[task]: https://jsr.io/@effection/effection/doc/~/Task

--- a/www/docs/events.mdx
+++ b/www/docs/events.mdx
@@ -72,6 +72,6 @@ await main(function*() {
 
 [wscode]: https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent
 [childprocess]: https://nodejs.org/api/child_process.html#child_process_class_childprocess
-[once]: https://deno.land/x/effection/mod.ts?s=once
-[on]: https://deno.land/x/effection/mod.ts?s=on
+[once]: https://jsr.io/@effection/effection/doc/~/once
+[on]: https://jsr.io/@effection/effection/doc/~/on
 [event-target]: https://developer.mozilla.org/en-US/docs/Web/API/EventTarget

--- a/www/docs/installation.mdx
+++ b/www/docs/installation.mdx
@@ -24,7 +24,7 @@ yarn add effection
 Effection has first class support for Deno because it is developed with [Deno](https://deno.land). Releases are published to [https://deno.land/x/effection](https://deno.land/x/effection). For example, to import the `main()` function:
 
 ```ts
-import { main } from "https://deno.land/x/effection/mod.ts";
+import { main } from "https://jsr.io/@effection/effection/doc";
 ```
 
 > 💡 If you're curious how we keep NPM/YARN and Deno packages in-sync, you can [checkout the blog post on how publish Deno packages to NPM.][deno-npm-publish].

--- a/www/docs/operations.mdx
+++ b/www/docs/operations.mdx
@@ -266,6 +266,6 @@ the programmer free to not worry about it.
 [async function]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function
 [promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise
 [spawn-suspend]: ./spawn#suspend
-[run]: https://deno.land/x/effection/mod.ts?s=run
-[suspend]: https://deno.land/x/effection/mod.ts?s=suspend
-[ensure]: https://deno.land/x/effection/mod.ts?s=ensure
+[run]: https://jsr.io/@effection/effection/doc/~/run
+[suspend]: https://jsr.io/@effection/effection/doc/~/suspend
+[ensure]: https://jsr.io/@effection/effection/doc/~/ensure

--- a/www/docs/resources.mdx
+++ b/www/docs/resources.mdx
@@ -179,6 +179,6 @@ Resources allow us to create powerful, reusable abstractions which are also able
 to clean up after themselves.
 
 [tasks]: /docs/guides/tasks
-[operation]: https://deno.land/x/effection/mod.ts?s=Operation
-[resource]: https://deno.land/x/effection/mod.ts?s=resource
-[ensure]: https://deno.land/x/effection/mod.ts?s=ensure
+[operation]: https://jsr.io/@effection/effection/doc/~/Operation
+[resource]: https://jsr.io/@effection/effection/doc/~/resource
+[ensure]: https://jsr.io/@effection/effection/doc/~/ensure

--- a/www/docs/scope.mdx
+++ b/www/docs/scope.mdx
@@ -350,7 +350,7 @@ Whenever you use `createScope()`, it is important that you `await` the
 destruction operation when the scope is no longer needed since it will not
 be destroyed implicitly.
 
-[spawn]: https://deno.land/x/effection/mod.ts?s=spawn
-[use-abort-signal]: https://deno.land/x/effection/mod.ts?s=useAbortSignal
-[scope]: https://deno.land/x/effection/mod.ts?s=Scope
-[create-scope]: https://deno.land/x/effection/mod.ts?s=createScope
+[spawn]: https://jsr.io/@effection/effection/doc/~/spawn
+[use-abort-signal]: https://jsr.io/@effection/effection/doc/~/useAbortSignal
+[scope]: https://jsr.io/@effection/effection/doc/~/Scope
+[create-scope]: https://jsr.io/@effection/effection/doc/~/createScope

--- a/www/docs/spawn.mdx
+++ b/www/docs/spawn.mdx
@@ -204,5 +204,5 @@ You can learn more about this in the [scope guide](./scope).
 
 [structured concurrency]: https://vorpus.org/blog/notes-on-structured-concurrency-or-go-statement-considered-harmful/
 [express]: https://expressjs.org
-[scope.run]: https://deno.land/x/effection/mod.ts?s=Scope#method_run_0
-[Operation]: https://deno.land/x/effection/mod.ts?s=Operation
+[scope.run]: https://jsr.io/@effection/effection/doc/~/Scope#method_run_0
+[Operation]: https://jsr.io/@effection/effection/doc/~/Operation

--- a/www/docs/typescript.mdx
+++ b/www/docs/typescript.mdx
@@ -89,4 +89,4 @@ it and expect to receive a number.
 Now anybody using your operation won't have any doubt about what it is and how
 they can use it.
 
-[operation]: https://deno.land/x/effection/mod.ts?s=Operation
+[operation]: https://jsr.io/@effection/effection/doc/~/Operation

--- a/www/routes/docs-route.tsx
+++ b/www/routes/docs-route.tsx
@@ -47,7 +47,7 @@ export function docsRoute(docs: Docs): SitemapRoute<JSXElement> {
         <AppHtml
           navLinks={[
             <a href="/docs/installation">Guides</a>,
-            <a href="https://deno.land/x/effection/mod.ts">API</a>,
+            <a href="https://jsr.io/@effection/effection/doc">API</a>,
             <a
               class="flex flex-row"
               href="https://github.com/thefrontside/effection"

--- a/www/routes/index-route.tsx
+++ b/www/routes/index-route.tsx
@@ -25,7 +25,7 @@ export function indexRoute(): SitemapRoute<JSXElement> {
         <AppHtml
           navLinks={[
             <a href="/docs/installation">Guides</a>,
-            <a href="https://deno.land/x/effection/mod.ts">API</a>,
+            <a href="https://jsr.io/@effection/effection/doc">API</a>,
             <a
               class="flex flex-row"
               href="https://github.com/thefrontside/effection"
@@ -84,7 +84,7 @@ export function indexRoute(): SitemapRoute<JSXElement> {
                     </a>
                     <a
                       class="col-span-6 md:col-span-2 p-2 lg:col-span-1 text-md text-blue-900 bg-white hover:bg-blue-100 transition border-blue-900 border-solid border-2 w-full rounded md:px-4"
-                      href="https://deno.land/x/effection/mod.ts"
+                      href="https://jsr.io/@effection/effection/doc"
                     >
                       API Reference
                     </a>


### PR DESCRIPTION
## Motivation

The current link to the documentation causes the entrypoint to get downloaded instead of showing documentation. This prevents all doc links from working. JSR is more accessible to Node users and has nice documentation.

## Approach

I changed all of the links to point to https://jsr.io/@effection/effection/doc
