### PR TITLE
🐛 run resources at the priority level of their caller

### DIFF
--- a/lib/contexts.ts
+++ b/lib/contexts.ts
@@ -5,7 +5,7 @@ export const Routine = createContext<Coroutine<unknown>>(
   "@effection/coroutine",
 );
 
-export const Generation = createContext<number>(
+export const Priority = createContext<number>(
   "@effection/scope.generation",
   0,
 );

--- a/lib/coroutine.ts
+++ b/lib/coroutine.ts
@@ -1,4 +1,4 @@
-import { Generation } from "./contexts.ts";
+import { Priority } from "./contexts.ts";
 import { DelimiterContext } from "./delimiter.ts";
 import { ReducerContext } from "./reducer.ts";
 import { Ok } from "./result.ts";
@@ -32,7 +32,7 @@ export function createCoroutine<T>(
       routine.data.exit((exitResult) => {
         routine.data.exit = (didExit) => didExit(Ok());
         reducer.reduce([
-          scope.expect(Generation),
+          scope.expect(Priority),
           routine,
           exitResult.ok ? result : exitResult,
           scope.expect(DelimiterContext).validator,
@@ -44,7 +44,7 @@ export function createCoroutine<T>(
       routine.data.exit((exitResult) => {
         routine.data.exit = (didExit) => didExit(Ok());
         reducer.reduce([
-          scope.expect(Generation),
+          scope.expect(Priority),
           routine,
           exitResult.ok ? result : exitResult,
           scope.expect(DelimiterContext).validator,

--- a/lib/resource.ts
+++ b/lib/resource.ts
@@ -1,9 +1,10 @@
 import { suspend } from "./suspend.ts";
-import { spawn } from "./spawn.ts";
 import type { Operation } from "./types.ts";
-import { trap } from "./task.ts";
+import { createTask, trap } from "./task.ts";
 import { Ok } from "./result.ts";
 import { useCoroutine } from "./coroutine.ts";
+import type { ScopeInternal } from "./scope-internal.ts";
+import { Priority } from "./contexts.ts";
 
 /**
  * Define an Effection [resource](https://frontside.com/effection/docs/resources)
@@ -57,7 +58,16 @@ export function resource<T>(
       // establishing a control boundary lets us catch errors in
       // resource initializer
       return yield* trap<T>(function* () {
-        yield* spawn(() => op(provide));
+        let { scope, start } = createTask<void>({
+          owner: caller.scope as ScopeInternal,
+          operation: () => op(provide),
+        });
+
+        // a resource runs at the priority of its parent
+        scope.set(Priority, caller.scope.expect(Priority));
+
+        start();
+
         return (yield {
           description: "await resource",
           enter: () => (uninstalled) => uninstalled(Ok()),

--- a/lib/scope-internal.ts
+++ b/lib/scope-internal.ts
@@ -1,4 +1,4 @@
-import { Children, Generation } from "./contexts.ts";
+import { Children, Priority } from "./contexts.ts";
 import { Err, Ok, unbox } from "./result.ts";
 import { createTask } from "./task.ts";
 import type { Context, Operation, Scope, Task } from "./types.ts";
@@ -57,7 +57,7 @@ export function createScopeInternal(
     },
   });
 
-  scope.set(Generation, scope.expect(Generation) + 1);
+  scope.set(Priority, scope.expect(Priority) + 1);
   scope.set(Children, new Set());
   parent?.expect(Children).add(scope);
 

--- a/test/resource.test.ts
+++ b/test/resource.test.ts
@@ -84,6 +84,29 @@ describe("resource", () => {
 
     expect(state.status).toEqual("pending");
   });
+
+  it("does not relinquish control when a resource initialized synchronously", async () => {
+    let sequence: number[] = [];
+
+    await run(function* () {
+      sequence.push(1);
+
+      let task = yield* spawn(function* () {
+        sequence.push(4);
+      });
+
+      yield* resource<void>(function* (provide) {
+        sequence.push(2);
+        yield* provide();
+      });
+
+      sequence.push(3);
+
+      yield* task;
+    });
+
+    expect(sequence).toEqual([1, 2, 3, 4]);
+  });
 });
 
 function createResource(container: State): Operation<State> {


### PR DESCRIPTION
## Motivation

When initializing a resource that does not do anything asynchronous, we do not want to release control of the reduction loop so that the parent can continue to run.

## Approach

- Rename `Generation` -> `Priority` for the context since the generation and the priority are no longer necessarily the same.
- Set the priority of a resource task to the same level as its parent
