### PR TITLE
Rename actions page in v4

### DIFF
--- a/docs/actions.mdx
+++ b/docs/actions.mdx
@@ -1,12 +1,10 @@
-In this section, we'll cover one of the most fundamental operations in
-Effection: `action()`, and how we can use it as a safe alternative to
+In this section, we'll cover how we can use `action` as a safe alternative to
 the [Promise constructor][promise-constructor].
 
 ## Example: Sleep
 
 Let's revisit our sleep operation from the [introduction to
-operations](./operations):
-
+operations](../operations):
 
 ```js
 export function sleep(duration: number): Operation<void> {
@@ -58,7 +56,8 @@ an abort signal was there without sacrificing any clarity in achieving it.
 
 ## Action Constructor
 
-The [`action()`][action] function provides a callback based API to create Effection operations. You don't need it all that often, but when you do it functions almost exactly like the 
+The [`action()`][action] function provides a callback based API to create Effection operations.
+You don't need it all that often, but when you do it functions almost exactly like the
 [promise constructor][promise-constructor]. To see this, let's
 use [one of the examples from MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/Promise#examples)
 that uses promises to make a crude replica of the global [`fetch()`][fetch]
@@ -90,7 +89,7 @@ function* fetch(url) {
     xhr.onload = () => resolve(xhr.responseText);
     xhr.onerror = () => reject(xhr.statusText);
     xhr.send();
-	return () => { } // "finally" function place holder.
+    return () => {}; // "finally" function place holder.
   });
 }
 ```
@@ -109,11 +108,11 @@ until _both_ requests are have received a response.
 ```js
 await Promise.race([
   fetch("https://openweathermap.org"),
-  fetch("https://open-meteo.org")
-])
+  fetch("https://open-meteo.org"),
+]);
 ```
 
-With Effection, this is easily fixed by calling `abort()` in the finally function to 
+With Effection, this is easily fixed by calling `abort()` in the finally function to
 make sure that the request is cancelled when it is either resolved, rejected, or
 passes out of scope.
 
@@ -125,14 +124,15 @@ function* fetch(url) {
     xhr.onload = () => resolve(xhr.responseText);
     xhr.onerror = () => reject(xhr.statusText);
     xhr.send();
-    return () => { xhr.abort(); }; // called in all cases
+    return () => {
+      xhr.abort();
+    }; // called in all cases
   });
 }
 ```
 
->💡Almost every usage of the [promise concurrency primitives][promise-concurrency]
+> 💡Almost every usage of the [promise concurrency primitives][promise-concurrency]
 > will contain bugs born of leaked effects.
-
 
 [abort-signal]: https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
 [fetch]: https://developer.mozilla.org/en-US/docs/Web/API/fetch

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -3,12 +3,6 @@ If you encounter obstacles integrating with your environment, please create a [G
 
 ## Node.js & Browser
 
-<p class="inline-flex my-0 flex-wrap gap-1">
-  <img class="my-1" src="https://badgen.net/bundlephobia/min/effection" alt="Bundlephobia badge showing effection minified" />
-  <img class="my-1" src="https://badgen.net/bundlephobia/minzip/effection" alt="Bundlephobia badge showing effection gzipped size" />
-  <img class="my-1" src="https://badgen.net/bundlephobia/tree-shaking/effection" alt="Bundlephobia badge showing it's treeshackable" />
-</p>
-
 Effection is available on [NPM][npm], as well as derived registries such as [Yarn][yarn] and [UNPKG][unpkg]. It comes with TypeScript types and can be consumed as both ESM and CommonJS.
 
 ```bash
@@ -24,7 +18,7 @@ yarn add effection
 Effection has first class support for Deno because it is developed with [Deno](https://deno.land). Releases are published to [https://deno.land/x/effection](https://deno.land/x/effection). For example, to import the `main()` function:
 
 ```ts
-import { main } from "https://deno.land/x/effection/mod.ts";
+import { main } from "jsr:@effection/effection@4.0.0-beta.2";
 ```
 
 > 💡 If you're curious how we keep NPM/YARN and Deno packages in-sync, you can [checkout the blog post on how publish Deno packages to NPM.][deno-npm-publish].

--- a/docs/structure.json
+++ b/docs/structure.json
@@ -8,13 +8,13 @@
   ],
   "Learn Effection": [
     ["operations.mdx", "Operations"],
-    ["actions.mdx", "Actions and Suspensions"],
-    ["resources.mdx", "Resources"],
     ["spawn.mdx", "Spawn"],
+    ["resources.mdx", "Resources"],
     ["collections.mdx", "Streams and Subscriptions"],
     ["events.mdx", "Events"],
     ["errors.mdx", "Error Handling"],
-    ["context.mdx", "Context"]
+    ["context.mdx", "Context"],
+    ["actions.mdx", "Actions"]
   ],
   "Advanced": [
     ["faq.mdx", "FAQ"],


### PR DESCRIPTION
## Motivation

Since v3 and v4 have API parity for the most part, it  makes sense to also reuse their documentation.

## Approach

1. Cleaned up installation page to use latest beta from JSR
2. Renamed `Actions and Suspension` to `Actions`
3. Moved `Actions` link in the sidebar to the bottom of the section
4. Move `Spawn` page up and `Resources` afterwards
