### PR TITLE
docs: fix spelling mistakes in documentation

### DIFF
--- a/docs/context.mdx
+++ b/docs/context.mdx
@@ -2,7 +2,7 @@ Effection contexts store ambient values that are needed by the operations in you
 use cases of `Context` are
 
 
-* **Configuration**: most apps require values that come from the environment such as evironment variables or configuration files. Use context to easily retrieve such values from within any operation.
+* **Configuration**: most apps require values that come from the environment such as environment variables or configuration files. Use context to easily retrieve such values from within any operation.
 * **Client APIs**: many APIs provide client libraries to connect with them. With an Effection context, you can create a client instance once and share it between all child operations.
 * **Services**: Database connections, Websockets, and many other types of APIs involve a handle to a stateful object that needs to be
 destroyed accordingly to a set lifecycle. Combined with [resource api][resources], Effection context allows you to share a service between child operations and also to guarantee that it is disposed of properly when it is no longer needed.
@@ -15,12 +15,12 @@ verbose and inconvenient when you have to pass them through many operations in
 the middle, or if many operations need the same information. Likewise, passing information
 via lexical scope is only possible if you define the child operation in the body of the
 parent operation. `Context` lets the parent operation make some information available to any
-operation in the tree below it-no matter how deep-without passing it explicitely through function
+operation in the tree below it-no matter how deep-without passing it explicitly through function
 arguments or lexical scope.
 
 > 💁 If you're familiar with React Context, you already know most of 
 > what you need to know about Effection Context. The biggest difference
-> is the API but general concepts are same. 
+> is the API but general concepts are the same. 
 
 ## What is argument drilling?
 
@@ -30,7 +30,7 @@ But passing arguments can become inconvenient when the child operation is nested
 the same arguments need to be passed to many operations. This situation is called "argument drilling".
 
 Wouldn't it be great if you could access information in a deeply nested operation from a parent operation without 
-modifying operations in the middle? That's exaclty what Effection Context does.
+modifying operations in the middle? That's exactly what Effection Context does.
 
 ## Context: an alternative to passing arguments
 
@@ -57,7 +57,7 @@ function* fetchRepositories() {
   // 3. use the context value in a child operation
   const token = yield* GithubTokenContext.expect();
   // or
-  // const token = yield* GithubTokenContext.expect();
+  // const token = yield* GithubTokenContext.get();
 
   console.log(token);
   // -> gha-1234567890
@@ -84,7 +84,7 @@ To use context in your operations, you need to do the following 3 steps:
 
 ### Step 1: Create a context.
 
-Effection provides a function for creating a context appropriatelly called `createContext`. This function will return
+Effection provides a function for creating a context appropriately called `createContext`. This function will return
 a reference that you use to identify the context value in the scope.
 
 ``` javascript

--- a/docs/operations.mdx
+++ b/docs/operations.mdx
@@ -112,7 +112,7 @@ await main(function*() {
 });
 ```
 
-Or, it can be embeded in an operation which itself is embedded in another
+Or, it can be embedded in an operation which itself is embedded in another
 operation:
 
 ```javascript
@@ -180,7 +180,7 @@ async function sleep(milliseconds) {
 await Promise.race([sleep(10), sleep(1000)]);
 ```
 
-The anwser is 1000ms even though our intuition tells us that it
+The answer is 1000ms even though our intuition tells us that it
 should be 10ms. It takes 1000ms because `setTimeout` installs a
 callback onto the Node run loop, and our process cannot exit until it is
 removed.
@@ -256,7 +256,7 @@ not the programmer's responsibility to un-render the children, only that they
 ensure each child is written to take whatever steps necessary to un-render
 itself.
 
-By the same token, Effection Operations seemlessly bundle setup and
+By the same token, Effection Operations seamlessly bundle setup and
 teardown together into composable units so that when any operation
 passes out of scope (or is un-rendered to use the parlance of the UI
 world) all subordinate operations also pass out of scope. This in turn

--- a/docs/processes.mdx
+++ b/docs/processes.mdx
@@ -25,7 +25,7 @@ export function useCommand(...args) {
     let stderr = createSignal();
 
 
-    // create a task that finishes the process finishes
+    // create a task that runs until the process finishes
     let exit = yield* spawn(function*() {
       // get the exit code
       let code = yield* action(function*(resolve) {

--- a/docs/thinking-in-effection.mdx
+++ b/docs/thinking-in-effection.mdx
@@ -14,12 +14,12 @@ have even dreamed before.
 In JavaScript, developers rarely have to think about memory allocation because memory lifetime is bound to the scope of
 the function that it was allocated for. When a function is finished, its scope is torn down and all of the memory
 allocated to variables in function's scope are released safely. Binding memory management to scope gives developers the
-freedom to focus on their application instead worrying about leaking memory.
+freedom to focus on their application instead of worrying about leaking memory.
 
 Structured concurrency establishes the same relationship between scope and asynchrony. Every Effection operation is
 bound to the lifetime of its parent. Because of this, Effection automatically tears down
 child operations when the parent operation completes or is halted. Like with memory management, binding asynchrony to
-scope frees developers to focus on writing their applications instead of worrying about where and when to run
+about the scope frees developers to focus on writing their applications instead of worrying about where and when to run
 asynchronous cleanup.
 
 The key to achieving this freedom is to make the following mental shift about the natural lifetime of an asynchronous 


### PR DESCRIPTION
## Motivation

I wanted to try Claude Code. it generated this commit. 

## Approach

- Fixed typos in context.mdx: "evironment" → "environment", "explicitely" → "explicitly", "appropriatelly" → "appropriately"
- Added missing "the" in several places
- Fixed "embeded" → "embedded", "anwser" → "answer", "seemlessly" → "seamlessly"
- Improved awkward phrasing in processes.mdx

🤖 Generated with [Claude Code](https://claude.ai/code)

