### PR TITLE
🔥 get rid of unused dependency on assert.

### DIFF
--- a/lib/deps.ts
+++ b/lib/deps.ts
@@ -1,2 +1,1 @@
-export { assert } from "jsr:@std/assert@1.0.10";
 export * from "jsr:@frontside/continuation@0.1.6";


### PR DESCRIPTION
## Motivation

This code is completely unused and removing it has zero effect on the test and packaging of code.

## Approach

🔪 cut it!