### PR TITLE
Do not bind SIGTERM in Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,19 @@
+# Set default line ending behavior
+* text=auto
+
+# Explicitly set line endings for text files
+*.ts text eol=lf
+*.js text eol=lf
+*.json text eol=lf
+*.md text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+
+# Binary files
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.woff binary
+*.woff2 binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,7 @@
 
 # Explicitly set line endings for text files
 *.ts text eol=lf
+*.mjs text eol=lf
 *.js text eol=lf
 *.json text eol=lf
 *.md text eol=lf

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -38,7 +38,13 @@ jobs:
       - name: lint
         run: deno lint
 
-      - name: test
+      - name: test (Windows)
+        if: runner.os == 'Windows'
+        run: deno task test
+        shell: cmd
+
+      - name: test (Unix)
+        if: runner.os != 'Windows'
         run: deno task test
 
       - name: test:node

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -14,6 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -39,5 +40,6 @@ jobs:
 
       - name: test
         run: deno task test
+
       - name: test:node
         run: deno task test:node

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -11,7 +11,10 @@ permissions:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
 
     steps:
       - name: checkout

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -13,7 +13,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/deno.json
+++ b/deno.json
@@ -7,7 +7,7 @@
   },
   "lock": false,
   "tasks": {
-    "test": "deno test --allow-run=deno --allow-ffi",
+    "test": "deno test --allow-run --allow-ffi",
     "test:node": "deno task build:npm 0.0.0 && node test/main/node.mjs hello world",
     "build:jsr": "deno run -A tasks/build-jsr.ts",
     "build:npm": "deno run -A tasks/build-npm.ts"

--- a/deno.json
+++ b/deno.json
@@ -20,7 +20,8 @@
       "build",
       "website",
       "www",
-      "packages"
+      "packages",
+      "docs/*.ts"
     ]
   },
   "fmt": {
@@ -46,5 +47,12 @@
       "dom",
       "dom.iterable"
     ]
+  },
+  "imports": {
+    "@deno/dnt": "jsr:@deno/dnt@0.41.3",
+    "ctrlc-windows": "npm:ctrlc-windows@2.2.0",
+    "@std/testing": "jsr:@std/testing@^1",
+    "@std/expect": "jsr:@std/expect@^1",
+    "ts-expect": "npm:ts-expect@1.3.0"
   }
 }

--- a/deno.json
+++ b/deno.json
@@ -7,7 +7,7 @@
   },
   "lock": false,
   "tasks": {
-    "test": "deno test --allow-run=deno",
+    "test": "deno test --allow-run=deno --allow-ffi",
     "test:node": "deno task build:npm 0.0.0 && node test/main/node.mjs hello world",
     "build:jsr": "deno run -A tasks/build-jsr.ts",
     "build:npm": "deno run -A tasks/build-npm.ts"

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -1,7 +1,6 @@
 import { createContext } from "./context.ts";
 import type { Operation } from "./types.ts";
 import { action } from "./instructions.ts";
-import process from "node:process";
 import { run } from "./run.ts";
 import { call } from "./call.ts";
 

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -1,6 +1,7 @@
 import { createContext } from "./context.ts";
 import type { Operation } from "./types.ts";
 import { action } from "./instructions.ts";
+import process from "node:process";
 import { run } from "./run.ts";
 import { call } from "./call.ts";
 
@@ -83,11 +84,18 @@ export async function main(
             hardexit = (status) => Deno.exit(status);
             try {
               Deno.addSignalListener("SIGINT", interrupt.SIGINT);
-              Deno.addSignalListener("SIGTERM", interrupt.SIGTERM);
+              /**
+               * Windows only supports ctrl-c (SIGINT), ctrl-break (SIGBREAK), and ctrl-close (SIGUP)
+               */
+              if (Deno.build.os !== "windows") {
+                Deno.addSignalListener("SIGTERM", interrupt.SIGTERM);
+              }
               yield* body(Deno.args.slice());
             } finally {
               Deno.removeSignalListener("SIGINT", interrupt.SIGINT);
-              Deno.removeSignalListener("SIGTERM", interrupt.SIGTERM);
+              if (Deno.build.os !== "windows") {
+                Deno.removeSignalListener("SIGTERM", interrupt.SIGTERM);
+              }
             }
           },
           *node() {
@@ -99,11 +107,15 @@ export async function main(
             hardexit = (status) => process.exit(status);
             try {
               process.on("SIGINT", interrupt.SIGINT);
-              process.on("SIGTERM", interrupt.SIGTERM);
+              if (process.platform !== "win32") {
+                process.on("SIGTERM", interrupt.SIGTERM);
+              }
               yield* body(process.argv.slice(2));
             } finally {
               process.off("SIGINT", interrupt.SIGINT);
-              process.off("SIGTERM", interrupt.SIGINT);
+              if (process.platform !== "win32") {
+                process.off("SIGTERM", interrupt.SIGINT);
+              }
             }
           },
           *browser() {

--- a/tasks/build-npm.ts
+++ b/tasks/build-npm.ts
@@ -1,4 +1,4 @@
-import { build, emptyDir } from "jsr:@deno/dnt@0.41.3";
+import { build, emptyDir } from "@deno/dnt";
 
 const outDir = "./build/npm";
 

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -21,24 +21,26 @@ describe("main", () => {
     });
   });
 
-  it("gracefully shuts down on SIGTERM", async () => {
-    await run(function* () {
-      let daemon = yield* useCommand("deno", {
-        stdout: "piped",
-        args: ["run", "test/main/ok.daemon.ts"],
+  if (Deno.build.os !== "windows") {
+    it("gracefully shuts down on SIGTERM", async () => {
+      await run(function* () {
+        let daemon = yield* useCommand("deno", {
+          stdout: "piped",
+          args: ["run", "test/main/ok.daemon.ts"],
+        });
+        let stdout = yield* buffer(daemon.stdout);
+        yield* detect(stdout, "started");
+
+        daemon.kill("SIGTERM");
+
+        let status = yield* daemon.status;
+
+        expect(status.code).toBe(143);
+
+        yield* detect(stdout, "gracefully stopped");
       });
-      let stdout = yield* buffer(daemon.stdout);
-      yield* detect(stdout, "started");
-
-      daemon.kill("SIGTERM");
-
-      let status = yield* daemon.status;
-
-      expect(status.code).toBe(143);
-
-      yield* detect(stdout, "gracefully stopped");
     });
-  });
+  }
 
   it("exits gracefully on explicit exit()", async () => {
     await run(function* () {

--- a/test/suite.ts
+++ b/test/suite.ts
@@ -78,16 +78,18 @@ export function useCommand(
     let command = new Deno.Command(cmd, options);
     let process = command.spawn();
 
-    // Wrap the kill method to use ctrlc-windows on Windows
-    // See: https://github.com/denoland/deno/issues/29599
-    const originalKill = process.kill.bind(process);
-    process.kill = (signal) => {
-      if (Deno.build.os === "windows" && signal === "SIGINT") {
-        ctrlc(process.pid);
-      } else {
-        originalKill(signal);
-      }
-    };
+    if (Deno.build.os === "windows") {
+      // Wrap the kill method to use ctrlc-windows on Windows
+      // See: https://github.com/denoland/deno/issues/29599
+      const originalKill = process.kill.bind(process);
+      process.kill = (signal) => {
+        if (signal === "SIGINT") {
+          ctrlc(process.pid);
+        } else {
+          originalKill(signal);
+        }
+      };
+    }
 
     try {
       yield* provide(process);

--- a/test/suite.ts
+++ b/test/suite.ts
@@ -1,16 +1,9 @@
-export * from "https://deno.land/std@0.163.0/testing/bdd.ts";
-export { expect } from "jsr:@std/expect";
-export { expectType } from "https://esm.sh/ts-expect@1.3.0?pin=v123";
+export * from "@std/testing/bdd";
+export { expect } from "@std/expect";
+export { expectType } from "ts-expect";
 
-import { ctrlc } from "npm:ctrlc-windows";
-import {
-  action,
-  call,
-  type Operation,
-  resource,
-  sleep,
-  spawn,
-} from "../mod.ts";
+import { ctrlc } from "ctrlc-windows";
+import { action, type Operation, resource, sleep, spawn } from "../mod.ts";
 
 declare global {
   interface Promise<T> extends Operation<T> {}

--- a/test/suite.ts
+++ b/test/suite.ts
@@ -2,6 +2,7 @@ export * from "https://deno.land/std@0.163.0/testing/bdd.ts";
 export { expect } from "jsr:@std/expect";
 export { expectType } from "https://esm.sh/ts-expect@1.3.0?pin=v123";
 
+import { ctrlc } from "npm:ctrlc-windows";
 import {
   action,
   call,
@@ -83,12 +84,24 @@ export function useCommand(
   return resource(function* (provide) {
     let command = new Deno.Command(cmd, options);
     let process = command.spawn();
+
+    // Wrap the kill method to use ctrlc-windows on Windows
+    // See: https://github.com/denoland/deno/issues/29599
+    const originalKill = process.kill.bind(process);
+    process.kill = (signal) => {
+      if (Deno.build.os === "windows" && signal === "SIGINT") {
+        ctrlc(process.pid);
+      } else {
+        originalKill(signal);
+      }
+    };
+
     try {
       yield* provide(process);
     } finally {
       try {
         process.kill("SIGINT");
-        yield* call(process.status);
+        yield* process.status;
       } catch (error) {
         // if the process already quit, then this error is expected.
         // unfortunately there is no way (I know of) to check this


### PR DESCRIPTION
## Motivation

Problem 1: Binding SIGTERM in windows in Deno triggers this warning `Windows only supports ctrl-c (SIGINT), ctrl-break (SIGBREAK), and ctrl-close (SIGUP)`. We don't want `main` to produce any warnings.

To verify that this is working on Windows, I ran tests on windows. Which lead to Problem 2: `TypeError: Windows only supports ctrl-c (SIGINT), ctrl-break (SIGBREAK), and ctrl-close (SIGUP), but got SIGTERM` (note the _but got SIGTERM_)

## Approach

The solution to problem 1 is to avoid binding SIGTERM in Deno and Node using their platform flags.

The solution to problem 2 is to use ctrlc-windows instead of sending SIGINT to terminate in Windows.

The test produced stderr which caused the test to fail in pwsh. In bash, it would hang because bash is capturing command's stderr which disrupted ctrlc-windows function. In `@effectionx/process` we use ctrlc-windows with a process in detached mode which bypasses this problem. I used `cmd` shell which doesn't disrupt stderr like bash, nor fails the process when stderr is produced.