### PR TITLE
Revert to using case sensitive file system in Linux to build the website

### DIFF
--- a/.github/workflows/www.yaml
+++ b/.github/workflows/www.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   www:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     timeout-minutes: 15
 
     permissions:
@@ -43,14 +43,14 @@ jobs:
 
       - name: Download Staticalize
         run: |
-          wget https://github.com/thefrontside/staticalize/releases/download/v0.2.2/staticalize-macos.tar.gz \
-            -O /tmp/staticalize-macos.tar.gz
-          tar -xzf /tmp/staticalize-macos.tar.gz -C /usr/local/bin
-          chmod +x /usr/local/bin/staticalize-macos
+          wget https://github.com/thefrontside/staticalize/releases/download/v0.2.2/staticalize-linux.tar.gz \
+            -O /tmp/staticalize-linux.tar.gz
+          tar -xzf /tmp/staticalize-linux.tar.gz -C /usr/local/bin
+          chmod +x /usr/local/bin/staticalize-linux
 
       - name: Staticalize
         run: |
-          staticalize-macos \
+          staticalize-linux \
             --site=http://127.0.0.1:8000 \
             --output=www/built \
             --base=https://effection-www.deno.dev/

--- a/www/deno.json
+++ b/www/deno.json
@@ -1,7 +1,7 @@
 {
   "tasks": {
     "dev": "deno run -A @effectionx/watch deno run -A main.tsx",
-    "staticalize": "deno run -A jsr:@frontside/staticalize@0.2.1/cli --site http://localhost:8000 --output=built --base=http://localhost:8000",
+    "staticalize": "deno run -A jsr:@frontside/staticalize@0.2.2/cli --site http://localhost:8000 --output=built --base=http://localhost:8000",
     "pagefind": "npx pagefind --site built",
     "test": "deno test --allow-run --allow-write --allow-read"
   },


### PR DESCRIPTION
## Motivation

Fixes https://github.com/thefrontside/effection/issues/1066

In effort to align build environment with our local development environment, I switched CI build to run in Mac OS instead of Ubuntu. This introduced a problem caused by Mac OS's case insensitive file system.

During local development, we use Mac OS with dynamically rendered pages which properly handled `/api/v4/withResolvers` and `/WithResolvers`. In CI, we start the website and run staticalize which is supposed to create `/api/v4/withResolvers/index.html` and `/api/v4/WithResolvers/index.html`. This works in Linux because the files system is case sensitive but on Mac OS's case insensitive file system, `withResolvers` and `WithResolvers` are the same directory. Staticalize skips the second directory assuming it's same.

## Approach

Revert back to using Linux for CI