### PR TITLE
Introducing until helper to replace call(promise)

### DIFF
--- a/lib/call.ts
+++ b/lib/call.ts
@@ -103,10 +103,10 @@ export function call<T>(callable: () => T): Operation<T>;
 
 /**
  * @deprecated calling bare promises, operations, and constants will
- * be removed in v4, always pass a function to call()
+ * be removed in v4 use {@link until} instead
  *
  * before: call(operation);
- * after:  call(() => operation);
+ * after:  until(operation);
  */
 export function call<T>(callable: Operation<T>): Operation<T>;
 
@@ -189,4 +189,19 @@ function isInstructionIterator<T>(it: unknown): it is Iterator<Instruction, T> {
 function isIterable<T>(it: unknown): it is Iterable<T> {
   if (!it) return false;
   return typeof (it as Iterable<T>)[Symbol.iterator] === "function";
+}
+
+/**
+ * It can be used to treat a promise as an operation. This function
+ * is a replacement to the deprecated `call(promise)` function form.
+ *
+ * @example
+ * ```js
+ * let response = yield* until(fetch('https://google.com'));
+ * ```
+ * @param promise 
+ * @returns 
+ */
+export function until<T>(promise: PromiseLike<T>): Operation<T> {
+  return call(async () => await promise);
 }

--- a/lib/call.ts
+++ b/lib/call.ts
@@ -199,8 +199,9 @@ function isIterable<T>(it: unknown): it is Iterable<T> {
  * ```js
  * let response = yield* until(fetch('https://google.com'));
  * ```
+ * @template {T}
  * @param promise 
- * @returns 
+ * @returns {Operation<T>}
  */
 export function until<T>(promise: PromiseLike<T>): Operation<T> {
   return call(async () => await promise);

--- a/lib/call.ts
+++ b/lib/call.ts
@@ -200,7 +200,7 @@ function isIterable<T>(it: unknown): it is Iterable<T> {
  * let response = yield* until(fetch('https://google.com'));
  * ```
  * @template {T}
- * @param promise 
+ * @param promise
  * @returns {Operation<T>}
  */
 export function until<T>(promise: PromiseLike<T>): Operation<T> {

--- a/test/call.test.ts
+++ b/test/call.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "./suite.ts";
 
-import { call, run, spawn, suspend } from "../mod.ts";
+import { call, run, spawn, suspend, until } from "../mod.ts";
 
 describe("call", () => {
   it("evaluates an operation function", async () => {
@@ -41,6 +41,11 @@ describe("call", () => {
   it("evaluates a promise directly", async () => {
     await expect(run(() => call(Promise.resolve(42)))).resolves.toEqual(42);
   });
+
+  it("evaluates a promise directly with `until`", async () => {
+    await expect(run(() => until(Promise.resolve(42)))).resolves.toEqual(42);
+  });
+
 
   it("can be used as an error boundary", async () => {
     let error = new Error("boom!");

--- a/test/call.test.ts
+++ b/test/call.test.ts
@@ -46,7 +46,6 @@ describe("call", () => {
     await expect(run(() => until(Promise.resolve(42)))).resolves.toEqual(42);
   });
 
-
   it("can be used as an error boundary", async () => {
     let error = new Error("boom!");
     let result = await run(function* () {


### PR DESCRIPTION
## Motivation

It was very convenient to use `call(promise)` but it created disharmony with `call` function in JavaScript. We wanted to keep that functionality with `until` function. 

## Approach

Added `until` which does `call(() => promise)`

