### PR TITLE
✨ properly propagate errors from nested scopes

### DIFF
--- a/lib/delimiter.ts
+++ b/lib/delimiter.ts
@@ -50,13 +50,16 @@ export class Delimiter<T>
     if (this.finalized) {
       return;
     }
-    this.outcome = outcome;
+    this.outcome =
+      (this.outcome && this.outcome.exists && !this.outcome.value.ok)
+        ? this.outcome
+        : outcome;
     this.level++;
     if (!this.routine) {
       this.finalized = true;
-      this.future.resolve(outcome);
+      this.future.resolve(this.outcome);
     } else {
-      this.routine.return(Ok(outcome));
+      this.routine.return(Ok(this.outcome));
     }
   }
 

--- a/test/scoped.test.ts
+++ b/test/scoped.test.ts
@@ -1,3 +1,4 @@
+import { box } from "../lib/box.ts";
 import {
   createContext,
   resource,
@@ -157,7 +158,7 @@ describe("scoped", () => {
       }));
   });
 
-  it.skip("throws errors at the correct point when there are multiple nested scopes", async () => {
+  it("throws errors at the correct point when there are multiple nested scopes", async () => {
     let task = run(function* () {
       return yield* scoped(function* () {
         yield* spawn(function* () {
@@ -165,13 +166,13 @@ describe("scoped", () => {
           throw new Error("boom!");
         });
 
-        try {
-          return yield* scoped(function* () {
-            yield* suspend();
-          });
-        } catch (error) {
-          return error;
-        }
+        yield* box(() =>
+          scoped(function* () {
+            yield* scoped(function* () {
+              yield* suspend();
+            });
+          })
+        );
       });
     });
 

--- a/test/spawn.test.ts
+++ b/test/spawn.test.ts
@@ -122,7 +122,6 @@ describe("spawn", () => {
 
     await expect(root.halt()).rejects.toHaveProperty("message", "moo");
     await expect(child!.halt()).rejects.toHaveProperty("message", "moo");
-    await expect(root.halt()).rejects.toHaveProperty("message", "moo");
   });
 
   it("halts when child finishes during asynchronous halt", async () => {


### PR DESCRIPTION
## Motivation

There was a problem where raising errors within nested scopes was causing the outermost delimiter to have its outcome overwritten by its children propagating up.

fixes #1013 

## Approach
This changes delimiters so that their outcomes cannot be overwritten unless that outcome is, in fact, an error.

