### PR TITLE
Don't register SIGTERM listener on Windows

### DIFF
--- a/lib/main.ts
+++ b/lib/main.ts
@@ -83,11 +83,15 @@ export async function main(
             hardexit = (status) => Deno.exit(status);
             try {
               Deno.addSignalListener("SIGINT", interrupt.SIGINT);
-              Deno.addSignalListener("SIGTERM", interrupt.SIGTERM);
+              if (Deno.build.os !== 'windows') {
+                Deno.addSignalListener("SIGTERM", interrupt.SIGTERM);
+              }
               yield* body(Deno.args.slice());
             } finally {
               Deno.removeSignalListener("SIGINT", interrupt.SIGINT);
-              Deno.removeSignalListener("SIGTERM", interrupt.SIGTERM);
+              if (Deno.build.os !== 'windows') {
+                Deno.removeSignalListener("SIGTERM", interrupt.SIGTERM);
+              }
             }
           },
           *node() {
@@ -97,11 +101,15 @@ export async function main(
             hardexit = (status) => process.exit(status);
             try {
               process.on("SIGINT", interrupt.SIGINT);
-              process.on("SIGTERM", interrupt.SIGTERM);
+              if (process.platform !== 'win32') {
+                process.on("SIGTERM", interrupt.SIGTERM);
+              }
               yield* body(process.argv.slice(2));
             } finally {
               process.off("SIGINT", interrupt.SIGINT);
-              process.off("SIGTERM", interrupt.SIGINT);
+              if (process.platform !== 'win32') {
+                process.off("SIGTERM", interrupt.SIGINT);
+              }
             }
           },
           *browser() {


### PR DESCRIPTION
Windows does not support SIGTERM.

References:
- https://docs.deno.com/api/deno/~/Deno.addSignalListener
- https://docs.deno.com/api/deno/~/Deno.build.os
- https://nodejs.org/api/process.html#processplatform
- https://learn.microsoft.com/en-us/previous-versions/xdkz3x12(v=vs.140)

## Motivation

I'd like to use Effection on Windows/Deno.

## Approach

Currently, Effection is unusable on Deno on Windows because `Deno.addSignalListener("SIGTERM", ...)` throws, because SIGTERM is not supported by Windows.

To solve this problem, I guard signal registration with a platform check. 