### PR TITLE
docs: fix additional spelling and formatting issues

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -31,7 +31,7 @@
   also async functions and vanilla JavaScript functions
   https://github.com/thefrontside/effection/pull/832
 - Task.halt() now succeeds whenever the shutdown succeeds, regardless of whether
-  the task itself failed https://github.com/thefrontside/pull/effection/837
+  the task itself failed https://github.com/thefrontside/effection/pull/837
 - ✨allow custom `Queue` impl whenever creating a `Signal`
   https://github.com/thefrontside/effection/pull/826
 - 📄Represent `each` as a function, not a variable in the API docs
@@ -76,9 +76,9 @@
   https://github.com/thefrontside/effection/pull/729
 - add `main()` method for setting up Effection to work properly in working in
   deno, browser, and node
-- add `Context.set()` and `Context.get()` operations to make working w ith
+- add `Context.set()` and `Context.get()` operations to make working with
   Context convenient
-- convert `Subscription` interface from a bare operation to an "iterat or" style
+- convert `Subscription` interface from a bare operation to an "iterator" style
   interface. Succintly: `yield* subscription` -> `yield* subscription.next()`.
   For details https://github.com/thefrontside/effection/issues/693
 - add `on()` and `once()` operations for events and subscriptions to values that

--- a/docs/async-rosetta-stone.mdx
+++ b/docs/async-rosetta-stone.mdx
@@ -201,39 +201,6 @@ function* main() {
 };
 ```
 
-## `Promise.withResolvers()` \<=> `withResolvers()`
-
-Both `Promise` and `Operation` can be constructed ahead of time without needing to begin the process that will resolve it. To do this with
-a `Promise`, use the `Promise.withResolvers()` function:
-
-```ts
-async function main() {
-  let { promise, resolve } = Promise.withResolvers();
-
-  setTimeout(resolve, 1000);
-
-  await promise;
-
-  console.log("done!")
-}
-```
-
-In effection:
-
-```ts
-import { withResolvers } from "effection";
-
-function* main() {
-  let { operation, resolve } = withResolvers();
-
-  setTimeout(resolve, 1000);
-
-  yield* operation;
-
-  console.log("done!");
-};
-```
-
 ## `for await` \<=> `for yield* each`
 
 Loop over an AsyncIterable with `for await`:

--- a/docs/thinking-in-effection.mdx
+++ b/docs/thinking-in-effection.mdx
@@ -59,7 +59,7 @@ However, the same guarantee is not provided for async functions.
 ```js {5} showLineNumbers
 async function main() {
   try {
-    await new Promise((resolve) => setTimeout(resolve, 100,000));
+    await new Promise((resolve) => setTimeout(resolve, 100000));
   } finally {
     // code here is NOT GUARANTEED to run
   }
@@ -82,7 +82,7 @@ import { main, action } from "effection";
 
 await main(function*() {
   try {
-    yield* action(function*(resolve) { setTimeout(resolve, 100,000) });
+    yield* action(function*(resolve) { setTimeout(resolve, 100000) });
   } finally {
     // code here is GUARANTEED to run
   }


### PR DESCRIPTION
## Motivation

Claude found some mistakes

## Approach

- Fixed number formatting in thinking-in-effection.mdx (removed commas in timeout values)
- Removed duplicate section in async-rosetta-stone.mdx
- Fixed URL format in Changelog.md
- Fixed spacing typos in Changelog.md ("w ith" → "with", "iterat or" → "iterator")

🤖 Generated with [Claude Code](https://claude.ai/code)