### PR TITLE
enable preview packages

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -34,4 +34,4 @@ jobs:
         run: deno task build:npm ${{steps.vars.outputs.version}}
 
       - name: Publish Preview Versions
-        run: npx pkg-pr-new publish './build'
+        run: npx pkg-pr-new publish './build/npm'

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,37 @@
+name: preview
+
+on: [pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: setup deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Get Version
+        id: vars
+        # this will pull the last tag off the current branch
+        run: echo ::set-output name=version::$(git describe --abbrev=0 --tags | sed 's/^effection-v//')-pr+$(git rev-parse HEAD)
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          registry-url: https://registry.npmjs.com
+
+      - name: Build NPM
+        run: deno task build:npm ${{steps.vars.outputs.version}}
+
+      - name: Publish Preview Versions
+        run: npx pkg-pr-new publish './build'


### PR DESCRIPTION
## Motivation

This workflow will publish preview packages on every commit to https://pkg.pr.new/. This is an NPM compatible registry which is also supported by https://esm.sh/.

## Additional Context

- I installed the related GitHub App to this repository.
- This is the same preview process running in the simulacrum repo and neurosnap/starfx.
- Workflows need to be on the default branch to run. We can pull it into the v4 branch next.
