### PR TITLE
🚛 Backport `Scope.spawn()` to v3

### DIFF
--- a/lib/run/scope.ts
+++ b/lib/run/scope.ts
@@ -61,6 +61,18 @@ export function createScope(frame?: Frame): [Scope, () => Future<void>] {
 
       return frame.getTask();
     },
+
+    get spawn() {
+      let scope = this!;
+      return function spawn<T>(operation: () => Operation<T>) {
+        return {
+          *[Symbol.iterator]() {
+            return scope.run(operation);
+          },
+        };
+      };
+    },
+
     get<T>(context: Context<T>) {
       let { key, defaultValue } = context;
       return (parent.context[key] ?? defaultValue) as T | undefined;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -194,6 +194,16 @@ export interface Scope {
    * @returns a task rep
    */
   run<T>(operation: () => Operation<T>): Task<T>;
+
+  /**
+   * Spawn an {@link Operation} within `Scope`.
+   *
+   * This is used to create concurrent tasks from _within_ a running
+   * operation. To create concurrent from outside of Effection, use
+   * {@link Scope#run}
+   */
+  spawn<T>(operation: () => Operation<T>): Operation<Task<T>>;
+
   /**
    * Get a {@link Context} value from outside of an operation.
    * @param context - the context to get

--- a/test/scope.test.ts
+++ b/test/scope.test.ts
@@ -22,6 +22,22 @@ describe("Scope", () => {
     expect(await t2).toEqual(2);
   });
 
+  it("can be used to spawn", async () => {
+    let [scope] = createScope();
+    let t1 = run(() =>
+      scope.spawn(function* () {
+        return 1;
+      })
+    );
+    let t2 = run(() =>
+      scope.spawn(function* () {
+        return 2;
+      })
+    );
+    expect(await t1).toEqual(1);
+    expect(await t2).toEqual(2);
+  });
+
   it("succeeds on close if the frame has errored", async () => {
     let error = new Error("boom!");
     let [scope, close] = createScope();


### PR DESCRIPTION
## Motivation

In V4, `scope.spawn()` is encouraged when starting background tasks from an existing operation (as opposed to `scope.run()`). 

In order to make forward compatible apps, this API should be in v3.

## Approach

This adds a trivial implementation of spawn that delegates to `scope.run()`