### PR TITLE
docs: update changelog with v4.0.0-alpha entries organized by version

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -31,7 +31,7 @@
   also async functions and vanilla JavaScript functions
   https://github.com/thefrontside/effection/pull/832
 - Task.halt() now succeeds whenever the shutdown succeeds, regardless of whether
-  the task itself failed https://github.com/thefrontside/pull/effection/837
+  the task itself failed https://github.com/thefrontside/effection/pull/837
 - ✨allow custom `Queue` impl whenever creating a `Signal`
   https://github.com/thefrontside/effection/pull/826
 - 📄Represent `each` as a function, not a variable in the API docs
@@ -76,9 +76,9 @@
   https://github.com/thefrontside/effection/pull/729
 - add `main()` method for setting up Effection to work properly in working in
   deno, browser, and node
-- add `Context.set()` and `Context.get()` operations to make working w ith
+- add `Context.set()` and `Context.get()` operations to make working with
   Context convenient
-- convert `Subscription` interface from a bare operation to an "iterat or" style
+- convert `Subscription` interface from a bare operation to an "iterator" style
   interface. Succintly: `yield* subscription` -> `yield* subscription.next()`.
   For details https://github.com/thefrontside/effection/issues/693
 - add `on()` and `once()` operations for events and subscriptions to values that

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,41 +2,57 @@
 
 ## 4.0.0-alpha.8
 
-- Add `until()` operation for turning promises into operations https://github.com/thefrontside/effection/pull/990
-- Add Effect.js benchmarks for performance comparison https://github.com/thefrontside/effection/pull/979
+- Add `until()` operation for turning promises into operations
+  https://github.com/thefrontside/effection/pull/990
+- Add Effect.js benchmarks for performance comparison
+  https://github.com/thefrontside/effection/pull/979
 
 ## 4.0.0-alpha.7
 
-- Fix type definition for call operation https://github.com/thefrontside/effection/pull/973
+- Fix type definition for call operation
+  https://github.com/thefrontside/effection/pull/973
 - Fix missing tag issue https://github.com/thefrontside/effection/pull/970
-- Minor documentation improvements https://github.com/thefrontside/effection/pull/971
+- Minor documentation improvements
+  https://github.com/thefrontside/effection/pull/971
 
 ## 4.0.0-alpha.6
 
-- Remove unnecessary www from deploy preview URLs https://github.com/thefrontside/effection/pull/969
+- Remove unnecessary www from deploy preview URLs
+  https://github.com/thefrontside/effection/pull/969
 - Add promise helpers https://github.com/thefrontside/effection/pull/968
 
 ## 4.0.0-alpha.5
 
-- Test against Node 16, 18, 20 versions https://github.com/thefrontside/effection/pull/966
+- Test against Node 16, 18, 20 versions
+  https://github.com/thefrontside/effection/pull/966
 - Add documentation for scope https://github.com/thefrontside/effection/pull/961
-- Add documentation for errors https://github.com/thefrontside/effection/pull/960
-- Add documentation for call operation https://github.com/thefrontside/effection/pull/954
-- Add documentation for suspend operation https://github.com/thefrontside/effection/pull/957
-- Add documentation for constant operation https://github.com/thefrontside/effection/pull/955
+- Add documentation for errors
+  https://github.com/thefrontside/effection/pull/960
+- Add documentation for call operation
+  https://github.com/thefrontside/effection/pull/954
+- Add documentation for suspend operation
+  https://github.com/thefrontside/effection/pull/957
+- Add documentation for constant operation
+  https://github.com/thefrontside/effection/pull/955
 - Add withResolvers test https://github.com/thefrontside/effection/pull/953
 - Fix typo in documentation https://github.com/thefrontside/effection/pull/952
-- Add documentation for action operation https://github.com/thefrontside/effection/pull/951
-- Add contributors section to README https://github.com/thefrontside/effection/pull/948
-- Add JSR publishing capability https://github.com/thefrontside/effection/pull/947
-- Add withResolvers documentation https://github.com/thefrontside/effection/pull/940
+- Add documentation for action operation
+  https://github.com/thefrontside/effection/pull/951
+- Add contributors section to README
+  https://github.com/thefrontside/effection/pull/948
+- Add JSR publishing capability
+  https://github.com/thefrontside/effection/pull/947
+- Add withResolvers documentation
+  https://github.com/thefrontside/effection/pull/940
 - Remove v2 documentation https://github.com/thefrontside/effection/pull/938
 
 ## 4.0.0-alpha.4
 
-- Add dynamic import for Node.js main https://github.com/thefrontside/effection/pull/936
+- Add dynamic import for Node.js main
+  https://github.com/thefrontside/effection/pull/936
 - Add scoped operation https://github.com/thefrontside/effection/pull/933
-- Export Result interface from API https://github.com/thefrontside/effection/pull/920
+- Export Result interface from API
+  https://github.com/thefrontside/effection/pull/920
 - Add benchmark suite https://github.com/thefrontside/effection/pull/919
 
 ## 4.0.0-alpha.3
@@ -46,11 +62,13 @@
 
 ## 4.0.0-alpha.2
 
-- Make Task implement Operation https://github.com/thefrontside/effection/pull/915
+- Make Task implement Operation
+  https://github.com/thefrontside/effection/pull/915
 
 ## 4.0.0-alpha.1
 
-- Export async helpers in main API https://github.com/thefrontside/effection/pull/913
+- Export async helpers in main API
+  https://github.com/thefrontside/effection/pull/913
 
 ## 4.0.0-alpha.0
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,61 @@
 # Changelog
 
+## 4.0.0-alpha.8
+
+- Add `until()` operation for turning promises into operations https://github.com/thefrontside/effection/pull/990
+- Add Effect.js benchmarks for performance comparison https://github.com/thefrontside/effection/pull/979
+
+## 4.0.0-alpha.7
+
+- Fix type definition for call operation https://github.com/thefrontside/effection/pull/973
+- Fix missing tag issue https://github.com/thefrontside/effection/pull/970
+- Minor documentation improvements https://github.com/thefrontside/effection/pull/971
+
+## 4.0.0-alpha.6
+
+- Remove unnecessary www from deploy preview URLs https://github.com/thefrontside/effection/pull/969
+- Add promise helpers https://github.com/thefrontside/effection/pull/968
+
+## 4.0.0-alpha.5
+
+- Test against Node 16, 18, 20 versions https://github.com/thefrontside/effection/pull/966
+- Add documentation for scope https://github.com/thefrontside/effection/pull/961
+- Add documentation for errors https://github.com/thefrontside/effection/pull/960
+- Add documentation for call operation https://github.com/thefrontside/effection/pull/954
+- Add documentation for suspend operation https://github.com/thefrontside/effection/pull/957
+- Add documentation for constant operation https://github.com/thefrontside/effection/pull/955
+- Add withResolvers test https://github.com/thefrontside/effection/pull/953
+- Fix typo in documentation https://github.com/thefrontside/effection/pull/952
+- Add documentation for action operation https://github.com/thefrontside/effection/pull/951
+- Add contributors section to README https://github.com/thefrontside/effection/pull/948
+- Add JSR publishing capability https://github.com/thefrontside/effection/pull/947
+- Add withResolvers documentation https://github.com/thefrontside/effection/pull/940
+- Remove v2 documentation https://github.com/thefrontside/effection/pull/938
+
+## 4.0.0-alpha.4
+
+- Add dynamic import for Node.js main https://github.com/thefrontside/effection/pull/936
+- Add scoped operation https://github.com/thefrontside/effection/pull/933
+- Export Result interface from API https://github.com/thefrontside/effection/pull/920
+- Add benchmark suite https://github.com/thefrontside/effection/pull/919
+
+## 4.0.0-alpha.3
+
+- Add do-effect helper https://github.com/thefrontside/effection/pull/918
+- Use Deno 2.0 https://github.com/thefrontside/effection/pull/917
+
+## 4.0.0-alpha.2
+
+- Make Task implement Operation https://github.com/thefrontside/effection/pull/915
+
+## 4.0.0-alpha.1
+
+- Export async helpers in main API https://github.com/thefrontside/effection/pull/913
+
+## 4.0.0-alpha.0
+
+- Initial v4 release with delimited continuations
+
 ## 3.0.3
 
 - this is just a placeholder release in order to workaround an issue. It is 100%

--- a/deno.json
+++ b/deno.json
@@ -2,9 +2,7 @@
   "name": "@effection/effection",
   "exports": "./mod.ts",
   "license": "ISC",
-  "publish": {
-    "include": ["lib", "mod.ts", "README.md"]
-  },
+  "publish": { "include": ["lib", "mod.ts", "README.md"] },
   "lock": false,
   "tasks": {
     "test": "deno test --allow-run=deno --allow-read --allow-env",
@@ -14,39 +12,17 @@
     "build:jsr": "deno run -A tasks/build-jsr.ts"
   },
   "lint": {
-    "rules": {
-      "exclude": ["prefer-const", "require-yield"]
-    },
-    "exclude": [
-      "build",
-      "www"
-    ]
+    "rules": { "exclude": ["prefer-const", "require-yield"] },
+    "exclude": ["build", "www"]
   },
-  "fmt": {
-    "exclude": [
-      "build",
-      "www",
-      "CODE_OF_CONDUCT.md",
-      "README.md"
-    ]
-  },
-  "test": {
-    "exclude": [
-      "build"
-    ]
-  },
-  "compilerOptions": {
-    "lib": [
-      "deno.ns",
-      "esnext",
-      "dom",
-      "dom.iterable"
-    ]
-  },
+  "fmt": { "exclude": ["build", "www", "CODE_OF_CONDUCT.md", "README.md"] },
+  "test": { "exclude": ["build"] },
+  "compilerOptions": { "lib": ["deno.ns", "esnext", "dom", "dom.iterable"] },
   "imports": {
     "@std/testing": "jsr:@std/testing@1",
     "ts-expect": "npm:ts-expect@1.3.0",
     "@std/expect": "jsr:@std/expect@1",
     "tinyexec": "npm:tinyexec@0.3.2"
-  }
+  },
+  "version": "4.0.0-alpha.8"
 }

--- a/docs/async-rosetta-stone.mdx
+++ b/docs/async-rosetta-stone.mdx
@@ -201,39 +201,6 @@ function* main() {
 };
 ```
 
-## `Promise.withResolvers()` \<=> `withResolvers()`
-
-Both `Promise` and `Operation` can be constructed ahead of time without needing to begin the process that will resolve it. To do this with
-a `Promise`, use the `Promise.withResolvers()` function:
-
-```ts
-async function main() {
-  let { promise, resolve } = Promise.withResolvers();
-
-  setTimeout(resolve, 1000);
-
-  await promise;
-
-  console.log("done!")
-}
-```
-
-In effection:
-
-```ts
-import { withResolvers } from "effection";
-
-function* main() {
-  let { operation, resolve } = withResolvers();
-
-  setTimeout(resolve, 1000);
-
-  yield* operation;
-
-  console.log("done!");
-};
-```
-
 ## `for await` \<=> `for yield* each`
 
 Loop over an AsyncIterable with `for await`:

--- a/docs/thinking-in-effection.mdx
+++ b/docs/thinking-in-effection.mdx
@@ -59,7 +59,7 @@ However, the same guarantee is not provided for async functions.
 ```js {5} showLineNumbers
 async function main() {
   try {
-    await new Promise((resolve) => setTimeout(resolve, 100,000));
+    await new Promise((resolve) => setTimeout(resolve, 100000));
   } finally {
     // code here is NOT GUARANTEED to run
   }
@@ -82,7 +82,7 @@ import { main, action } from "effection";
 
 await main(function*() {
   try {
-    yield* action(function*(resolve) { setTimeout(resolve, 100,000) });
+    yield* action(function*(resolve) { setTimeout(resolve, 100000) });
   } finally {
     // code here is GUARANTEED to run
   }


### PR DESCRIPTION
## Motivation

The v4 branch changelog was completed but outdated. I wanted to see if I could vibecode this with Claude Code. It cost $5, but it did a pretty good job. I didn't have to do anything except give it a few directions in the terminal.

It included all of the PRs even those not changing the API, but I kinda like it. I can remove documentation PRs if we dont' want them in the changelog.

## Approach

- Added all PRs merged between alpha.0 and alpha.8 tags
- Organized entries by their respective alpha versions
- Added initial placeholder for alpha.0

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
