### PR TITLE
✨ Allow peformance optimizations by setting co-routine iterator

### DIFF
--- a/lib/coroutine.ts
+++ b/lib/coroutine.ts
@@ -26,6 +26,9 @@ export function createCoroutine<T>(
         }
         return iterator;
       },
+      set iterator(value) {
+        iterator = value;
+      },
       exit: (resolve) => resolve(Ok()),
     },
     next(result) {


### PR DESCRIPTION
## Motivation

In order to perform iterator hoisting wherein all iterators are consumed within a single yield point, we need a way to modify a co-routine's iterator.

## Approach

This just adds a corresponding setter for the iterator.
