### PR TITLE
Effect benchmark

### DIFF
--- a/tasks/bench.ts
+++ b/tasks/bench.ts
@@ -25,9 +25,7 @@ import { Cell, Row, Table } from "jsr:@cliffy/table@1.0.0-rc.7";
 await main(function* (args) {
   let options = parser()
     .name("bench")
-    .description(
-      "Run Effection benchmarks",
-    )
+    .description("Run Effection benchmarks")
     .version("0.0.0")
     .options({
       include: {
@@ -58,7 +56,7 @@ await main(function* (args) {
   for (let scenario of filter(scenarios, { include, exclude })) {
     tasks.push(
       yield* spawn(() =>
-        runBenchmark(scenario, { ...options, type: "benchmark" })
+        runBenchmark(scenario, { ...options, type: "benchmark" }),
       ),
     );
   }
@@ -66,6 +64,7 @@ await main(function* (args) {
   let results = yield* all(tasks);
 
   let events = results.filter((result) => result.name.match("events"));
+  let startups = results.filter((result) => result.name.match("startup"));
   let recursion = results.filter((result) => result.name.match("recursion"));
 
   if (events.length == 0 && recursion.length === 0) {
@@ -73,18 +72,27 @@ await main(function* (args) {
     return;
   }
 
-  let rows = [];
+  let rows: Row[] = [];
+
+  let cells = ["Library", "Avg (ms)", "Avg Startup Time (ms)"];
+  let cols = cells.length;
 
   if (recursion.length > 0) {
-    rows.push(Row.from([new Cell("Basic Recursion").colSpan(2).border()]));
-    rows.push(Row.from<Cell | string>(["Library", "Avg (ms)"]).border());
+    rows.push(Row.from([new Cell("Basic Recursion").colSpan(cols).border()]));
+    rows.push(Row.from<Cell | string>(cells).border());
     rows.push(...recursion.map((event) => Row.from(toTableRow(event))));
   }
 
   if (events.length > 0) {
-    rows.push(Row.from([new Cell("Recursive Events").colSpan(2).border()]));
-    rows.push(Row.from<Cell | string>(["Library", "Avg (ms)"]).border());
+    rows.push(Row.from([new Cell("Recursive Events").colSpan(cols).border()]));
+    rows.push(Row.from<Cell | string>(cells).border());
     rows.push(...events.map((event) => Row.from(toTableRow(event))));
+  }
+
+  if (startups.length > 0) {
+    rows.push(Row.from([new Cell("Start-up Time").colSpan(cols).border()]));
+    rows.push(Row.from<Cell | string>(cells).border());
+    rows.push(...startups.map((event) => Row.from(toTableRow(event))));
   }
 
   Table.from(rows).render();
@@ -150,8 +158,8 @@ function filter(
 function toTableRow(event: BenchmarkDoneEvent): string[] {
   let [name = event.name] = event.name.split(".");
   if (event.result.ok) {
-    let { avgTime } = event.result.value;
-    return [name, String(avgTime)];
+    let { avgTime, avgStartupTime } = event.result.value;
+    return [name, String(avgTime), String(avgStartupTime)];
   } else {
     return [name, "❌"];
   }

--- a/tasks/bench/scenarios.ts
+++ b/tasks/bench/scenarios.ts
@@ -8,4 +8,6 @@ export default [
   "./scenarios/rxjs.events.ts",
   "./scenarios/add-event-listener.events.ts",
   "./scenarios/effect.events.ts",
+  "./scenarios/effection.startup.ts",
+  "./scenarios/effect.startup.ts",
 ].map((mod) => import.meta.resolve(mod));

--- a/tasks/bench/scenarios/effect.recursion.ts
+++ b/tasks/bench/scenarios/effect.recursion.ts
@@ -3,7 +3,7 @@ import { call } from "../../../mod.ts";
 import { scenario } from "./scenario.ts";
 
 await scenario("effect.recursion", (depth) =>
-  call(() => Effect.runPromise(recurse(depth)))
+  call(() => Effect.runPromise(recurse(depth))),
 );
 
 function recurse(depth: number): Effect.Effect<void, never, never> {

--- a/tasks/bench/scenarios/effect.startup.ts
+++ b/tasks/bench/scenarios/effect.startup.ts
@@ -1,12 +1,20 @@
-import { Effect } from "npm:effect";
-import { call } from "../../../mod.ts";
+import { Effect, Fiber } from "npm:effect";
+import { call, ensure } from "../../../mod.ts";
 import { scenario } from "./scenario.ts";
 
 await scenario("effect.startup", function* (_, exit) {
+  let start = performance.now();
+
   const startup = Effect.gen(function* () {
-    exit(performance.now());
+    exit(performance.now() - start);
     yield* Effect.promise(() => Promise.resolve());
   });
 
-  return yield* call(() => Effect.runPromise(startup));
+  const fiber = Effect.runFork(startup);
+
+  yield* ensure(function* () {
+    yield* call(() => Effect.runPromise(Fiber.interrupt(fiber)));
+  });
+
+  return yield* call(() => Effect.runPromise(Fiber.join(fiber)));
 });

--- a/tasks/bench/scenarios/effect.startup.ts
+++ b/tasks/bench/scenarios/effect.startup.ts
@@ -1,0 +1,12 @@
+import { Effect } from "npm:effect";
+import { call } from "../../../mod.ts";
+import { scenario } from "./scenario.ts";
+
+await scenario("effect.startup", function* (_, exit) {
+  const startup = Effect.gen(function* () {
+    exit(performance.now());
+    yield* Effect.promise(() => Promise.resolve());
+  });
+
+  return yield* call(() => Effect.runPromise(startup));
+});

--- a/tasks/bench/scenarios/effection.startup.ts
+++ b/tasks/bench/scenarios/effection.startup.ts
@@ -1,0 +1,11 @@
+import { call, type Operation } from "../../../mod.ts";
+import { scenario } from "./scenario.ts";
+
+await scenario("effection.startup", function* (_, exit) {
+  function* startup(): Operation<void> {
+    exit(performance.now());
+    yield* call(() => Promise.resolve());
+  }
+
+  return yield* startup();
+});

--- a/tasks/bench/scenarios/effection.startup.ts
+++ b/tasks/bench/scenarios/effection.startup.ts
@@ -2,8 +2,10 @@ import { call, type Operation } from "../../../mod.ts";
 import { scenario } from "./scenario.ts";
 
 await scenario("effection.startup", function* (_, exit) {
+  let start = performance.now();
+
   function* startup(): Operation<void> {
-    exit(performance.now());
+    exit(performance.now() - start);
     yield* call(() => Promise.resolve());
   }
 

--- a/tasks/bench/scenarios/scenario.ts
+++ b/tasks/bench/scenarios/scenario.ts
@@ -71,7 +71,7 @@ export function scenario(
               times.push(time);
 
               if (entryTime) {
-                entryTimes.push(entryTime - start);
+                entryTimes.push(entryTime);
               }
             }
 

--- a/tasks/bench/scenarios/scenario.ts
+++ b/tasks/bench/scenarios/scenario.ts
@@ -2,11 +2,14 @@ import { callcc } from "../../../lib/callcc.ts";
 import { Err, Ok } from "../../../lib/result.ts";
 import { encapsulate } from "../../../lib/task.ts";
 import {
+  call,
   createChannel,
   each,
   main,
   type Operation,
+  race,
   spawn,
+  withResolvers,
 } from "../../../mod.ts";
 import type {
   BenchmarkOptions,
@@ -21,7 +24,7 @@ const send = (event: BenchmarkWorkerEvent) => self.postMessage(event);
 
 export function scenario(
   name: string,
-  perform: (depth: number) => Operation<void>,
+  perform: (depth: number, exit: (time: number) => void) => Operation<void>,
 ) {
   return main(function* () {
     try {
@@ -41,25 +44,52 @@ export function scenario(
 
           for (let options of yield* each(work)) {
             let times: number[] = [];
+            let entryTimes: number[] = [];
+
             for (let i = 0; i < options.repeat; i++) {
               let start = performance.now();
 
-              yield* encapsulate(() => perform(options.depth));
+              const exit = withResolvers<number | null>();
+
+              const task = yield* spawn(function* () {
+                yield* encapsulate(() => perform(options.depth, exit.resolve));
+              });
+
+              // Avoid blocking indefintely because not all benchmarks need the exit function
+              yield* race([
+                exit.operation,
+                call(function* () {
+                  yield* task;
+                  exit.resolve(null);
+                }),
+              ]);
+
+              const entryTime = yield* exit.operation;
 
               let time = performance.now() - start;
               send({ type: "repeat", name, time, rep: i + 1 });
               times.push(time);
+
+              if (entryTime) {
+                entryTimes.push(entryTime - start);
+              }
             }
 
             let total = times.reduce((sum, time) => sum + time, 0);
             let avgTime = total / times.length;
-            let result = Ok({ avgTime, reps: options.repeat });
+
+            let startupTime = entryTimes.reduce((sum, time) => sum + time, 0);
+
+            let avgStartupTime =
+              entryTimes.length > 0 ? startupTime / entryTimes.length : 0;
+
+            let result = Ok({ avgTime, avgStartupTime, reps: options.repeat });
 
             send({ type: "done", name, result });
 
             yield* each.next();
           }
-        })
+        }),
       );
     } catch (error) {
       send({ type: "done", name, result: Err(error as Error) });

--- a/tasks/bench/types.ts
+++ b/tasks/bench/types.ts
@@ -31,5 +31,6 @@ export interface BenchmarkDoneEvent {
   result: Result<{
     reps: number;
     avgTime: number;
+    avgStartupTime: number;
   }>;
 }


### PR DESCRIPTION
## Motivation

Compares start-up times of effect and effection

## Approach

Exit operation early and capture time at moment of exit

### Alternate Designs

Use an annotation context provider that can capture more than just start-up time

## Screenshots

<img width="682" alt="Screenshot 2025-03-06 at 15 09 23" src="https://github.com/user-attachments/assets/e762dcd7-a94b-45ed-96d2-f785ac689ac1" />

