### PR TITLE
🎒backport `each()` 🐛 fixes to v3

### DIFF
--- a/lib/each.ts
+++ b/lib/each.ts
@@ -1,5 +1,8 @@
 import type { Operation, Stream, Subscription } from "./types.ts";
 import { createContext } from "./context.ts";
+import { useScope } from "./run/scope.ts";
+import { resource, spawn } from "./instructions.ts";
+import { withResolvers } from "./with-resolvers.ts";
 
 /**
  * Consume an effection stream using a simple for-of loop.
@@ -28,32 +31,39 @@ import { createContext } from "./context.ts";
 export function each<T>(stream: Stream<T, unknown>): Operation<Iterable<T>> {
   return {
     *[Symbol.iterator]() {
-      let subscription = yield* stream;
-      let current = yield* subscription.next();
-      let stack = yield* EachStack.get();
-      if (!stack) {
-        stack = yield* EachStack.set([]);
-      }
+      let scope = yield* useScope();
+      let stack = scope.hasOwn(EachStack)
+        ? scope.expect(EachStack)
+        : yield* EachStack.set([]);
 
-      let context: EachLoop<T> = { subscription, current };
+      let loop = yield* resource<EachLoop<T>>(function* (provide) {
+        let subscription = yield* stream;
+        let current = yield* subscription.next();
+        let { operation: finished, resolve: finish } = withResolvers<void>();
 
-      stack.push(context);
+        yield* spawn(() => provide({ current, subscription, finish }));
+
+        yield* finished;
+      });
+
+      stack.push(loop);
 
       let iterator: Iterator<T> = {
         next() {
-          if (context.stale) {
+          if (loop.stale) {
             let error = new Error(
               `for each loop did not use each.next() operation before continuing`,
             );
             error.name = "IterationError";
             throw error;
           } else {
-            context.stale = true;
-            return context.current;
+            loop.stale = true;
+            return loop.current;
           }
         },
         return() {
-          stack!.pop();
+          stack.pop();
+          loop.finish();
           return { done: true, value: void 0 };
         },
       };
@@ -89,6 +99,7 @@ each.next = function next(): Operation<void> {
 interface EachLoop<T> {
   subscription: Subscription<T, unknown>;
   current: IteratorResult<T>;
+  finish(): void;
   stale?: true;
 }
 

--- a/test/each.test.ts
+++ b/test/each.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, it } from "./suite.ts";
-import { createChannel, each, run, spawn, suspend } from "../mod.ts";
+import {
+  createChannel,
+  createQueue,
+  each,
+  resource,
+  run,
+  spawn,
+  type Stream,
+  suspend,
+} from "../mod.ts";
 
 describe("each", () => {
   it("can be used to iterate a stream", async () => {
@@ -87,4 +96,38 @@ describe("each", () => {
       "MissingContextError",
     );
   });
+
+  it("closes the stream after exiting from the loop", async () => {
+    let state = { status: "pending" };
+    let stream: Stream<string, void> = resource(function* (provide) {
+      try {
+        state.status = "active";
+        yield* provide(yield* sequence("one", "two"));
+      } finally {
+        state.status = "closed";
+      }
+    });
+
+    await run(function* () {
+      yield* spawn(function* () {
+        for (let _ of yield* each(stream)) {
+          expect(state.status).toEqual("active");
+          yield* each.next();
+        }
+      });
+    });
+
+    expect(state.status).toEqual("closed");
+  });
 });
+
+function sequence(...values: string[]): Stream<string, void> {
+  return resource(function* (provide) {
+    let q = createQueue<string, void>();
+    for (let value of values) {
+      q.add(value);
+    }
+    q.close();
+    yield* provide(q);
+  });
+}


### PR DESCRIPTION
## Motivation

There were two problems with `each()` in v3 that were fixed in v4.

1. EachLoops are stacked so that you can iterate within an iteration, within an iteration, and so on. This is appropriate when all of the iterations are part of the same coroutine because they will be executed in serial. In other words, you can only be in a single iteration at a time. The problem arises when you have the scope of one coroutine inheriting from the scope of another, but those coroutines are executing concurrently. This can result in the loop stack being changed during the middle of an execution and all kinds of mayhem can ensue.
2. The subscription for an each loop is never being released because it is not running in its own resource. That means if you have an iteration within an iteration, it pile up subscriptions which could lead to memory leaks.

## Approach

This makes sure that every unique scope (coroutine) has its own stack of each loops, and that they run in a resource which is exited when the loop is completed.