### PR TITLE
♻️ simplify spawn() by delegating to scope.run

### DIFF
--- a/lib/spawn.ts
+++ b/lib/spawn.ts
@@ -1,7 +1,5 @@
-import { Ok } from "./result.ts";
-import type { ScopeInternal } from "./scope-internal.ts";
-import { createTask, type NewTask } from "./task.ts";
-import type { Effect, Operation, Task } from "./types.ts";
+import { useScope } from "./scope.ts";
+import type { Operation, Task } from "./types.ts";
 
 /**
  * Run another operation concurrently as a child of the current one.
@@ -30,20 +28,11 @@ import type { Effect, Operation, Task } from "./types.ts";
  * @typeParam T the type that the spawned task evaluates to
  * @returns a {@link Task} representing a handle to the running operation
  */
-export function* spawn<T>(op: () => Operation<T>): Operation<Task<T>> {
-  let { task, start } = (yield Spawn(op)) as NewTask<T>;
-  start();
-  return task;
-}
-
-function Spawn<T>(operation: () => Operation<T>): Effect<NewTask<T>> {
+export function spawn<T>(op: () => Operation<T>): Operation<Task<T>> {
   return {
-    description: `spawn(${operation.name})`,
-    enter: (resolve, { scope }) => {
-      resolve(Ok(createTask({ owner: scope as ScopeInternal, operation })));
-      return (done) => {
-        done(Ok());
-      };
+    *[Symbol.iterator]() {
+      let scope = yield* useScope();
+      return scope.run(op);
     },
   };
 }


### PR DESCRIPTION
## Motivation
We're going to end up wrapping unified APIs around most Effection functions so that they can be decorated with middleware. As such, there is no need to have separate code paths for Scope.run() and Scope.spawn() since they end up calling the same thing under the hood.

## Approach
This has `spawn()` delegate to `Scope.run()` so that the apis can be unified and wrapped as one. In other words, wraping `Scope.run()` is the same as wrapping `spawn()`.