### PR TITLE
🎒backport advanced scope helpers from v4 -> v3

### DIFF
--- a/lib/run/scope.ts
+++ b/lib/run/scope.ts
@@ -70,6 +70,22 @@ export function createScope(frame?: Frame): [Scope, () => Future<void>] {
       parent.context[key] = value;
       return value;
     },
+    expect<T>(context: Context<T>): T {
+      let value = scope.get(context);
+      if (typeof value === "undefined") {
+        let error = new Error(context.key);
+        error.name = `MissingContextError`;
+        throw error;
+      }
+      return value;
+    },
+    delete<T>(context: Context<T>): boolean {
+      let { key } = context;
+      return delete parent.context[key];
+    },
+    hasOwn<T>(context: Context<T>): boolean {
+      return !!Reflect.getOwnPropertyDescriptor(parent.context, context.key);
+    },
   });
 
   parent.enter();

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -208,6 +208,29 @@ export interface Scope {
    * @returns - the value that was set
    */
   set<T>(context: Context<T>, value: T): T;
+
+  /**
+   * Get a {@link Context} value from outside of an operation, and throw
+   * a `MissingContextError` if this context is not specified for this scope.
+   *
+   * @param context - the context to get
+   * @returns the value of that context in this scope if it exists
+   */
+  expect<T>(context: Context<T>): T;
+
+  /**
+   * Remove a {@link Context} value from this scope.
+   *
+   * @param context - the context to delete
+   */
+  delete<T>(context: Context<T>): boolean;
+
+  /**
+   * Check if scope has its own unique value for `context`.
+   *
+   * @returns `true` if scope has its own context, `false` if context is not present, or inherited from its parent.
+   */
+  hasOwn<T>(context: Context<T>): boolean;
 }
 
 /**

--- a/test/scope.test.ts
+++ b/test/scope.test.ts
@@ -4,6 +4,7 @@ import {
   createScope,
   resource,
   run,
+  spawn,
   suspend,
   useScope,
 } from "../mod.ts";
@@ -98,7 +99,7 @@ describe("Scope", () => {
     });
   });
 
-  it("can get and set a context programatically", async () => {
+  it("can get and set and delete a context programatically", async () => {
     let context = createContext<string>("aString");
     let [scope] = createScope();
     expect(scope.get(context)).toEqual(void 0);
@@ -107,6 +108,44 @@ describe("Scope", () => {
     await expect(scope.run(() => context.expect())).resolves.toEqual(
       "Hello World!",
     );
+
+    scope.delete(context);
+
+    expect(scope.get(context)).toEqual(void 0);
+  });
+
+  it("can expect() a context and raise an error if not defined", () => {
+    let [scope] = createScope();
+    let msg = createContext<string>("msg.context");
+
+    expect(() => scope.expect(msg)).toThrow(/msg\.context/);
+
+    scope.set(msg, "hello world");
+
+    expect(scope.expect(msg)).toEqual("hello world");
+  });
+
+  it("can find out if a value is local to this context", async () => {
+    let context = createContext<string>("message");
+    let [parent] = createScope();
+    parent.set(context, "Hello World!");
+
+    await parent.run(function* () {
+      let child = yield* spawn(function* () {
+        let scope = yield* useScope();
+        return scope.hasOwn(context);
+      });
+      expect(yield* child).toEqual(false);
+    });
+
+    await parent.run(function* () {
+      let child = yield* spawn(function* () {
+        let scope = yield* useScope();
+        scope.set(context, "Hello Planet!");
+        return scope.hasOwn(context);
+      });
+      expect(yield* child).toEqual(true);
+    });
   });
 
   it("propagates uncaught errors within a scope", async () => {


### PR DESCRIPTION
## Motivation

In v4, the `Scope` interface got a little more powerful 💪💪

Specifically, it got an `expect()` helper to throw an error if a context is missing. It's the scope equivalent of `Context.expect()`. Also, there is a `hasOwn()` helper which is necessary for some cases where there needs to be a single context value per task.

Finally, there is `delete()` which is very rarely used, but rounds out the API, and since it's present in v4, it's probably a good idea to add it.

## Approach

Bring the methods on over, along with some tests.