### PR TITLE
Fix webpack compatibility

### DIFF
--- a/lib/main.ts
+++ b/lib/main.ts
@@ -91,8 +91,10 @@ export async function main(
             }
           },
           *node() {
+            // Annotate dynamic import so that webpack ignores it.
+            // See https://webpack.js.org/api/module-methods/#webpackignore
             let { default: process } = yield* call(() =>
-              import("node:process")
+              import(/* webpackIgnore: true */ "node:process")
             );
             hardexit = (status) => process.exit(status);
             try {


### PR DESCRIPTION
This is related to PR #935. Unfortunately, webpack follows even dynamic
imports unless told not to. This one-line change adds the magic comment to
tell webpack not to try to import ‘node:process’.

## Motivation

This PR fixes webpack compatibility.

## Approach

This PR adds a single comment to tell webpack not to try to import
node:process.
