### PR TITLE
🙈 Ignore .env and .aider files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 .netlify
 /build/
 /node_modules/
+/.env
+/.aider*


### PR DESCRIPTION
## Motivation
This allows IDEs to use the Aider coding client along with env files without creating detritus inside the repo.
