### PR TITLE
🔥Remove obsolete $await helper

### DIFF
--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -1,6 +1,14 @@
 // deno-lint-ignore-file no-unsafe-finally
-import { $await, blowUp, createNumber, describe, expect, it } from "./suite.ts";
-import { action, run, sleep, spawn, suspend, type Task } from "../mod.ts";
+import { blowUp, createNumber, describe, expect, it } from "./suite.ts";
+import {
+  action,
+  run,
+  sleep,
+  spawn,
+  suspend,
+  type Task,
+  until,
+} from "../mod.ts";
 
 describe("run()", () => {
   it("can run an operation", async () => {
@@ -11,8 +19,8 @@ describe("run()", () => {
 
   it("can compose multiple promises via generator", async () => {
     let result = await run(function* () {
-      let one = yield* $await(Promise.resolve(12));
-      let two = yield* $await(Promise.resolve(55));
+      let one = yield* until(Promise.resolve(12));
+      let two = yield* until(Promise.resolve(55));
       return one + two;
     });
     expect(result).toEqual(67);
@@ -49,16 +57,16 @@ describe("run()", () => {
   it("can recover from errors in promise", async () => {
     let error = new Error("boom");
     let task = run(function* () {
-      let one = yield* $await(Promise.resolve(12));
+      let one = yield* until(Promise.resolve(12));
       let two;
       try {
-        yield* $await(Promise.reject(error));
+        yield* until(Promise.reject(error));
         two = 9;
       } catch (_) {
         // swallow error and yield in catch block
-        two = yield* $await(Promise.resolve(8));
+        two = yield* until(Promise.resolve(8));
       }
-      let three = yield* $await(Promise.resolve(55));
+      let three = yield* until(Promise.resolve(55));
       return one + two + three;
     });
     await expect(task).resolves.toEqual(75);
@@ -66,16 +74,16 @@ describe("run()", () => {
 
   it("can recover from errors in operation", async () => {
     let task = run(function* () {
-      let one = yield* $await(Promise.resolve(12));
+      let one = yield* until(Promise.resolve(12));
       let two;
       try {
         yield* blowUp();
         two = 9;
       } catch (_e) {
         // swallow error and yield in catch block
-        two = yield* $await(Promise.resolve(8));
+        two = yield* until(Promise.resolve(8));
       }
-      let three = yield* $await(Promise.resolve(55));
+      let three = yield* until(Promise.resolve(55));
       return one + two + three;
     });
     await expect(task).resolves.toEqual(75);
@@ -308,7 +316,7 @@ describe("run()", () => {
   it("propagates errors from promises", async () => {
     try {
       await run(function* () {
-        yield* $await(Promise.reject(new Error("boom")));
+        yield* until(Promise.reject(new Error("boom")));
       });
       throw new Error("expected error to propagate");
     } catch (error) {

--- a/test/spawn.test.ts
+++ b/test/spawn.test.ts
@@ -1,13 +1,13 @@
 // deno-lint-ignore-file no-unsafe-finally
-import { $await, describe, expect, it } from "./suite.ts";
-import { run, sleep, spawn, suspend } from "../mod.ts";
+import { describe, expect, it } from "./suite.ts";
+import { run, sleep, spawn, suspend, until } from "../mod.ts";
 
 describe("spawn", () => {
   it("can spawn a new child task", async () => {
     let root = run(function* root() {
       let child = yield* spawn(function* child() {
-        let one = yield* $await(Promise.resolve(12));
-        let two = yield* $await(Promise.resolve(55));
+        let one = yield* until(Promise.resolve(12));
+        let two = yield* until(Promise.resolve(55));
         return one + two;
       });
       return yield* child;

--- a/test/suite.ts
+++ b/test/suite.ts
@@ -6,10 +6,6 @@ import { type KillSignal, type Options, type Output, x as $x } from "tinyexec";
 import type { Operation, Stream } from "../lib/types.ts";
 import { call, resource, sleep, spawn, stream } from "../mod.ts";
 
-export function $await<T>(promise: Promise<T>): Operation<T> {
-  return call(() => promise);
-}
-
 export function* createNumber(value: number): Operation<number> {
   yield* sleep(1);
   return value;


### PR DESCRIPTION
## Motivation
Now that we have our very own `until()` function that can convert any promise into an operation, we don't need the the `$await()` helper that the tests were using that does the exact same thing.

## Approach

Kill it with fire!
