### PR TITLE
🚨 Add linting rule to prefer-let

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -13,11 +13,14 @@
   },
   "lint": {
     "rules": { "exclude": ["prefer-const", "require-yield"] },
-    "exclude": ["build", "www", "docs", "tasks"]
+    "exclude": ["build", "www", "docs", "tasks"],
+    "plugins": ["lint/prefer-let.ts"]
   },
   "fmt": { "exclude": ["build", "www"] },
   "test": { "exclude": ["build"] },
-  "compilerOptions": { "lib": ["deno.ns", "esnext", "dom", "dom.iterable"] },
+  "compilerOptions": {
+    "lib": ["deno.ns", "esnext", "dom", "dom.iterable", "deno.unstable"]
+  },
   "imports": {
     "@std/testing": "jsr:@std/testing@1",
     "ts-expect": "npm:ts-expect@1.3.0",

--- a/lib/all.ts
+++ b/lib/all.ts
@@ -34,7 +34,7 @@ export function* all<T extends readonly Operation<unknown>[] | []>(
   try {
     return yield* trap(function* (): Operation<All<T>> {
       for (let operation of ops) {
-        const member = () => operation;
+        let member = () => operation;
         tasks.push(yield* spawn(member));
       }
       let results: unknown[] = [];

--- a/lib/reducer.ts
+++ b/lib/reducer.ts
@@ -23,7 +23,7 @@ export class Reducer {
       while (item) {
         let [, routine, result, _, method = "next" as const] = item;
         try {
-          const iterator = routine.data.iterator;
+          let iterator = routine.data.iterator;
           if (result.ok) {
             if (method === "next") {
               let next = iterator.next(result.value);

--- a/lint/prefer-let.ts
+++ b/lint/prefer-let.ts
@@ -1,0 +1,65 @@
+type VariableDeclaration = Deno.lint.VariableDeclaration;
+
+const plugin: Deno.lint.Plugin = {
+  name: "effection",
+  rules: {
+    "prefer-let": {
+      create(context) {
+        function isTopLevelScope(node: VariableDeclaration): boolean {
+          // deno-lint-ignore no-explicit-any
+          let current: any = node.parent;
+
+          // Walk up the tree until we find a function, block, or reach the program
+
+          while (current) {
+            switch (current.type) {
+              // These create new scopes - if we hit one, we're not at top level
+
+              case "FunctionDeclaration":
+              case "FunctionExpression":
+              case "ArrowFunctionExpression":
+              case "BlockStatement":
+                // Exception: BlockStatement that is direct child of Program is still top-level
+
+                if (
+                  current.type === "BlockStatement" &&
+                  current.parent?.type === "Program"
+                ) {
+                  current = current.parent;
+
+                  continue;
+                }
+
+                return false;
+
+              case "Program":
+                return true;
+              default:
+                current = current.parent;
+            }
+          }
+
+          return false;
+        }
+
+        return {
+          VariableDeclaration(node) {
+            if (node.kind === "var") {
+              context.report({
+                message: "prefer `let` over `var` to declare value bindings",
+                node,
+              });
+            } else if (node.kind === "const" && !isTopLevelScope(node)) {
+              context.report({
+                message: "`const` declaration outside top-level scope",
+                node,
+              });
+            }
+          },
+        };
+      },
+    },
+  },
+};
+
+export default plugin;

--- a/test/events.test.ts
+++ b/test/events.test.ts
@@ -4,8 +4,8 @@ import { describe, expectType, it } from "./suite.ts";
 
 describe("events", () => {
   describe("types", () => {
-    const domElement = {} as HTMLElement;
-    const socket = {} as WebSocket;
+    let domElement = {} as HTMLElement;
+    let socket = {} as WebSocket;
 
     it("should find event from eventTarget", () => {
       expectType<Operation<CloseEvent>>(once(socket, "close"));

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, x } from "./suite.ts";
 import { each, run, type Stream } from "../mod.ts";
 
 function* detect(stream: Stream<string, void>, text: string) {
-  for (const line of yield* each(stream)) {
+  for (let line of yield* each(stream)) {
     if (line.includes(text)) {
       return;
     }
@@ -17,7 +17,7 @@ describe("main", () => {
 
       yield* detect(proc.lines, "started");
 
-      const { exitCode, stdout } = yield* proc.kill("SIGINT");
+      let { exitCode, stdout } = yield* proc.kill("SIGINT");
 
       expect(stdout).toContain("gracefully stopped");
 
@@ -32,7 +32,7 @@ describe("main", () => {
 
         yield* detect(proc.lines, "started");
 
-        const { exitCode, stdout } = yield* proc.kill("SIGTERM");
+        let { exitCode, stdout } = yield* proc.kill("SIGTERM");
 
         expect(stdout).toContain("gracefully stopped");
 
@@ -56,7 +56,7 @@ describe("main", () => {
 
       yield* detect(proc.lines, "goodbye.");
 
-      const { exitCode } = yield* proc;
+      let { exitCode } = yield* proc;
 
       expect(exitCode).toEqual(0);
     });
@@ -66,7 +66,7 @@ describe("main", () => {
     await run(function* () {
       let proc = yield* x("deno", ["run", "test/main/fail.exit.ts"]);
 
-      const { stderr, exitCode, stdout } = yield* proc;
+      let { stderr, exitCode, stdout } = yield* proc;
 
       expect(stdout).toContain("graceful goodbye");
       expect(stderr).toContain("It all went horribly wrong");
@@ -78,7 +78,7 @@ describe("main", () => {
     await run(function* () {
       let proc = yield* x("deno", ["run", "test/main/fail.unexpected.ts"]);
 
-      const { stderr, stdout, exitCode } = yield* proc;
+      let { stderr, stdout, exitCode } = yield* proc;
 
       expect(stdout).toContain("graceful goodbye");
       expect(stderr).toContain("Error: moo");
@@ -92,7 +92,7 @@ describe("main", () => {
 
       yield* detect(proc.lines, "started");
 
-      const { exitCode, stdout } = yield* proc.kill("SIGINT");
+      let { exitCode, stdout } = yield* proc.kill("SIGINT");
 
       expect(exitCode).toBe(130);
       expect(stdout).toContain("gracefully stopped");


### PR DESCRIPTION
## Motivation

We have a long history of prefering `let` over `const` for local function variable bindings (https://www.npmjs.com/package/eslint-plugin-prefer-let) , but we haven't been able to use the `eslint` plugin because Effection is developed with Deno. We've just been muddling along, but ultimately it not fair to ask a community to adhere to a style, but not provide tool support for that style.

## Approach

This ports over the eslint plugin to Deno, installs it in our codebase, and makes the corrections that it found.