### PR TITLE
Add support for async disposable

### DIFF
--- a/docs/scope.mdx
+++ b/docs/scope.mdx
@@ -280,10 +280,18 @@ The nice thing about scope is that you don't need to worry about it. It's just
 there, ensuring that things get cleaned up as soon as they are no longer needed.
 Sometimes, however, it is necessary to interact with the scope of an operation
 from outside of Effection in normal JavaScript execution. To do this we use the
-[Scope][scope] API. Once we have a reference to a `Scope`, we can use it to run
+[Scope][scope] API.  Once we have a reference to a `Scope`, we can use it to run
 operations as though they were being spawned directly from an operation running
-in that scope. An example of this might be to spawn a new operation for each
-request to an express server.
+in that scope. The best way to use a scope is to capture it from an already running
+operation, but you can also create a new one from scratch.
+
+### Capturing a `Scope` from a running `Operation`
+
+If you are in an operation, the `useScope()` function allows you to
+capture a reference to the current `Scope`. You can then use that
+scope to create tasks that are descendants of that original scope. An
+example of this would be to spawn a new operation for each request to
+an express server.
 
 Express handles the http request, but it does not know anything about
 Effection, and so we have to explicitly connect each request to an
@@ -318,13 +326,37 @@ And, because every request runs inside of our main scope when that scope
 exits because someone hit `CTRL-C`, then any in-flight requests will be
 canceled.
 
+### Creating a brand new `Scope`
+
 The other way to get a reference to a [`Scope`][scope] is to create a completely
 new one from scratch. This can be done with the [`createScope()`][create-scope]
 function. This will create a fresh scope that is completely disconnected from
-any other scope.
+any other scope. Scope supports both explicit resource management as well as
+manual destruction. The following example uses explicit resource management to
+execute fetch that will timeout after one second.
 
-One common use of [`createScope()`][create-scope] is for running operations in
-test cases.
+
+```js
+async function main() {
+  await using scope = createScope();
+
+  scope.run(function*() {
+    let response = yield* until(fetch("http://example.com"));
+    return yield* response.text();
+  }).then(response => console.log(response));
+
+  await scope.run(sleep(1000));
+} //=> scope is destroyed!
+```
+
+Normally, this is the best way to create a new Scope. However, you can
+also create and then manually destroy a `Scope` by hand. Use this
+method in cases where the scope is destroyed in different lexical
+scope than the one in which it is created. To do this, destructure the
+return value of `createScope()` to capture both the new scope as well
+as a reference to a async function that will destroy it.
+
+One common use is for running operations within test cases.
 
 ```js
 let scope;
@@ -345,9 +377,9 @@ afterEach(async () => {
 });
 ```
 
-Whenever you use `createScope()`, it is important that you `await` the
-destruction operation when the scope is no longer needed since it will not
-be destroyed implicitly.
+Whenever you use `createScope()` in this way, it is important that you
+`await` the destruction operation when the scope is no longer needed
+since it will not be destroyed implicitly.
 
 [spawn]: /api/v4/spawn
 [use-abort-signal]: /api/v4/useAbortSignal

--- a/docs/upgrade.mdx
+++ b/docs/upgrade.mdx
@@ -188,6 +188,20 @@ execution of their children. However, it does mean that if your v3
 code relied on child tasks starting immediately, you might need to
 adjust your approach.
 
+## Async Disposable Support
+
+Both `Task` and `Scope` now implement `Symbol.asyncDispose`. This
+allows them to be used with the `await using` syntax for automatic
+resource management or any other tool that consumes the
+`AsyncDisposable` interface.
+
+```js
+await using task = run(function*() {
+  yield* suspend();
+});
+// task is halted automatically
+```
+
 ## Migration Strategies
 
 Most of the changes from v3 to v4 will be caught by deprecation

--- a/lib/scope-internal.ts
+++ b/lib/scope-internal.ts
@@ -96,7 +96,7 @@ export function createScopeInternal(
   return [scope, destroy];
 }
 
-export interface ScopeInternal extends Scope {
+export interface ScopeInternal extends Scope, AsyncDisposable {
   contexts: Record<string, unknown>;
   ensure(op: () => Operation<void>): () => void;
 }

--- a/lib/scope.ts
+++ b/lib/scope.ts
@@ -35,15 +35,55 @@ export const global = createScopeInternal()[0] as Scope;
  * await destroy(); // prints "done!";
  * ```
  *
+ * `createScope()` also supports explicit resource management
+ * @example
+ * ```js
+ * {
+ *  await using scope = createScope();
+ *
+ *  let delay = scope.run(function*() {
+ *    yield* sleep(1000);
+ *  });
+ *
+ *  scope.run(function*() {
+ *    try {
+ *      yield* suspend();
+ *    } finally {
+ *      console.log('done!');
+ *    }
+ *  });
+ *
+ *  await delay;
+ *  // prints "done!";
+ * }
+ * ```
+ *
  * @param parent scope. If no parent is specified it will derive directly from {@link global}
  * @returns a tuple containing the freshly created scope, along with a function to
  *          destroy it.
  */
 export function createScope(
   parent: Scope = global,
-): [Scope, () => Future<void>] {
+): Scope & AsyncDisposable & [Scope, () => Future<void>] {
   let [scope, destroy] = createScopeInternal(parent);
-  return [scope, () => parent.run(destroy)];
+  let dispose = () => parent.run(destroy);
+
+  let tuple = [scope, dispose];
+
+  Object.defineProperty(scope, Symbol.iterator, {
+    value: tuple[Symbol.iterator].bind(tuple),
+    enumerable: false,
+  });
+
+  Object.defineProperty(scope, Symbol.asyncDispose, {
+    enumerable: false,
+    value: dispose,
+  });
+
+  return scope as unknown as
+    & Scope
+    & AsyncDisposable
+    & [Scope, () => Future<void>];
 }
 
 /**

--- a/lib/task.ts
+++ b/lib/task.ts
@@ -1,3 +1,4 @@
+/// <reference lib="esnext" />
 // deno-lint-ignore-file no-unsafe-finally
 import { DelimiterContext, ErrorContext } from "./delimiter.ts";
 import { createCoroutine } from "./coroutine.ts";
@@ -63,6 +64,10 @@ export function createTask<T>(options: TaskOptions<T>): NewTask<T> {
     [Symbol.toStringTag]: {
       enumerable: false,
       value: "Task",
+    },
+    [Symbol.asyncDispose]: {
+      enumerable: false,
+      value: () => task.halt(),
     },
   }) as Task<T>;
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -145,6 +145,8 @@ export interface Task<T> extends Future<T> {
    * Task is complete.
    */
   halt(): Future<void>;
+
+  [Symbol.asyncDispose](): Promise<void>;
 }
 
 /**

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -347,4 +347,43 @@ describe("run()", () => {
 
     expect(scope.expect(Children).size).toEqual(0);
   });
+
+  it("can be disposed with 'await using'", async () => {
+    let halted = false;
+
+    {
+      await using _ = run(function* () {
+        try {
+          yield* suspend();
+        } finally {
+          halted = true;
+        }
+      });
+    }
+
+    expect(halted).toEqual(true);
+  });
+
+  it("should throw when 'halt' is invoked after 'await using'", async () => {
+    let halted = false;
+    let error: Error | undefined;
+
+    let task = run(function* () {
+      try {
+        yield* suspend();
+      } finally {
+        halted = true;
+      }
+    });
+
+    {
+      await using _ = task;
+    }
+
+    await task.catch((e) => error = e);
+
+    expect(error).toBeDefined();
+    expect(error?.message).toEqual("halted");
+    expect(halted).toEqual(true);
+  });
 });

--- a/test/scope.test.ts
+++ b/test/scope.test.ts
@@ -1,4 +1,3 @@
-import { describe, expect, it } from "./suite.ts";
 import {
   createContext,
   createScope,
@@ -8,6 +7,7 @@ import {
   suspend,
   useScope,
 } from "../mod.ts";
+import { describe, expect, it } from "./suite.ts";
 
 describe("Scope", () => {
   it("can be used to run operations", async () => {
@@ -163,6 +163,29 @@ describe("Scope", () => {
 
     await destroy();
     expect(halted).toEqual(true);
+  });
+
+  it("should close scope when using 'using'", async () => {
+    let halted = false;
+    let error: Error | undefined;
+
+    {
+      await using scope = createScope();
+
+      let task = scope.run(function* () {
+        try {
+          yield* suspend();
+        } finally {
+          halted = true;
+        }
+      });
+
+      task.catch((e) => (error = e));
+    }
+
+    expect(halted).toEqual(true);
+    expect(error).toBeDefined();
+    expect(error?.message).toEqual("halted");
   });
 });
 


### PR DESCRIPTION
## Motivation

Cleanup effection task at application/effection boundary to avoid hanging operations.

> resolves #1023 

JavaScript now has a native scope based mechanism for cleanup called "Explicit Resource Management"

## Approach
This integrates this spec in two ways:

1. Every Task implements the AsyncDisposable api directly.
2. When calling `createScope()` the scope returned also implements AsyncDisposable interface

There is a bit of hackery that we needed to do with `createScope()` so that it can support both:

```ts
await using scope = createScope();
```
and

```ts
let [scope, destroy] = createScope();
```
