### PR TITLE
🎯 publish v4 on "latest" tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,7 @@ jobs:
         run: deno task build:npm ${{steps.vars.outputs.version}}
 
       - name: Publish NPM
-        run: npm publish --access=public --tag=next
+        run: npm publish --access=public --tag=latest
         working-directory: ./build/npm
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,8 +38,6 @@ jobs:
       - name: Publish NPM
         run: npm publish --access=public --tag=latest
         working-directory: ./build/npm
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}
 
   publish-jsr:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Motivation
v4 is now the current release, so newest NPM packages are published with the `latest` tag
