### PR TITLE
⬇️ Make the v3 dist tag a legacy tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,10 +36,8 @@ jobs:
         run: deno task build:npm ${{steps.vars.outputs.version}}
 
       - name: Publish NPM
-        run: npm publish --access=public
+        run: npm publish --access=public --tag=latest-v3
         working-directory: ./build/npm
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}
 
   publish-jsr:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Motivation

With the publication of 4.0, 3.x is no longer the latest tag. packages from the 4.x series will be published as latest.

## Approach

We'll use `latest-v3` so that if you are still using v3, you can always get the most recent package from that release series.
