### PR TITLE
🕸️ point the website at the main v3 branch

### DIFF
--- a/.github/workflows/www.yaml
+++ b/.github/workflows/www.yaml
@@ -6,7 +6,7 @@ on:
   pull_request:
   push:
     branches:
-      - tm/import-www
+      - v3
 
 jobs:
   www:


### PR DESCRIPTION
## Motivation

While developing the new website, we used the `tm/import-www` branch as the branch from which to deploy. However, now that it's merged, we can make it the default repo branch.


## Approach

update the `www` workflow