### PR TITLE
Use h4 instead of h1

### DIFF
--- a/www/components/footer.tsx
+++ b/www/components/footer.tsx
@@ -4,9 +4,9 @@ export function Footer(): JSX.Element {
   return (
     <footer class="grid grid-cols-4 text-center text-gray-500 tracking-wide bg-gray-100 dark:bg-gray-900 dark:text-gray-400 py-8 gap-y-4 leading-8 justify-self-end px-5">
       <section class="flex flex-col gap-y-1">
-        <h1 class="text-sm uppercase font-bold text-blue-primary dark:text-blue-secondary mb-4">
+        <h4 class="text-sm uppercase font-bold text-blue-primary dark:text-blue-secondary mb-4">
           About
-        </h1>
+        </h4>
         <a
           class="text-gray-800 dark:text-gray-200"
           href="https://frontside.com"
@@ -21,9 +21,9 @@ export function Footer(): JSX.Element {
         </a>
       </section>
       <section class="flex flex-col gap-y-1">
-        <h1 class="text-sm uppercase font-bold text-blue-primary dark:text-blue-secondary mb-4">
+        <h4 class="text-sm uppercase font-bold text-blue-primary dark:text-blue-secondary mb-4">
           OSS Projects
-        </h1>
+        </h4>
         <a
           href="https://frontside.com/interactors"
           class="text-gray-800 dark:text-gray-200"
@@ -32,9 +32,9 @@ export function Footer(): JSX.Element {
         </a>
       </section>
       <section class="flex flex-col gap-y-1">
-        <h1 class="text-sm uppercase font-bold text-blue-primary dark:text-blue-secondary mb-4">
+        <h4 class="text-sm uppercase font-bold text-blue-primary dark:text-blue-secondary mb-4">
           Resources
-        </h1>
+        </h4>
         <a href="/assets/llms.txt" class="text-gray-800 dark:text-gray-200">
           LLM Reference
         </a>
@@ -43,9 +43,9 @@ export function Footer(): JSX.Element {
         </a>
       </section>
       <section class="flex flex-col gap-y-1">
-        <h1 class="text-sm uppercase font-bold text-blue-primary dark:text-blue-secondary mb-4">
+        <h4 class="text-sm uppercase font-bold text-blue-primary dark:text-blue-secondary mb-4">
           Community
-        </h1>
+        </h4>
         <a
           href="https://discord.gg/r6AvtnU"
           class="text-gray-800 dark:text-gray-200"


### PR DESCRIPTION
## Motivation

In #1069, @jbolda pointed out that we should not be using h1 in the footer. I made that change but didn't push it.

Complete it now.
