### PR TITLE
🎒bring Context.with() to v3

### DIFF
--- a/lib/context.ts
+++ b/lib/context.ts
@@ -1,4 +1,4 @@
-import type { Context } from "./types.ts";
+import type { Context, Operation } from "./types.ts";
 import { create } from "./run/create.ts";
 import { useScope } from "./run/scope.ts";
 
@@ -14,6 +14,19 @@ export function createContext<T>(key: string, defaultValue?: T): Context<T> {
       return scope.set(context, value);
     },
     expect,
+    *with<R>(value: T, operation: (value: T) => Operation<R>): Operation<R> {
+      let scope = yield* useScope();
+      let original = scope.hasOwn(context) ? scope.get(context) : undefined;
+      try {
+        return yield* operation(scope.set(context, value));
+      } finally {
+        if (typeof original === "undefined") {
+          scope.delete(context);
+        } else {
+          scope.set(context, original);
+        }
+      }
+    },
     [Symbol.iterator]() {
       console.warn(
         `⚠️ using a context (${key}) directly as an operation is deprecated. Use context.expect() instead`,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -298,6 +298,22 @@ export interface Context<T> extends Operation<T> {
    * @return an operation providing the context value in the current scope.
    */
   expect(): Operation<T>;
+
+  /**
+   * Evaluate an operation using `value` for the context. Once the operation is completed, the context
+   * will be reverted to its original value, or removed if it was not present originally.
+   *
+   * @example
+   * ```ts
+   * let user = yield* login();
+   * yield* UserContext.with(user, function*() {
+   *   //do stuff
+   * })
+   * ```
+   *
+   * @returns the result of evaluating the operation.
+   */
+  with<R>(value: T, operation: (value: T) => Operation<R>): Operation<R>;
 }
 
 /**

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -13,6 +13,21 @@ describe("context", () => {
     ).toEqual(3);
   });
 
+  it("can delimit the bounds of a context within a single scope", async () => {
+    let values = await run(function* () {
+      let before = yield* numbers.get();
+
+      let within = yield* numbers.with(22, function* () {
+        return yield* numbers.get();
+      });
+
+      let after = yield* numbers.get();
+      return [before, within, after];
+    });
+
+    expect(values).toEqual([3, 22, 3]);
+  });
+
   it("can be set within a given scope, but reverts after", async () => {
     let values = await run(function* () {
       let before = yield* numbers.expect();


### PR DESCRIPTION
## Motivation

The v4 Context.with() operation is a real pleasure to work with. It allows you to delimit the boundaries of a scope within a single iterator. Where as before you would need to create a separate scope, and a separate iterator to be able to automatically unwind changes, it is simply done using `with()`

An example of using Context.with to use `vscode` disposables:

```ts
export const connect = disposableScoped(function* connect(options) {
  let readable = yield* use(new rpc.StreamMessageReader(
    Readable.fromWeb(options.read, { signal }),
  ));
  let writable = yield* use(new rpc.StreamMessageWriter(
    Writable.fromWeb(options.write, { signal }),
  ));

  let connection = yield* use(rpc.createMessageConnection(readable, writable));

  yield* handle(connection);
});
```

It's really easy to implement 

```ts
const DisposableContext = createContext<{ dispose(): void}[]>("disposables");

export function disposableScope<T, TArgs extends unknown[]>(body: (...args: TArgs) => Operation<T>): (...args: TArgs) => Operation<T> {
  return (...args) => DisposableContext.with([], function*(disposables) {
    try {
      return yield* body(...args);
    } finally {
      for (let disposable of disposables) {
	disposable.dispose();
      }
    }
  });
}

export function* use<T extends { dispose(): void }>(disposable: T): Operation<T> {
  let disposables = yield* DisposableContext.expect();
  disposables.push(disposable);
  return disposable
}
```

## Approach

Now that we have v4 scope helpers in v3, we can just bring back the context helpers that depend on them.
