### PR TITLE
◀️ point website duplicates to the canonical url

### DIFF
--- a/www/plugins/rebase.ts
+++ b/www/plugins/rebase.ts
@@ -80,3 +80,17 @@ export function* useAbsoluteUrlFactory(): Operation<(path: string) => string> {
     }
   };
 }
+
+/**
+ * Get the canonical url for the current path.
+ */
+export function* useCanonicalUrl(options: { base: string; }): Operation<string> {
+  let request = yield* CurrentRequest.expect()
+
+  let req = new URL(request.url);
+  let url = new URL(options.base);
+  url.pathname = `${url.pathname}${req.pathname}`;
+
+  return String(url);
+
+}

--- a/www/routes/app.html.tsx
+++ b/www/routes/app.html.tsx
@@ -3,7 +3,7 @@ import type { JSXChild } from "revolution";
 
 import { Footer } from "../components/footer.tsx";
 import { Header, type HeaderProps } from "../components/header.tsx";
-import { useAbsoluteUrl } from "../plugins/rebase.ts";
+import { useAbsoluteUrl, useCanonicalUrl } from "../plugins/rebase.ts";
 import { JSXElement } from "revolution/jsx-runtime";
 
 export type Options = {
@@ -28,6 +28,8 @@ export function* useAppHtml({
   );
   let homeURL = yield* useAbsoluteUrl("/");
 
+  let canonicalURL = yield* useCanonicalUrl({ base: "https://frontside.com/effection" });
+
   const header = yield* Header({ hasLeftSidebar });
 
   return ({ children, search }) => (
@@ -43,7 +45,7 @@ export function* useAppHtml({
         <meta name="twitter:image" content={twitterImageURL} />
         <link rel="icon" href="/assets/images/favicon-effection.png" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <link rel="canonical" href={homeURL} />
+        <link rel="canonical" href={canonicalURL} />
         <link rel="alternate" href={homeURL} hreflang="en" />
         <link rel="alternate" href={homeURL} hreflang="x-default" />
         <link


### PR DESCRIPTION
## Motivation

We do not want Google, Bing, and friends crawling these websites and indexing them independently of the main website. This happened to us recently when somehow the top google search result for "Effection JavasScript" yields to `https://effection-www.deno.dev`/ as its first result.

## Approach

This sets up a "canonical" url to point to the main effection site. It is mapped to whatever the current path is rebased onto https://frontside.com/effection/
