### PR TITLE
Add missing tag from v4

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,7 @@ jobs:
         run: deno task build:npm ${{steps.vars.outputs.version}}
 
       - name: Publish NPM
-        run: npm publish --access=public
+        run: npm publish --access=public --tag=next
         working-directory: ./build/npm
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}


### PR DESCRIPTION
## Motivation

v4 alphas keep overriding v3 stable releases because npm publish is missing --tag=next 

## Approach

Add the lost argument