### PR TITLE
✨ add interval() helper to consume a stream of intervals

### DIFF
--- a/lib/interval.ts
+++ b/lib/interval.ts
@@ -1,0 +1,31 @@
+import { resource } from "./instructions.ts";
+import { createSignal } from "./signal.ts";
+import type { Stream } from "./types.ts";
+
+/**
+ * Consume an interval as an infinite stream.
+ *
+ * ```ts
+ * let startTime = Date.now();
+ *
+ * for (let _ of yield* each(interval(10))) {
+ *   let elapsed = Date.now() - startTime;
+ *   console.log(`elapsed time: ${elapsed} ms`);
+ *   yield* each.next();
+ * }
+ * ```
+ * @param milliseconds - how long to delay between each item in the stream
+ */
+export function interval(milliseconds: number): Stream<void, never> {
+  return resource(function* (provide) {
+    let signal = createSignal<void, never>();
+
+    let id = setInterval(signal.send, milliseconds);
+
+    try {
+      yield* provide(yield* signal);
+    } finally {
+      clearInterval(id);
+    }
+  });
+}

--- a/lib/mod.ts
+++ b/lib/mod.ts
@@ -5,6 +5,7 @@ export * from "./instructions.ts";
 export * from "./call.ts";
 export * from "./run.ts";
 export * from "./sleep.ts";
+export * from "./interval.ts";
 export * from "./async.ts";
 export * from "./abort-signal.ts";
 export * from "./result.ts";

--- a/test/interval.test.ts
+++ b/test/interval.test.ts
@@ -1,0 +1,27 @@
+import { call, each, interval, race, run, sleep, spawn } from "../mod.ts";
+import { describe, expect, it } from "./suite.ts";
+
+describe("interval", () => {
+  it("can be iterated", async () => {
+    await run(function* () {
+      let task = yield* spawn(function* () {
+        let total = 0;
+        for (let _ of yield* each(interval(1))) {
+          total++;
+          if (total == 10) {
+            return total;
+          }
+          yield* each.next();
+        }
+      });
+      let result = yield* race([
+        task,
+        call(function* () {
+          yield* sleep(50);
+          return "interval not producing!";
+        }),
+      ]);
+      expect(result).toEqual(10);
+    });
+  });
+});


### PR DESCRIPTION
## Motivation

[`setInterval()`][1] is a core JavaScript API that allows you to setup global state. As such, there really isn't any reason that you shouldn't consume it using structured concurrency.

## Approach
This adds an `interval()` function that constructs a stream that emits an item every time that the interval is triggered.

```ts
let startTime = Date.now();

for (let _ of yield* each(interval(10))) {
  let elapsed = Date.now() - startTime;
  console.log(`elapsed time: ${elapsed} ms`);
  yield* each.next();
}
```

[1]: https://developer.mozilla.org/en-US/docs/Web/API/Window/setInterval
