### PR TITLE
🚨 lint and format www/

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,12 +3,16 @@
 
 # Explicitly set line endings for text files
 *.ts text eol=lf
+*.tsx text eol=lf
 *.mjs text eol=lf
 *.js text eol=lf
+*.jsx text eol=lf
 *.json text eol=lf
 *.md text eol=lf
 *.yml text eol=lf
 *.yaml text eol=lf
+*.svg text eol=lf
+*.css text eol=lf
 
 # Binary files
 *.png binary

--- a/deno.json
+++ b/deno.json
@@ -13,10 +13,10 @@
   },
   "lint": {
     "rules": { "exclude": ["prefer-const", "require-yield"] },
-    "exclude": ["build", "www", "docs", "tasks"],
+    "exclude": ["build", "docs", "tasks"],
     "plugins": ["lint/prefer-let.ts"]
   },
-  "fmt": { "exclude": ["build", "www"] },
+  "fmt": { "exclude": ["build"] },
   "test": { "exclude": ["build"] },
   "compilerOptions": {
     "lib": ["deno.ns", "esnext", "dom", "dom.iterable", "deno.unstable"]

--- a/www/assets/search.js
+++ b/www/assets/search.js
@@ -11,13 +11,13 @@ import {
 } from "https://esm.sh/effection@4.0.0-beta.3";
 
 await main(function* () {
-  const input = document.getElementById("search");
+  let input = document.getElementById("search");
   if (!input) {
     console.log(`Search could not be setup because input was not found.`);
     return;
   }
 
-  const label = input.closest("label");
+  let label = input.closest("label");
   if (!label) {
     console.log(
       `Search could not be setup because label element was not found.`,
@@ -25,7 +25,7 @@ await main(function* () {
     return;
   }
 
-  const button = input.nextElementSibling;
+  let button = input.nextElementSibling;
   if (!button) {
     console.log(
       `Search could not be setup because button element was not found.`,
@@ -33,7 +33,7 @@ await main(function* () {
     return;
   }
 
-  const events = yield* join([
+  let events = yield* join([
     on(input, "focus"),
     on(button, "focus"),
     on(input, "blur"),
@@ -43,7 +43,7 @@ await main(function* () {
   /** @type {Task<void>} */
   let lastBlur;
   yield* spawn(function* () {
-    for (const event of yield* each(events)) {
+    for (let event of yield* each(events)) {
       if (event.type === "blur") {
         lastBlur = yield* spawn(function* () {
           yield* sleep(15);
@@ -62,7 +62,7 @@ await main(function* () {
     }
   });
 
-  for (const event of yield* each(on(document, "keydown"))) {
+  for (let event of yield* each(on(document, "keydown"))) {
     if (event.metaKey && event.key === "k") {
       event.preventDefault();
       input.focus();
@@ -82,11 +82,11 @@ await main(function* () {
  */
 function join(streams) {
   return resource(function* (provide) {
-    const channel = createChannel();
+    let channel = createChannel();
 
     yield* spawn(function* () {
       yield* all(streams.map(function* (stream) {
-        for (const event of yield* each(stream)) {
+        for (let event of yield* each(stream)) {
           yield* channel.send(event);
           yield* each.next();
         }

--- a/www/components/api/api-page.tsx
+++ b/www/components/api/api-page.tsx
@@ -73,21 +73,31 @@ export function* ApiPage({
                 series: s,
               });
               const seriesDocs = yield* seriesPkg.docs();
-              const hasSymbol = seriesDocs["."].some((node) => node.name === current);
+              const hasSymbol = seriesDocs["."].some((node) =>
+                node.name === current
+              );
 
               if (!hasSymbol) return null;
 
               return (
                 <a
                   href={yield* createRootUrl(`api/${s}`)(current)}
-                  class={`text-base ${s === currentSeries ? "font-bold text-sky-500" : "text-gray-600 dark:text-gray-400 hover:text-sky-500"}`}
+                  class={`text-base ${
+                    s === currentSeries
+                      ? "font-bold text-sky-500"
+                      : "text-gray-600 dark:text-gray-400 hover:text-sky-500"
+                  }`}
                 >
                   {seriesPkg.version}
                 </a>
               );
             }),
           );
-          return <span class="flex flex-row space-x-2">{...links.filter((link): link is JSXElement => link !== null)}</span>;
+          return (
+            <span class="flex flex-row space-x-2">
+              {...links.filter((link): link is JSXElement => link !== null)}
+            </span>
+          );
         })(),
       })}
     </>
@@ -143,7 +153,7 @@ export function* ApiReference({
   current,
   pages,
   linkResolver,
-  versionToggle
+  versionToggle,
 }: {
   pkg: Package;
   content: JSXElement;
@@ -174,7 +184,9 @@ export function* ApiReference({
   );
 }
 
-export function* SymbolHeader({ page, pkg }: { page: LocalDocPage; pkg: Package }) {
+export function* SymbolHeader(
+  { page, pkg }: { page: LocalDocPage; pkg: Package },
+) {
   return (
     <header class="flex flex-row items-center space-x-2">
       <h1 class="mb-0">

--- a/www/components/footer.tsx
+++ b/www/components/footer.tsx
@@ -38,7 +38,10 @@ export function Footer(): JSX.Element {
         <a href="/assets/llms.txt" class="text-gray-800 dark:text-gray-200">
           llms.txt
         </a>
-        <a href="https://raw.githubusercontent.com/thefrontside/effection/v4/AGENTS.md" class="text-gray-800 dark:text-gray-200">
+        <a
+          href="https://raw.githubusercontent.com/thefrontside/effection/v4/AGENTS.md"
+          class="text-gray-800 dark:text-gray-200"
+        >
           AGENTS.md
         </a>
       </section>

--- a/www/components/package/exports.tsx
+++ b/www/components/package/exports.tsx
@@ -17,9 +17,9 @@ export function* PackageExports({
   docs,
   linkResolver,
 }: PackageExportsParams) {
-  const elements: JSXElement[] = [];
+  let elements: JSXElement[] = [];
 
-  for (const [exportName, docPages] of Object.entries(docs)) {
+  for (let [exportName, docPages] of Object.entries(docs)) {
     if (docPages.filter((page) => page.kind !== "import").length > 0) {
       elements.push(
         yield* PackageExport({
@@ -48,10 +48,10 @@ function* PackageExport({
   docPages,
   linkResolver,
 }: PackageExportOptions): Operation<JSXElement> {
-  const exports: JSXChild[] = [];
+  let exports: JSXChild[] = [];
 
   for (
-    const page of docPages
+    let page of docPages
       .flatMap((page) => (page.kind === "import" ? [] : [page]))
       .sort((a, b) => a.name.localeCompare(b.name))
   ) {
@@ -94,9 +94,9 @@ function* PackageExport({
 }
 
 function chunk<T>(array: T[], chunkSize = 2): T[][] {
-  const chunks: T[][] = [];
+  let chunks: T[][] = [];
   for (let i = 0; i < array.length; i += chunkSize) {
-    const chunk = array.slice(i, i + chunkSize);
+    let chunk = array.slice(i, i + chunkSize);
     chunks.push(chunk);
   }
   return chunks;

--- a/www/components/package/header.tsx
+++ b/www/components/package/header.tsx
@@ -2,10 +2,10 @@ import type { Package } from "../../lib/package/types.ts";
 import { GithubPill } from "./source-link.tsx";
 
 export function* PackageHeader(pkg: Package) {
-  const name = yield* pkg.getName();
-  const version = yield* pkg.getVersion();
-  const scopeName = yield* pkg.getScopeName();
-  const shortName = name.includes("/") ? name.split("/")[1] : name;
+  let name = yield* pkg.getName();
+  let version = yield* pkg.getVersion();
+  let scopeName = yield* pkg.getScopeName();
+  let shortName = name.includes("/") ? name.split("/")[1] : name;
 
   return (
     <header class="space-y-3 mb-5">

--- a/www/components/type/jsx.tsx
+++ b/www/components/type/jsx.tsx
@@ -22,7 +22,7 @@ interface TypeProps {
 }
 
 export function* Type(props: TypeProps): Operation<JSXElement> {
-  const { node } = props;
+  let { node } = props;
 
   switch (node.kind) {
     case "function":
@@ -174,9 +174,9 @@ function TSParam({ param }: { param: ParamDef }) {
           <TSParam param={param.left} />
           <Operator>{" = "}</Operator>
           {param.tsType ? <TypeDef typeDef={param.tsType} /> : <></>}
-          {param.right === "[UNSUPPORTED]" ? "{}" : <></> }
+          {param.right === "[UNSUPPORTED]" ? "{}" : <></>}
         </>
-      )
+      );
     }
     default:
       console.log("<TSParam> unimplemented:", param);

--- a/www/components/type/markdown.tsx
+++ b/www/components/type/markdown.tsx
@@ -22,8 +22,8 @@ export const NO_DOCS_AVAILABLE = "*No documentation available.*";
 export function* extract(
   node: DocNode,
 ): Operation<{ markdown: string; ignore: boolean; pages: DocPage[] }> {
-  const lines = [];
-  const pages: DocPage[] = [];
+  let lines = [];
+  let pages: DocPage[] = [];
 
   let ignore = false;
 
@@ -31,11 +31,11 @@ export function* extract(
     lines.push(node.jsDoc.doc);
   }
 
-  const deprecated = node.jsDoc &&
+  let deprecated = node.jsDoc &&
     node.jsDoc.tags?.flatMap((tag) => (tag.kind === "deprecated" ? [tag] : []));
   if (deprecated && deprecated.length > 0) {
     lines.push(``);
-    for (const warning of deprecated) {
+    for (let warning of deprecated) {
       if (warning.doc) {
         lines.push(
           `<div class="border-l-4 border-red-500 mt-1 [&>*]:my-0 pl-3">
@@ -50,12 +50,12 @@ export function* extract(
     }
   }
 
-  const examples = node.jsDoc &&
+  let examples = node.jsDoc &&
     node.jsDoc.tags?.flatMap((tag) => (tag.kind === "example" ? [tag] : []));
   if (examples && examples?.length > 0) {
     lines.push("### Examples");
     let i = 1;
-    for (const example of examples) {
+    for (let example of examples) {
       lines.push(`#### Example ${i++}`, example.doc, "---");
     }
   }
@@ -63,7 +63,7 @@ export function* extract(
   if (node.kind === "class") {
     if (node.classDef.constructors.length > 0) {
       lines.push(`### Constructors`, "<dl>");
-      for (const constructor of node.classDef.constructors) {
+      for (let constructor of node.classDef.constructors) {
         lines.push(
           `<dt>${NEW} **${node.name}**(${
             constructor.params
@@ -78,14 +78,14 @@ export function* extract(
       lines.push("</dl>");
     }
 
-    const nonStatic = node.classDef.methods.filter(
+    let nonStatic = node.classDef.methods.filter(
       (method) => !method.isStatic,
     );
     if (nonStatic.length > 0) {
       lines.push("### Methods", `<dl>`, ...methodList(nonStatic), "</dl>");
     }
 
-    const staticMethods = node.classDef.methods.filter(
+    let staticMethods = node.classDef.methods.filter(
       (method) => method.isStatic,
     );
     if (staticMethods.length > 0) {
@@ -99,16 +99,16 @@ export function* extract(
   }
 
   if (node.kind === "namespace") {
-    const variables = node.namespaceDef.elements.flatMap((node) =>
+    let variables = node.namespaceDef.elements.flatMap((node) =>
       node.kind === "variable" ? [node] : []
     ) ?? [];
     if (variables.length > 0) {
       lines.push("### Variables");
       lines.push("<dl>");
-      for (const variable of variables) {
-        const name = `${node.name}.${variable.name}`;
-        const section = yield* extract(variable);
-        const description = variable.jsDoc?.doc || NO_DOCS_AVAILABLE;
+      for (let variable of variables) {
+        let name = `${node.name}.${variable.name}`;
+        let section = yield* extract(variable);
+        let description = variable.jsDoc?.doc || NO_DOCS_AVAILABLE;
         pages.push({
           name,
           kind: variable.kind,
@@ -142,9 +142,9 @@ export function* extract(
 
     if (node.interfaceDef.properties.length > 0) {
       lines.push("### Properties", "<dl>");
-      for (const property of node.interfaceDef.properties) {
-        const typeDef = property.tsType ? TypeDef(property.tsType) : "";
-        const description = property.jsDoc?.doc || NO_DOCS_AVAILABLE;
+      for (let property of node.interfaceDef.properties) {
+        let typeDef = property.tsType ? TypeDef(property.tsType) : "";
+        let description = property.jsDoc?.doc || NO_DOCS_AVAILABLE;
         lines.push(
           `<dt class="border-dotted dark:border-blue-900 [&:not(:first-child)]:border-t-1 [&:not(:first-child)]:pt-3 [&:not(:first-child)]:mt-2">**${property.name}**${
             property.readonly ? READONLY : ""
@@ -159,11 +159,11 @@ export function* extract(
 
     if (node.interfaceDef.methods.length > 0) {
       lines.push("### Methods", "<dl>");
-      for (const method of node.interfaceDef.methods) {
-        const typeParams = method.typeParams.map(TypeParam).join(", ");
-        const params = method.params.map(Param).join(", ");
-        const returnType = method.returnType ? TypeDef(method.returnType) : "";
-        const description = method.jsDoc?.doc || NO_DOCS_AVAILABLE;
+      for (let method of node.interfaceDef.methods) {
+        let typeParams = method.typeParams.map(TypeParam).join(", ");
+        let params = method.params.map(Param).join(", ");
+        let returnType = method.returnType ? TypeDef(method.returnType) : "";
+        let description = method.jsDoc?.doc || NO_DOCS_AVAILABLE;
         lines.push(
           `<dt class="border-dotted [&:not(:first-child)]:border-t-2 [&:not(:first-child)]:pt-3 [&:not(:first-child)]:mt-2"><h4 id="${method.name}" class="inline scroll-mt-[100px]">${method.name}</h4>${
             typeParams ? `&lt;${typeParams}&gt;` : ""
@@ -184,14 +184,14 @@ export function* extract(
   if (node.kind === "function") {
     lines.push(...TypeParams(node.functionDef.typeParams, node));
 
-    const { params } = node.functionDef;
+    let { params } = node.functionDef;
     if (params.length > 0) {
       lines.push("### Parameters");
-      const jsDocs = node.jsDoc?.tags?.flatMap((tag) =>
+      let jsDocs = node.jsDoc?.tags?.flatMap((tag) =>
         tag.kind === "param" ? [tag] : []
       ) ?? [];
       let i = 0;
-      for (const param of params) {
+      for (let param of params) {
         lines.push("\n", Param(param));
         if (jsDocs[i] && jsDocs[i].doc) {
           lines.push("\n", jsDocs[i].doc);
@@ -202,7 +202,7 @@ export function* extract(
 
     if (node.functionDef.returnType) {
       lines.push("### Return Type", "\n", TypeDef(node.functionDef.returnType));
-      const jsDocs = node.jsDoc?.tags?.find((tag) => tag.kind === "return");
+      let jsDocs = node.jsDoc?.tags?.find((tag) => tag.kind === "return");
       if (jsDocs && jsDocs.doc) {
         lines.push("\n", jsDocs.doc);
       }
@@ -213,9 +213,9 @@ export function* extract(
     lines.push("### Type", "\n", TypeDef(node.variableDef.tsType));
   }
 
-  const see: string[] = [];
+  let see: string[] = [];
   if (node.jsDoc && node.jsDoc.tags) {
-    for (const tag of node.jsDoc.tags) {
+    for (let tag of node.jsDoc.tags) {
       switch (tag.kind) {
         case "ignore": {
           ignore = true;
@@ -231,7 +231,7 @@ export function* extract(
     lines.push("\n", "### See", ...see.map((item) => `* ${item}`));
   }
 
-  const markdown = lines.join("\n");
+  let markdown = lines.join("\n");
 
   return {
     markdown,
@@ -248,11 +248,11 @@ export function TypeParams(typeParams: TsTypeParamDef[], node: DocNode) {
   let lines = [];
   if (typeParams.length > 0) {
     lines.push("### Type Parameters");
-    const jsDocs = node.jsDoc?.tags?.flatMap((tag) =>
+    let jsDocs = node.jsDoc?.tags?.flatMap((tag) =>
       tag.kind === "template" ? [tag] : []
     ) ?? [];
     let i = 0;
-    for (const typeParam of typeParams) {
+    for (let typeParam of typeParams) {
       lines.push(TypeParam(typeParam));
       if (jsDocs[i]) {
         lines.push(jsDocs[i].doc);
@@ -267,8 +267,8 @@ export function TypeParams(typeParams: TsTypeParamDef[], node: DocNode) {
 export function TypeDef(typeDef: TsTypeDef): string {
   switch (typeDef.kind) {
     case "fnOrConstructor": {
-      const params = typeDef.fnOrConstructor.params.map(Param).join(", ");
-      const tparams = typeDef.fnOrConstructor.typeParams
+      let params = typeDef.fnOrConstructor.params.map(Param).join(", ");
+      let tparams = typeDef.fnOrConstructor.typeParams
         .map(TypeParam)
         .join(", ");
       return `${tparams.length > 0 ? `&lt;${tparams}&gt;` : ""}(${params}) => ${
@@ -278,7 +278,7 @@ export function TypeDef(typeDef: TsTypeDef): string {
       }`;
     }
     case "typeRef": {
-      const tparams = typeDef.typeRef.typeParams?.map(TypeDef).join(", ");
+      let tparams = typeDef.typeRef.typeParams?.map(TypeDef).join(", ");
       return `{@link ${typeDef.typeRef.typeName}}${
         tparams && tparams?.length > 0 ? `&lt;${tparams}&gt;` : ""
       }`;
@@ -388,14 +388,14 @@ function Param(paramDef: ParamDef): string {
 }
 
 export function methodList(methods: ClassMethodDef[]) {
-  const lines = [];
-  for (const method of methods) {
-    const typeParams = method.functionDef.typeParams.map(TypeParam).join(", ");
-    const params = method.functionDef.params.map(Param).join(", ");
-    const returnType = method.functionDef.returnType
+  let lines = [];
+  for (let method of methods) {
+    let typeParams = method.functionDef.typeParams.map(TypeParam).join(", ");
+    let params = method.functionDef.params.map(Param).join(", ");
+    let returnType = method.functionDef.returnType
       ? TypeDef(method.functionDef.returnType)
       : "";
-    const description = method.jsDoc?.doc || NO_DOCS_AVAILABLE;
+    let description = method.jsDoc?.doc || NO_DOCS_AVAILABLE;
     lines.push(
       `<dt>**${method.name}**${
         typeParams ? `&lt;${typeParams}&gt;` : ""

--- a/www/context/config.ts
+++ b/www/context/config.ts
@@ -10,7 +10,9 @@ const ConfigContext = createContext<SiteConfig>("site-config", {
   current: "v4",
 });
 
-export function* initConfig<T extends string>(config: SiteConfig<T>): Operation<void> {
+export function* initConfig<T extends string>(
+  config: SiteConfig<T>,
+): Operation<void> {
   yield* ConfigContext.set(config);
 }
 

--- a/www/context/fetch.ts
+++ b/www/context/fetch.ts
@@ -16,17 +16,17 @@ export const fetchApi = createApi<FetchApi>("fetch", {
 export const { operations } = fetchApi;
 
 export function* initFetch() {
-  const cache = yield* until(caches.open("local-cache"));
+  let cache = yield* until(caches.open("local-cache"));
 
   yield* fetchApi.around({
     *fetch([input, init], next) {
       let request = input instanceof Request ? input : new Request(input, init);
       if (request.method === "GET") {
-        const response = yield* until(cache.match(request));
+        let response = yield* until(cache.match(request));
         if (response) {
           return response;
         } else {
-          const response = yield* next(input, init);
+          let response = yield* next(input, init);
           yield* until(cache.put(request, response.clone()));
           return response;
         }
@@ -37,14 +37,12 @@ export function* initFetch() {
 
   yield* fetchApi.around({
     *fetch([input, init], next) {
-      const url = input instanceof Request
-        ? new URL(input.url)
-        : new URL(input);
+      let url = input instanceof Request ? new URL(input.url) : new URL(input);
 
       if (url.protocol === "file:") {
         yield* log.debug(`Reading file system file from ${url}`);
         try {
-          const file = yield* until(Deno.open(url.pathname));
+          let file = yield* until(Deno.open(url.pathname));
           return new Response(file.readable);
         } catch (error) {
           if (error instanceof Deno.errors.NotFound) {
@@ -63,10 +61,8 @@ export function* initFetch() {
 
   yield* fetchApi.around({
     *fetch([input, init], next) {
-      const url = input instanceof Request
-        ? new URL(input.url)
-        : new URL(input);
-      const newUrl = yield* rewrite(url, input, init);
+      let url = input instanceof Request ? new URL(input.url) : new URL(input);
+      let newUrl = yield* rewrite(url, input, init);
       if (url !== newUrl) {
         yield* log.debug(`Rewrite ${url} to ${newUrl}`);
       }

--- a/www/context/jsr.ts
+++ b/www/context/jsr.ts
@@ -4,7 +4,7 @@ import { createJSRClient, JSRClient } from "../resources/jsr-client.ts";
 const JSRClientContext = createContext<JSRClient>("jsr-client");
 
 export function* initJSRClient() {
-  const token = Deno.env.get("JSR_API") ?? "";
+  let token = Deno.env.get("JSR_API") ?? "";
   if (token === "") {
     console.log("Missing JSR API token; expect score card not to load.");
   }

--- a/www/context/process.ts
+++ b/www/context/process.ts
@@ -14,7 +14,7 @@ export interface ProcessApi {
 
 export const processApi = createApi<ProcessApi>("process", {
   *useProcess(command: string, options): Operation<ProcessResult> {
-    const cwd = yield* useCwd();
+    let cwd = yield* useCwd();
     return yield* exec(command, {
       cwd,
       ...options,
@@ -22,13 +22,13 @@ export const processApi = createApi<ProcessApi>("process", {
   },
 });
 
-export const { useProcess } = processApi.operations;
+export let { useProcess } = processApi.operations;
 
 export function* drain(source: Stream<string, void>): Operation<string> {
-  const complete = withResolvers<string>();
+  let complete = withResolvers<string>();
   yield* spawn(function* () {
     let chunks = "";
-    for (const chunk of yield* each(source)) {
+    for (let chunk of yield* each(source)) {
       chunks += chunk;
       yield* each.next();
     }
@@ -43,28 +43,28 @@ export function urlFromCommand(command: string): URL {
 }
 
 export function* ProcessOutputCache(patterns: RegExp[]): Operation<void> {
-  const cache = yield* until(caches.open("command-cache"));
+  let cache = yield* until(caches.open("command-cache"));
 
   yield* processApi.around({
     *useProcess([command], next) {
       // Check if command matches any of the patterns
-      const shouldCache = patterns.some((pattern) => pattern.test(command));
+      let shouldCache = patterns.some((pattern) => pattern.test(command));
 
       if (!shouldCache) {
         return yield* next(command);
       }
 
-      const url = urlFromCommand(command);
+      let url = urlFromCommand(command);
 
       // Check if we have cached result
-      const cachedResponse = yield* until(cache.match(url));
+      let cachedResponse = yield* until(cache.match(url));
       if (cachedResponse) {
         // Return cached process with cached output
         return yield* createCachedProcess(cachedResponse);
       }
 
       // Execute the process normally
-      const process = yield* next(command);
+      let process = yield* next(command);
 
       yield* until(cache.put(url, new Response(process.stdout)));
 
@@ -85,7 +85,7 @@ function* createCachedProcess(
 }
 
 // Pattern for git show commands with named capture groups
-export const gitShowPattern = regex(
+export let gitShowPattern = regex(
   "^git show (?<owner>[^/]+)/(?<repo>[^/]+)/(?<branch>[^:]+):(?<path>.+)$",
 );
 
@@ -94,7 +94,7 @@ export const gitShowPattern = regex(
  */
 function* isDescendantOf(ref: string): Operation<boolean> {
   try {
-    const result = yield* exec(
+    let result = yield* exec(
       `git merge-base --is-ancestor ${ref} HEAD`,
     ).expect();
     return result.code === 0;
@@ -112,19 +112,19 @@ export function* ProcessFileSystemRead(
 ): Operation<void> {
   yield* processApi.around({
     *useProcess([command], next) {
-      const match = pattern.exec(command);
+      let match = pattern.exec(command);
 
       if (!match) {
         return yield* next(command);
       }
 
-      const { owner, repo, branch, path: filePath } = match.groups;
-      const repoPath = `${owner}/${repo}`;
-      const remote = `${owner}/${repo}/${branch}`;
+      let { owner, repo, branch, path: filePath } = match.groups;
+      let repoPath = `${owner}/${repo}`;
+      let remote = `${owner}/${repo}/${branch}`;
 
       // Check if origin matches the repository
-      const originResult = yield* exec("git remote get-url origin").expect();
-      const originUrl = originResult.stdout.trim();
+      let originResult = yield* exec("git remote get-url origin").expect();
+      let originUrl = originResult.stdout.trim();
 
       if (!originUrl.includes(repoPath)) {
         yield* log.debug(
@@ -133,7 +133,7 @@ export function* ProcessFileSystemRead(
         return yield* next(command);
       }
 
-      const isDescendant = yield* isDescendantOf(remote);
+      let isDescendant = yield* isDescendantOf(remote);
 
       if (!isDescendant) {
         yield* log.debug(
@@ -146,8 +146,8 @@ export function* ProcessFileSystemRead(
         yield* log.debug(
           `Reading ${filePath} from filesystem instead of executing: ${command}`,
         );
-        const basePath = fileURLToPath(new URL("../../", import.meta.url));
-        const [process] = yield* cwd(basePath, [next(`cat ${filePath}`)]);
+        let basePath = fileURLToPath(new URL("../../", import.meta.url));
+        let [process] = yield* cwd(basePath, [next(`cat ${filePath}`)]);
         return process;
       } catch (error) {
         yield* log.debug(

--- a/www/context/shell.ts
+++ b/www/context/shell.ts
@@ -21,10 +21,10 @@ export function* cwd<T extends readonly Operation<unknown>[]>(
 ): Operation<{ [K in keyof T]: T[K] extends Operation<infer R> ? R : never }> {
   return yield* scoped(function* () {
     yield* log.debug(`cwd: ${directory}`);
-    const result = yield* CwdContext.with(directory, function* () {
+    let result = yield* CwdContext.with(directory, function* () {
       yield* indent();
-      const results = [];
-      for (const op of ops) {
+      let results = [];
+      for (let op of ops) {
         results.push(yield* op);
       }
       // deno-lint-ignore no-explicit-any
@@ -38,7 +38,7 @@ export function* $echo(
   data: string | ReadableStream<string>,
   filename: string | URL,
 ): Operation<void> {
-  const cwd = yield* CwdContext.expect();
+  let cwd = yield* CwdContext.expect();
   if (typeof filename === "string") {
     yield* until(Deno.writeTextFile(join(cwd, filename), data));
     return;

--- a/www/deno.json
+++ b/www/deno.json
@@ -6,7 +6,14 @@
     "test": "deno test --allow-run --allow-write --allow-read"
   },
   "lint": {
-    "exclude": ["docs/esm"],
+    "exclude": [
+      "docs/esm",
+      "build",
+      "built",
+      "pagefind",
+      "routes/guides-route.tsx",
+      "components/api/api-page.tsx"
+    ],
     "rules": {
       "exclude": [
         "prefer-const",
@@ -18,7 +25,14 @@
     }
   },
   "fmt": {
-    "exclude": ["docs/esm"]
+    "exclude": [
+      "assets/images",
+      "docs/esm",
+      "build",
+      "built",
+      "pagefind",
+      "tailwind"
+    ]
   },
   "compilerOptions": {
     "lib": ["deno.ns", "dom.iterable", "dom"],

--- a/www/e4.ts
+++ b/www/e4.ts
@@ -37,7 +37,7 @@ export function generate(
 ) {
   return async function () {
     return await run(function* () {
-      const built = new URL(publicDir, import.meta.url);
+      let built = new URL(publicDir, import.meta.url);
 
       if (yield* exists(built, { isDirectory: true })) {
         log(`Reusing existing staticalized ${built.pathname} directory`);
@@ -56,11 +56,11 @@ export function generate(
 
       log("Adding index");
 
-      const index = yield* createPagefindIndex(indexOptions);
+      let index = yield* createPagefindIndex(indexOptions);
 
       log(`Adding directory: ${built.pathname}`);
 
-      const added = yield* index.addDirectory({ path: built.pathname });
+      let added = yield* index.addDirectory({ path: built.pathname });
 
       log(`Addedd ${added} pages from ${built.pathname}`);
 
@@ -74,7 +74,7 @@ export class EPagefindIndex {
   constructor(private readonly index: PagefindIndex) {}
 
   *addDirectory(path: SiteDirectory): Operation<number> {
-    const response = yield* call(() => this.index.addDirectory(path));
+    let response = yield* call(() => this.index.addDirectory(path));
     if (response.errors.length > 0) {
       console.error(
         `Encountered errors while adding ${path.path}: ${response.errors.join()}`,
@@ -84,7 +84,7 @@ export class EPagefindIndex {
   }
 
   *writeFiles(options?: WriteOptions): Operation<string> {
-    const response = yield* call(() => this.index.writeFiles(options));
+    let response = yield* call(() => this.index.writeFiles(options));
     if (response.errors.length > 0) {
       console.error(
         `Encountered errors while writing to ${options?.outputPath}: ${response.errors.join()}`,
@@ -96,7 +96,7 @@ export class EPagefindIndex {
 
 export function createPagefindIndex(config?: PagefindServiceConfig) {
   return resource<EPagefindIndex>(function* (provide) {
-    const { errors, index } = yield* call(() => createIndex(config));
+    let { errors, index } = yield* call(() => createIndex(config));
 
     if (!index) {
       throw new Error(`Failed to create an index: ${errors.join()}`);

--- a/www/hooks/use-deno-doc.tsx
+++ b/www/hooks/use-deno-doc.tsx
@@ -4,7 +4,7 @@ import {
   type DocNode,
   type DocOptions,
   LoadResponse,
-  Location
+  Location,
 } from "@deno/doc";
 import { call, type Operation, until, useScope } from "effection";
 import { createGraph } from "@deno/graph";
@@ -17,7 +17,7 @@ import { useDescription } from "./use-description-parse.tsx";
 
 // Matches npm/jsr specifiers like @std/testing/bdd or lodash/fp
 export const npmSpecifierPattern = regex(
-  "^(?:(?<scope>@[^/]+)/)?(?<package>[^/]+)(?<subpath>/.*)?$"
+  "^(?:(?<scope>@[^/]+)/)?(?<package>[^/]+)(?<subpath>/.*)?$",
 );
 
 export type { DocNode };
@@ -60,17 +60,17 @@ export function* useDocPages(
   specifier: string,
   imports?: Record<string, string>,
 ): Operation<DocsPages> {
-  const scope = yield* useScope();
+  let scope = yield* useScope();
 
-  const loader = (specifier: string) => scope.run(docLoader(specifier));
+  let loader = (specifier: string) => scope.run(docLoader(specifier));
 
   // If imports not provided, try to extract from deno.json
-  const resolvedImports = imports ?? (yield* extractImports(
+  let resolvedImports = imports ?? (yield* extractImports(
     new URL("./deno.json", specifier).toString(),
     loader,
   ));
 
-  const resolve = resolvedImports
+  let resolve = resolvedImports
     ? (specifier: string, referrer: string) => {
       let resolved: string = specifier;
       if (specifier in resolvedImports) {
@@ -80,12 +80,12 @@ export function* useDocPages(
       } else if (specifier.startsWith("node:")) {
         resolved = `npm:@types/node@^22.13.5`;
       } else {
-        const match = npmSpecifierPattern.exec(specifier);
+        let match = npmSpecifierPattern.exec(specifier);
         if (match) {
-          const { scope, package: pkg, subpath } = match.groups;
-          const baseKey = scope ? `${scope}/${pkg}` : pkg;
+          let { scope, package: pkg, subpath } = match.groups;
+          let baseKey = scope ? `${scope}/${pkg}` : pkg;
           if (baseKey in resolvedImports) {
-            const baseUrl = resolvedImports[baseKey];
+            let baseUrl = resolvedImports[baseKey];
             resolved = subpath ? `${baseUrl}${subpath}` : baseUrl;
           }
         }
@@ -94,18 +94,18 @@ export function* useDocPages(
     }
     : undefined;
 
-  const graph = yield* call(() =>
+  let graph = yield* call(() =>
     createGraph([specifier], {
       load: loader,
       resolve,
     })
   );
 
-  const externalDependencies: Dependency[] = graph.modules.flatMap((module) => {
+  let externalDependencies: Dependency[] = graph.modules.flatMap((module) => {
     if (module.kind === "external") {
-      const parts = module.specifier.match(/(.*):(.*)@(.*)/);
+      let parts = module.specifier.match(/(.*):(.*)@(.*)/);
       if (parts) {
-        const [, source, name, version] = parts;
+        let [, source, name, version] = parts;
         return [
           {
             source,
@@ -118,24 +118,24 @@ export function* useDocPages(
     return [];
   });
 
-  const docs = yield* useDenoDoc([specifier], {
+  let docs = yield* useDenoDoc([specifier], {
     load: loader,
     resolve,
   });
 
-  const entrypoints: Record<string, DocPage[]> = {};
+  let entrypoints: Record<string, DocPage[]> = {};
 
-  for (const [url, all] of Object.entries(docs)) {
-    const pages: DocPage[] = [];
+  for (let [url, all] of Object.entries(docs)) {
+    let pages: DocPage[] = [];
     for (
-      const [symbol, nodes] of Object.entries(
+      let [symbol, nodes] of Object.entries(
         Object.groupBy(all, (node) => node.name),
       )
     ) {
       if (nodes) {
-        const sections: DocPageSection[] = [];
-        for (const node of nodes) {
-          const { markdown, ignore, pages: _pages } = yield* extract(node);
+        let sections: DocPageSection[] = [];
+        for (let node of nodes) {
+          let { markdown, ignore, pages: _pages } = yield* extract(node);
           sections.push({
             id: exportHash(node, sections.length),
             node,
@@ -150,12 +150,12 @@ export function* useDocPages(
           );
         }
 
-        const markdown = sections
+        let markdown = sections
           .map((s) => s.markdown)
           .filter((m) => m)
           .join("");
 
-        const description = yield* useDescription(markdown);
+        let description = yield* useDescription(markdown);
 
         pages.push({
           name: symbol,
@@ -180,10 +180,10 @@ function docLoader(
   _checksum?: string,
 ): () => Operation<LoadResponse | undefined> {
   return function* downloadDocModules() {
-    const url = URL.parse(specifier);
+    let url = URL.parse(specifier);
 
     if (url?.protocol.startsWith("file")) {
-      const content = yield* until(Deno.readTextFile(url.pathname));
+      let content = yield* until(Deno.readTextFile(url.pathname));
       return {
         kind: "module",
         specifier,
@@ -191,9 +191,9 @@ function docLoader(
       };
     }
 
-    if (url?.host && ['github.com', 'jsr.io'].includes(url.host)) {
-      const response = yield* operations.fetch(specifier);
-      const content = yield* until(response.text());
+    if (url?.host && ["github.com", "jsr.io"].includes(url.host)) {
+      let response = yield* operations.fetch(specifier);
+      let content = yield* until(response.text());
       if (response.ok) {
         return {
           kind: "module",
@@ -217,19 +217,19 @@ export function isDocsPages(value: unknown): value is DocsPages {
   }
 
   // Check if each key is a string and value is an array of DocPage objects
-  for (const key in value) {
+  for (let key in value) {
     if (typeof key !== "string") {
       return false;
     }
 
-    const pages = (value as Record<string, unknown>)[key];
+    let pages = (value as Record<string, unknown>)[key];
 
     if (!Array.isArray(pages)) {
       return false;
     }
 
     // Check if each item in the array is a valid DocPage
-    for (const page of pages) {
+    for (let page of pages) {
       if (!isDocPage(page)) {
         return false;
       }
@@ -244,7 +244,7 @@ function isDocPage(value: unknown): value is DocPage {
     return false;
   }
 
-  const page = value as DocPage;
+  let page = value as DocPage;
 
   return (
     typeof page.name === "string" &&
@@ -262,7 +262,7 @@ function isDocPageSection(value: unknown): value is DocPageSection {
     return false;
   }
 
-  const section = value as DocPageSection;
+  let section = value as DocPageSection;
 
   return (
     typeof section.id === "string" &&
@@ -279,7 +279,7 @@ function isDependency(value: unknown): value is Dependency {
     return false;
   }
 
-  const dependency = value as Dependency;
+  let dependency = value as Dependency;
 
   return (
     typeof dependency.source === "string" &&
@@ -292,12 +292,12 @@ function* extractImports(
   url: string,
   loader: (specifier: string) => Operation<LoadResponse | undefined>,
 ) {
-  const module = yield* loader(url);
+  let module = yield* loader(url);
   if (!module) return;
-  const content = module.kind === "module"
+  let content = module.kind === "module"
     ? JSON.parse(`${module.content}`)
     : undefined;
-  const { imports } = DenoJsonSchema.parse(content);
+  let { imports } = DenoJsonSchema.parse(content);
 
   return imports;
 }
@@ -309,16 +309,16 @@ function* extractImports(
  */
 export type LocalDocsPages = Record<string, LocalDocPage[]>;
 
-export type LocalDocPage = DocPage & { sections: LocalDocPageSection[] }
+export type LocalDocPage = DocPage & { sections: LocalDocPageSection[] };
 
 export type LocalDocPageSection = DocPageSection & {
-  node: LocalDocNode
-}
+  node: LocalDocNode;
+};
 
 export type LocalDocNode = DocNode & {
-  location: LocalLocation
-}
+  location: LocalLocation;
+};
 
 export type LocalLocation = Location & {
-  url: URL
-}
+  url: URL;
+};

--- a/www/hooks/use-description-parse.tsx
+++ b/www/hooks/use-description-parse.tsx
@@ -9,12 +9,12 @@ import remarkRehype from "remark-rehype";
 import { trimAfterHR } from "../lib/trim-after-hr.ts";
 
 export function* useDescription(markdown: string): Operation<string> {
-  const file = yield* useMarkdownFile(markdown);
+  let file = yield* useMarkdownFile(markdown);
   return file.data?.meta?.description ?? "";
 }
 
 export function* useTitle(markdown: string): Operation<string> {
-  const file = yield* useMarkdownFile(markdown);
+  let file = yield* useMarkdownFile(markdown);
   return file.data?.meta?.title ?? "";
 }
 

--- a/www/hooks/use-markdown.test.ts
+++ b/www/hooks/use-markdown.test.ts
@@ -6,7 +6,7 @@ const sanitizer = createJsDocSanitizer();
 
 function sanitizedEquals(a: string, b: string) {
   Deno.test(`${a} => ${b}`, async function () {
-    const result = await run(function* () {
+    let result = await run(function* () {
       return yield* sanitizer(a);
     });
     assertEquals(result, b);

--- a/www/hooks/use-markdown.tsx
+++ b/www/hooks/use-markdown.tsx
@@ -18,7 +18,7 @@ export function* defaultLinkResolver(
   if (symbol && connector && method) {
     parts.push(connector, method);
   }
-  const name = parts.filter(Boolean).join("");
+  let name = parts.filter(Boolean).join("");
   if (name) {
     return `[${name}](${name})`;
   }
@@ -44,12 +44,12 @@ export function* useMarkdown(
    * I'm doing this pre-processing here because MDX throws a parse error when it encounteres `{@link }`.
    * I can't use a remark/rehype plugin to change this because they are applied after MDX parses is successful.
    */
-  const sanitize = createJsDocSanitizer(
+  let sanitize = createJsDocSanitizer(
     options?.linkResolver ?? defaultLinkResolver,
   );
-  const sanitized = yield* sanitize(markdown);
+  let sanitized = yield* sanitize(markdown);
 
-  const mod = yield* useMDX(sanitized, {
+  let mod = yield* useMDX(sanitized, {
     remarkPlugins: [remarkGfm, ...(options?.remarkPlugins ?? [])],
     rehypePlugins: [
       [removeDescriptionHR],
@@ -90,7 +90,7 @@ export function* useMarkdown(
 
   return yield* call(async () => {
     try {
-      const result = await mod.default();
+      let result = await mod.default();
       return result;
     } catch (e) {
       console.error(
@@ -110,7 +110,7 @@ export function createJsDocSanitizer(
       doc,
       /@?{@?link\s*(\w*)([^\w}])?(\w*)?([^}]*)?}/gm,
       function* (match) {
-        const [, symbol, connector, method] = match;
+        let [, symbol, connector, method] = match;
         return yield* resolver(symbol, connector, method);
       },
     );

--- a/www/lib/command-parser.test.ts
+++ b/www/lib/command-parser.test.ts
@@ -5,7 +5,7 @@ import { parseCommand, splitCommand } from "./command-parser.ts";
 describe("parseCommand", () => {
   // Test cases from minimist-string README
   it("solves the main minimist-string problem", function* () {
-    const result = parseCommand('foo --bar "Hello world!"');
+    let result = parseCommand('foo --bar "Hello world!"');
     expect(result).toEqual({
       _: ["foo"],
       bar: "Hello world!",
@@ -13,7 +13,7 @@ describe("parseCommand", () => {
   });
 
   it("handles escaped quotes correctly", function* () {
-    const result = parseCommand('foo --bar "Hello \\"world\\"!"');
+    let result = parseCommand('foo --bar "Hello \\"world\\"!"');
     expect(result).toEqual({
       _: ["foo"],
       bar: 'Hello "world"!',
@@ -21,7 +21,7 @@ describe("parseCommand", () => {
   });
 
   it("handles simple quoted string", function* () {
-    const result = parseCommand('foo --bar "Hello!"');
+    let result = parseCommand('foo --bar "Hello!"');
     expect(result).toEqual({
       _: ["foo"],
       bar: "Hello!",
@@ -30,7 +30,7 @@ describe("parseCommand", () => {
 
   // Additional comprehensive tests
   it("handles simple command without quotes", function* () {
-    const result = parseCommand("foo --bar hello");
+    let result = parseCommand("foo --bar hello");
     expect(result).toEqual({
       _: ["foo"],
       bar: "hello",
@@ -38,7 +38,7 @@ describe("parseCommand", () => {
   });
 
   it("handles multiple arguments", function* () {
-    const result = parseCommand("command arg1 arg2 --flag --option value");
+    let result = parseCommand("command arg1 arg2 --flag --option value");
     expect(result).toEqual({
       _: ["command", "arg1", "arg2"],
       flag: true,
@@ -47,7 +47,7 @@ describe("parseCommand", () => {
   });
 
   it("handles equals syntax for options", function* () {
-    const result = parseCommand("command --option=value --flag");
+    let result = parseCommand("command --option=value --flag");
     expect(result).toEqual({
       _: ["command"],
       option: "value",
@@ -56,7 +56,7 @@ describe("parseCommand", () => {
   });
 
   it("handles short flags", function* () {
-    const result = parseCommand("command -f -abc value");
+    let result = parseCommand("command -f -abc value");
     expect(result).toEqual({
       _: ["command"],
       f: true,
@@ -67,7 +67,7 @@ describe("parseCommand", () => {
   });
 
   it("handles mixed quotes", function* () {
-    const result = parseCommand(
+    let result = parseCommand(
       `command --single 'Hello world' --double "Hello world"`,
     );
     expect(result).toEqual({
@@ -78,7 +78,7 @@ describe("parseCommand", () => {
   });
 
   it("handles complex git command", function* () {
-    const result = parseCommand('git commit -m "Initial commit with spaces"');
+    let result = parseCommand('git commit -m "Initial commit with spaces"');
     expect(result).toEqual({
       _: ["git", "commit"],
       m: "Initial commit with spaces",
@@ -86,7 +86,7 @@ describe("parseCommand", () => {
   });
 
   it("handles empty quotes", function* () {
-    const result = parseCommand('command --empty ""');
+    let result = parseCommand('command --empty ""');
     expect(result).toEqual({
       _: ["command"],
       empty: "",
@@ -94,7 +94,7 @@ describe("parseCommand", () => {
   });
 
   it("handles boolean flags", function* () {
-    const result = parseCommand("command --verbose --quiet");
+    let result = parseCommand("command --verbose --quiet");
     expect(result).toEqual({
       _: ["command"],
       verbose: true,
@@ -103,7 +103,7 @@ describe("parseCommand", () => {
   });
 
   it("handles hyphenated options", function* () {
-    const result = parseCommand("command --dry-run --output-dir /tmp");
+    let result = parseCommand("command --dry-run --output-dir /tmp");
     expect(result).toEqual({
       _: ["command"],
       "dry-run": true,
@@ -114,12 +114,12 @@ describe("parseCommand", () => {
 
 describe("splitCommand", () => {
   it("splits simple command without quotes", function* () {
-    const result = splitCommand("git status --porcelain");
+    let result = splitCommand("git status --porcelain");
     expect(result).toEqual(["git", "status", "--porcelain"]);
   });
 
   it("preserves quoted strings with spaces", function* () {
-    const result = splitCommand('git commit -m "Initial commit with spaces"');
+    let result = splitCommand('git commit -m "Initial commit with spaces"');
     expect(result).toEqual([
       "git",
       "commit",
@@ -129,12 +129,12 @@ describe("splitCommand", () => {
   });
 
   it("handles escaped quotes", function* () {
-    const result = splitCommand('echo "Hello \\"world\\""');
+    let result = splitCommand('echo "Hello \\"world\\""');
     expect(result).toEqual(["echo", 'Hello "world"']);
   });
 
   it("handles mixed quotes", function* () {
-    const result = splitCommand(
+    let result = splitCommand(
       `command --single 'Hello world' --double "Hello world"`,
     );
     expect(result).toEqual([
@@ -147,12 +147,12 @@ describe("splitCommand", () => {
   });
 
   it("handles empty quotes", function* () {
-    const result = splitCommand('command --empty ""');
+    let result = splitCommand('command --empty ""');
     expect(result).toEqual(["command", "--empty", ""]);
   });
 
   it("handles multiple spaces", function* () {
-    const result = splitCommand("  command    arg1    arg2  ");
+    let result = splitCommand("  command    arg1    arg2  ");
     expect(result).toEqual(["command", "arg1", "arg2"]);
   });
 });

--- a/www/lib/command-parser.ts
+++ b/www/lib/command-parser.ts
@@ -17,12 +17,12 @@ export function splitCommand(input: string): string[] {
     return input.trim().split(/\s+/);
   }
 
-  const wrongPieces = input.split(" ");
+  let wrongPieces = input.split(" ");
   let goodPieces = solveQuotes(wrongPieces, '"');
   goodPieces = solveQuotes(goodPieces, "'");
 
   // Remove outer quotes but preserve escaped quotes
-  const regexQuotes = /["']/g;
+  let regexQuotes = /["']/g;
   for (let i = 0; i < goodPieces.length; i++) {
     goodPieces[i] = goodPieces[i].replace(/(\\\')/g, "%%%SINGLEQUOTE%%%");
     goodPieces[i] = goodPieces[i].replace(/(\\\")/g, "%%%DOUBLEQUOTE%%%");
@@ -50,18 +50,18 @@ export function parseCommand(input: string): ParsedCommand {
 }
 
 function parseSimple(input: string): ParsedCommand {
-  const pieces = input.trim().split(/\s+/);
+  let pieces = input.trim().split(/\s+/);
   return parseTokens(pieces);
 }
 
 function parseWithQuotes(input: string): ParsedCommand {
-  const wrongPieces = input.split(" ");
+  let wrongPieces = input.split(" ");
 
   let goodPieces = solveQuotes(wrongPieces, '"');
   goodPieces = solveQuotes(goodPieces, "'");
 
   // Remove outer quotes but preserve escaped quotes
-  const regexQuotes = /["']/g;
+  let regexQuotes = /["']/g;
   for (let i = 0; i < goodPieces.length; i++) {
     goodPieces[i] = goodPieces[i].replace(/(\\\')/g, "%%%SINGLEQUOTE%%%");
     goodPieces[i] = goodPieces[i].replace(/(\\\")/g, "%%%DOUBLEQUOTE%%%");
@@ -74,8 +74,8 @@ function parseWithQuotes(input: string): ParsedCommand {
 }
 
 function countQuotes(piece: string, quoteChar: string): number {
-  const regex = new RegExp(`[^${quoteChar}\\\\]`, "g");
-  const replaced = piece.replace(regex, "");
+  let regex = new RegExp(`[^${quoteChar}\\\\]`, "g");
+  let replaced = piece.replace(regex, "");
   return replaced
     .replace(new RegExp(`(\\\\${quoteChar})`, "g"), "")
     .replace(/\\/g, "").length;
@@ -94,23 +94,23 @@ function getFirstQuote(piece: string, quoteChar: string, position = 0): number {
 }
 
 function splitPiece(piece: string, quoteChar: string): [string, string] {
-  const firstQIndex = getFirstQuote(piece, quoteChar);
-  const secondQIndex = getFirstQuote(piece, quoteChar, firstQIndex + 1);
+  let firstQIndex = getFirstQuote(piece, quoteChar);
+  let secondQIndex = getFirstQuote(piece, quoteChar, firstQIndex + 1);
 
-  const firstPart = piece.substring(0, secondQIndex + 1);
-  const secondPart = piece.substring(secondQIndex + 1);
+  let firstPart = piece.substring(0, secondQIndex + 1);
+  let secondPart = piece.substring(secondQIndex + 1);
 
   return [firstPart, secondPart];
 }
 
 function solveQuotes(pieces: string[], quoteChar: string): string[] {
   let unclosedQuote = false;
-  const result: string[] = [];
+  let result: string[] = [];
 
   for (let i = 0; i < pieces.length; i++) {
     if (unclosedQuote) {
       if (hasQuote(pieces[i], quoteChar)) {
-        const qIndex = getFirstQuote(pieces[i], quoteChar);
+        let qIndex = getFirstQuote(pieces[i], quoteChar);
         if (qIndex !== pieces[i].length - 1) {
           // Closing quote is not the last character
           pieces[i + 1] = pieces[i].substring(qIndex + 1) +
@@ -125,19 +125,19 @@ function solveQuotes(pieces: string[], quoteChar: string): string[] {
       }
     } else {
       if (hasQuote(pieces[i], quoteChar)) {
-        const quoteCount = countQuotes(pieces[i], quoteChar);
+        let quoteCount = countQuotes(pieces[i], quoteChar);
 
         if (quoteCount === 1) {
           result.push(pieces[i]);
           unclosedQuote = true;
         } else if (quoteCount === 2) {
-          const split = splitPiece(pieces[i], quoteChar);
+          let split = splitPiece(pieces[i], quoteChar);
           result.push(split[0]);
           if (split[1] !== "") result.push(split[1]);
         } else {
           let next = pieces[i];
           do {
-            const split = splitPiece(next, quoteChar);
+            let split = splitPiece(next, quoteChar);
             result.push(split[0]);
             next = split[1];
           } while (countQuotes(next, quoteChar) > 2);
@@ -162,20 +162,20 @@ function solveQuotes(pieces: string[], quoteChar: string): string[] {
 }
 
 function parseTokens(tokens: string[]): ParsedCommand {
-  const result: ParsedCommand = { _: [] };
+  let result: ParsedCommand = { _: [] };
 
   for (let i = 0; i < tokens.length; i++) {
-    const token = tokens[i];
+    let token = tokens[i];
 
     if (token.startsWith("--")) {
       // Long option
-      const equalIndex = token.indexOf("=");
+      let equalIndex = token.indexOf("=");
       if (equalIndex !== -1) {
-        const key = token.substring(2, equalIndex);
-        const value = token.substring(equalIndex + 1);
+        let key = token.substring(2, equalIndex);
+        let value = token.substring(equalIndex + 1);
         result[key] = value;
       } else {
-        const key = token.substring(2);
+        let key = token.substring(2);
         // Check if next token is a value
         if (i + 1 < tokens.length && !tokens[i + 1].startsWith("-")) {
           result[key] = tokens[++i];
@@ -185,10 +185,10 @@ function parseTokens(tokens: string[]): ParsedCommand {
       }
     } else if (token.startsWith("-") && token.length > 1) {
       // Short option(s)
-      const flags = token.substring(1);
+      let flags = token.substring(1);
 
       for (let j = 0; j < flags.length; j++) {
-        const flag = flags[j];
+        let flag = flags[j];
 
         if (j === flags.length - 1) {
           // Last flag - might have a value

--- a/www/lib/deno-json.ts
+++ b/www/lib/deno-json.ts
@@ -13,7 +13,7 @@ export const DenoJsonSchema = z.object({
 export type DenoJson = z.infer<typeof DenoJsonSchema>;
 
 export function* useDenoJson(path: string): Operation<DenoJson> {
-  const { default: json } = yield* until(
+  let { default: json } = yield* until(
     import(path, { with: { type: "json" } }),
   );
 

--- a/www/lib/ensure-trailing-slash.ts
+++ b/www/lib/ensure-trailing-slash.ts
@@ -1,5 +1,5 @@
 export function ensureTrailingSlash(url: URL) {
-  const isFile = url.pathname.split("/").at(-1)?.includes(".");
+  let isFile = url.pathname.split("/").at(-1)?.includes(".");
   if (isFile || url.pathname.endsWith("/")) {
     return url;
   }

--- a/www/lib/links-resolvers.ts
+++ b/www/lib/links-resolvers.ts
@@ -8,8 +8,8 @@ export const createSibling: ResolveLinkFunction = function* (
   connector,
   method,
 ): Operation<string> {
-  const request = yield* CurrentRequest.expect();
-  const url = new URL(request.url);
+  let request = yield* CurrentRequest.expect();
+  let url = new URL(request.url);
   url.pathname = join(dirname(url.pathname), pathname);
   if (connector && method) {
     url.hash = `#${method}`;
@@ -19,8 +19,8 @@ export const createSibling: ResolveLinkFunction = function* (
 
 export function createChildURL(prefix?: string) {
   return function* (pathname: string): Operation<string> {
-    const request = yield* CurrentRequest.expect();
-    const url = new URL(request.url);
+    let request = yield* CurrentRequest.expect();
+    let url = new URL(request.url);
     url.pathname = join(
       "",
       ...[url.pathname, prefix, pathname].flatMap((s) => s ? [s] : []),
@@ -31,8 +31,8 @@ export function createChildURL(prefix?: string) {
 
 export function createRootUrl(prefix?: string) {
   return function* (pathname: string): Operation<string> {
-    const request = yield* CurrentRequest.expect();
-    const url = new URL(request.url);
+    let request = yield* CurrentRequest.expect();
+    let url = new URL(request.url);
     url.pathname = join("", ...[prefix, pathname].flatMap((s) => s ? [s] : []));
     return url.toString().replace(url.origin, "");
   };

--- a/www/lib/octokit.ts
+++ b/www/lib/octokit.ts
@@ -5,11 +5,11 @@ import { operations } from "../context/fetch.ts";
 const OctokitContext = createContext<Octokit>("github-client");
 
 export function* initOctokitContext() {
-  const token = Deno.env.get("GITHUB_TOKEN");
+  let token = Deno.env.get("GITHUB_TOKEN");
 
-  const scope = yield* useScope();
+  let scope = yield* useScope();
 
-  const octokit = new Octokit({
+  let octokit = new Octokit({
     auth: token,
     request: {
       fetch: (url: string, init?: RequestInit) => {
@@ -25,9 +25,9 @@ export function* initOctokitContext() {
  * Get star count for a repository using Octokit
  */
 export function* getStarCount(nameWithOwner: string): Operation<number> {
-  const github = yield* OctokitContext.expect();
-  const [owner, name] = nameWithOwner.split("/");
-  const response = yield* until(
+  let github = yield* OctokitContext.expect();
+  let [owner, name] = nameWithOwner.split("/");
+  let response = yield* until(
     github.rest.repos.get({
       repo: name,
       owner: owner,

--- a/www/lib/package.ts
+++ b/www/lib/package.ts
@@ -1,25 +1,21 @@
 import { all, Operation, until } from "effection";
-import { fileURLToPath } from "node:url";
 import { relative } from "node:path";
+import { fileURLToPath } from "node:url";
 
-import {
-  DocsPages,
-  LocalDocsPages,
-  useDocPages,
-} from "../hooks/use-deno-doc.tsx";
-import { createRepo, Ref } from "./repo.ts";
-import { extractVersion, findLatestSemverTag } from "./semver.ts";
-import { useWorktree } from "./worktrees.ts";
-import { DenoJson, useDenoJson } from "./deno-json.ts";
+import z from "zod";
+import { SiteConfig } from "../context/config.ts";
+import { useJSRClient } from "../context/jsr.ts";
+import { LocalDocsPages, useDocPages } from "../hooks/use-deno-doc.tsx";
+import { useDescription, useTitle } from "../hooks/use-description-parse.tsx";
+import { useMDX } from "../hooks/use-mdx.tsx";
 import {
   PackageDetailsResult,
   PackageScoreResult,
 } from "../resources/jsr-client.ts";
-import { useJSRClient } from "../context/jsr.ts";
-import z from "zod";
-import { useMDX } from "../hooks/use-mdx.tsx";
-import { useDescription, useTitle } from "../hooks/use-description-parse.tsx";
-import { SiteConfig } from "../context/config.ts";
+import { DenoJson, useDenoJson } from "./deno-json.ts";
+import { createRepo, Ref } from "./repo.ts";
+import { extractVersion, findLatestSemverTag } from "./semver.ts";
+import { useWorktree } from "./worktrees.ts";
 
 export type WorkTreePackageOptions = {
   type: "worktree";
@@ -145,7 +141,7 @@ function* initPackage(
       let docs: LocalDocsPages = {};
 
       for (let [entrypoint, url] of Object.entries(pkg.entrypoints)) {
-        const pages = yield* useDocPages(`${url}`);
+        let pages = yield* useDocPages(`${url}`);
 
         docs[entrypoint] = pages[`${url}`].map((page) => {
           return {
@@ -157,7 +153,12 @@ function* initPackage(
                 location: {
                   ...section.node.location,
                   url: new URL(
-                    `${relative(path, fileURLToPath(section.node.location.filename))}#L${section.node.location.line}`,
+                    `${
+                      relative(
+                        path,
+                        fileURLToPath(section.node.location.filename),
+                      )
+                    }#L${section.node.location.line}`,
                     `${ref.url}/`,
                   ),
                 },
@@ -186,9 +187,9 @@ function* initPackage(
       ]
     > {
       let [, packageName] = name.split("/");
-      const client = yield* useJSRClient();
+      let client = yield* useJSRClient();
       try {
-        const [details, score] = yield* all([
+        let [details, score] = yield* all([
           client.getPackageDetails({ scope, package: packageName }),
           client.getPackageScore({ scope, package: packageName }),
         ]);

--- a/www/lib/package/deno.ts
+++ b/www/lib/package/deno.ts
@@ -9,8 +9,8 @@ import { registries } from "../registries/mod.ts";
 import { useDocPages } from "../../hooks/use-deno-doc.tsx";
 import { useMDX } from "../../hooks/use-mdx.tsx";
 import {
-  useTitle,
   useDescription,
+  useTitle,
 } from "../../hooks/use-description-parse.tsx";
 
 /**
@@ -47,7 +47,7 @@ function normalizeExports(
  */
 function parseScope(name: string | undefined): string | undefined {
   if (!name) return undefined;
-  const match = name.match(/@([^/]+)\//);
+  let match = name.match(/@([^/]+)\//);
   return match ? match[1] : undefined;
 }
 
@@ -65,12 +65,12 @@ export function createDenoPackage(
   workspacePath: string,
   ref: Ref,
 ): Package {
-  const manifestUrl = new URL(`${path}/deno.json`, "file://");
+  let manifestUrl = new URL(`${path}/deno.json`, "file://");
 
   // We'll compute these lazily from the manifest
   let cachedName: string | undefined;
 
-  const pkg: Package = {
+  let pkg: Package = {
     manifestUrl,
     path,
     workspaceName,
@@ -82,17 +82,17 @@ export function createDenoPackage(
 
     // Registry URLs - will use the cached name once loaded
     get npm() {
-      const name = cachedName ?? `@effectionx/${workspaceName}`;
+      let name = cachedName ?? `@effectionx/${workspaceName}`;
       return new URL(`./${name}`, "https://www.npmjs.com/package/");
     },
     get npmVersionBadge() {
-      const name = cachedName ?? `@effectionx/${workspaceName}`;
+      let name = cachedName ?? `@effectionx/${workspaceName}`;
       return new URL(`./${name}`, "https://img.shields.io/npm/v/");
     },
 
     *getManifest(): Operation<PackageManifest> {
-      const content = yield* until(Deno.readTextFile(`${path}/deno.json`));
-      const denoJson = DenoJsonSchema.parse(JSON.parse(content));
+      let content = yield* until(Deno.readTextFile(`${path}/deno.json`));
+      let denoJson = DenoJsonSchema.parse(JSON.parse(content));
 
       // Cache the name for URL getters
       if (denoJson.name) {
@@ -109,47 +109,47 @@ export function createDenoPackage(
     },
 
     *getName(): Operation<string> {
-      const manifest = yield* this.getManifest();
+      let manifest = yield* this.getManifest();
       return manifest.name ?? workspaceName;
     },
 
     *getVersion(): Operation<string> {
-      const manifest = yield* this.getManifest();
+      let manifest = yield* this.getManifest();
       return manifest.version ?? "0.0.0";
     },
 
     *getScopeName(): Operation<string | undefined> {
-      const manifest = yield* this.getManifest();
+      let manifest = yield* this.getManifest();
       return parseScope(manifest.name);
     },
 
     *getExports(): Operation<Record<string, string>> {
-      const manifest = yield* this.getManifest();
+      let manifest = yield* this.getManifest();
       return manifest.exports;
     },
 
     *getImports(): Operation<Record<string, string>> {
-      const manifest = yield* this.getManifest();
+      let manifest = yield* this.getManifest();
       return manifest.imports;
     },
 
     *getEntrypoints(): Operation<Record<string, URL>> {
-      const manifest = yield* this.getManifest();
-      const entrypoints: Record<string, URL> = {};
-      for (const [key, value] of Object.entries(manifest.exports)) {
+      let manifest = yield* this.getManifest();
+      let entrypoints: Record<string, URL> = {};
+      for (let [key, value] of Object.entries(manifest.exports)) {
         entrypoints[key] = new URL(value, `file://${path}/`);
       }
       return entrypoints;
     },
 
     *getDocs(): Operation<LocalDocsPages> {
-      const entrypoints = yield* this.getEntrypoints();
-      const imports = yield* this.getImports();
+      let entrypoints = yield* this.getEntrypoints();
+      let imports = yield* this.getImports();
 
-      const docs: LocalDocsPages = {};
+      let docs: LocalDocsPages = {};
 
-      for (const [entrypoint, url] of Object.entries(entrypoints)) {
-        const pages = yield* useDocPages(`${url}`, imports);
+      for (let [entrypoint, url] of Object.entries(entrypoints)) {
+        let pages = yield* useDocPages(`${url}`, imports);
 
         docs[entrypoint] = pages[`${url}`].map((page) => ({
           ...page,
@@ -160,7 +160,12 @@ export function createDenoPackage(
               location: {
                 ...section.node.location,
                 url: new URL(
-                  `${relative(path, fileURLToPath(section.node.location.filename))}#L${section.node.location.line}`,
+                  `${
+                    relative(
+                      path,
+                      fileURLToPath(section.node.location.filename),
+                    )
+                  }#L${section.node.location.line}`,
                   `${ref.url}/`,
                 ),
               },
@@ -177,18 +182,18 @@ export function createDenoPackage(
     },
 
     *getMDXContent(): Operation<JSX.Element> {
-      const readme = yield* this.getReadme();
-      const mod = yield* useMDX(readme);
+      let readme = yield* this.getReadme();
+      let mod = yield* useMDX(readme);
       return mod.default({});
     },
 
     *getTitle(): Operation<string> {
-      const readme = yield* this.getReadme();
+      let readme = yield* this.getReadme();
       return yield* useTitle(readme);
     },
 
     *getDescription(): Operation<string> {
-      const readme = yield* this.getReadme();
+      let readme = yield* this.getReadme();
       return yield* useDescription(readme);
     },
   };

--- a/www/lib/package/mod.ts
+++ b/www/lib/package/mod.ts
@@ -1,3 +1,7 @@
 export type { Package, PackageManifest, Ref } from "./types.ts";
-export { createDenoPackage, DenoJsonSchema, type DenoJson } from "./deno.ts";
-export { createNodePackage, PackageJsonSchema, type PackageJson } from "./node.ts";
+export { createDenoPackage, type DenoJson, DenoJsonSchema } from "./deno.ts";
+export {
+  createNodePackage,
+  type PackageJson,
+  PackageJsonSchema,
+} from "./node.ts";

--- a/www/lib/package/node.ts
+++ b/www/lib/package/node.ts
@@ -9,8 +9,8 @@ import { registries } from "../registries/mod.ts";
 import { useDocPages } from "../../hooks/use-deno-doc.tsx";
 import { useMDX } from "../../hooks/use-mdx.tsx";
 import {
-  useTitle,
   useDescription,
+  useTitle,
 } from "../../hooks/use-description-parse.tsx";
 
 /**
@@ -79,16 +79,16 @@ function normalizeExports(
 
   // Check if it's a conditional export object (has development/default keys)
   if ("development" in exports || "default" in exports) {
-    const resolved = resolveExportValue(
+    let resolved = resolveExportValue(
       exports as z.infer<typeof ExportConditionsSchema>,
     );
     return resolved ? { ".": resolved } : { ".": "./src/index.ts" };
   }
 
   // It's a record of entrypoints
-  const result: Record<string, string> = {};
-  for (const [key, value] of Object.entries(exports)) {
-    const resolved = resolveExportValue(value);
+  let result: Record<string, string> = {};
+  for (let [key, value] of Object.entries(exports)) {
+    let resolved = resolveExportValue(value);
     if (resolved) {
       result[key] = resolved;
     }
@@ -118,15 +118,15 @@ function sanitizeVersion(version: string): string {
  * Converts npm package names to npm: specifiers.
  */
 function buildImports(packageJson: PackageJson): Record<string, string> {
-  const imports: Record<string, string> = {};
+  let imports: Record<string, string> = {};
 
-  const allDeps = {
+  let allDeps = {
     ...packageJson.dependencies,
     ...packageJson.peerDependencies,
   };
 
-  for (const [name, version] of Object.entries(allDeps)) {
-    const sanitizedVersion = sanitizeVersion(version);
+  for (let [name, version] of Object.entries(allDeps)) {
+    let sanitizedVersion = sanitizeVersion(version);
     imports[name] = `npm:${name}@${sanitizedVersion}`;
   }
 
@@ -138,7 +138,7 @@ function buildImports(packageJson: PackageJson): Record<string, string> {
  */
 function parseScope(name: string | undefined): string | undefined {
   if (!name) return undefined;
-  const match = name.match(/@([^/]+)\//);
+  let match = name.match(/@([^/]+)\//);
   return match ? match[1] : undefined;
 }
 
@@ -156,12 +156,12 @@ export function createNodePackage(
   workspacePath: string,
   ref: Ref,
 ): Package {
-  const manifestUrl = new URL(`${path}/package.json`, "file://");
+  let manifestUrl = new URL(`${path}/package.json`, "file://");
 
   // We'll compute these lazily from the manifest
   let cachedName: string | undefined;
 
-  const pkg: Package = {
+  let pkg: Package = {
     manifestUrl,
     path,
     workspaceName,
@@ -173,17 +173,17 @@ export function createNodePackage(
 
     // Registry URLs - will use the cached name once loaded
     get npm() {
-      const name = cachedName ?? `@effectionx/${workspaceName}`;
+      let name = cachedName ?? `@effectionx/${workspaceName}`;
       return new URL(`./${name}`, "https://www.npmjs.com/package/");
     },
     get npmVersionBadge() {
-      const name = cachedName ?? `@effectionx/${workspaceName}`;
+      let name = cachedName ?? `@effectionx/${workspaceName}`;
       return new URL(`./${name}`, "https://img.shields.io/npm/v/");
     },
 
     *getManifest(): Operation<PackageManifest> {
-      const content = yield* until(Deno.readTextFile(`${path}/package.json`));
-      const packageJson = PackageJsonSchema.parse(JSON.parse(content));
+      let content = yield* until(Deno.readTextFile(`${path}/package.json`));
+      let packageJson = PackageJsonSchema.parse(JSON.parse(content));
 
       // Cache the name for URL getters
       if (packageJson.name) {
@@ -200,47 +200,47 @@ export function createNodePackage(
     },
 
     *getName(): Operation<string> {
-      const manifest = yield* this.getManifest();
+      let manifest = yield* this.getManifest();
       return manifest.name ?? workspaceName;
     },
 
     *getVersion(): Operation<string> {
-      const manifest = yield* this.getManifest();
+      let manifest = yield* this.getManifest();
       return manifest.version ?? "0.0.0";
     },
 
     *getScopeName(): Operation<string | undefined> {
-      const manifest = yield* this.getManifest();
+      let manifest = yield* this.getManifest();
       return parseScope(manifest.name);
     },
 
     *getExports(): Operation<Record<string, string>> {
-      const manifest = yield* this.getManifest();
+      let manifest = yield* this.getManifest();
       return manifest.exports;
     },
 
     *getImports(): Operation<Record<string, string>> {
-      const manifest = yield* this.getManifest();
+      let manifest = yield* this.getManifest();
       return manifest.imports;
     },
 
     *getEntrypoints(): Operation<Record<string, URL>> {
-      const manifest = yield* this.getManifest();
-      const entrypoints: Record<string, URL> = {};
-      for (const [key, value] of Object.entries(manifest.exports)) {
+      let manifest = yield* this.getManifest();
+      let entrypoints: Record<string, URL> = {};
+      for (let [key, value] of Object.entries(manifest.exports)) {
         entrypoints[key] = new URL(value, `file://${path}/`);
       }
       return entrypoints;
     },
 
     *getDocs(): Operation<LocalDocsPages> {
-      const entrypoints = yield* this.getEntrypoints();
-      const imports = yield* this.getImports();
+      let entrypoints = yield* this.getEntrypoints();
+      let imports = yield* this.getImports();
 
-      const docs: LocalDocsPages = {};
+      let docs: LocalDocsPages = {};
 
-      for (const [entrypoint, url] of Object.entries(entrypoints)) {
-        const pages = yield* useDocPages(`${url}`, imports);
+      for (let [entrypoint, url] of Object.entries(entrypoints)) {
+        let pages = yield* useDocPages(`${url}`, imports);
 
         docs[entrypoint] = pages[`${url}`].map((page) => ({
           ...page,
@@ -251,7 +251,12 @@ export function createNodePackage(
               location: {
                 ...section.node.location,
                 url: new URL(
-                  `${relative(path, fileURLToPath(section.node.location.filename))}#L${section.node.location.line}`,
+                  `${
+                    relative(
+                      path,
+                      fileURLToPath(section.node.location.filename),
+                    )
+                  }#L${section.node.location.line}`,
                   `${ref.url}/`,
                 ),
               },
@@ -268,18 +273,18 @@ export function createNodePackage(
     },
 
     *getMDXContent(): Operation<JSX.Element> {
-      const readme = yield* this.getReadme();
-      const mod = yield* useMDX(readme);
+      let readme = yield* this.getReadme();
+      let mod = yield* useMDX(readme);
       return mod.default({});
     },
 
     *getTitle(): Operation<string> {
-      const readme = yield* this.getReadme();
+      let readme = yield* this.getReadme();
       return yield* useTitle(readme);
     },
 
     *getDescription(): Operation<string> {
-      const readme = yield* this.getReadme();
+      let readme = yield* this.getReadme();
       return yield* useDescription(readme);
     },
   };

--- a/www/lib/registries/jsr.ts
+++ b/www/lib/registries/jsr.ts
@@ -1,5 +1,5 @@
 import type { Operation } from "effection";
-import type { Registry, PackageDetails, PackageScore } from "./types.ts";
+import type { PackageDetails, PackageScore, Registry } from "./types.ts";
 
 export const jsr: Registry = {
   name: "JSR",

--- a/www/lib/registries/mod.ts
+++ b/www/lib/registries/mod.ts
@@ -1,8 +1,8 @@
 export type {
-  Registry,
-  Registries,
   PackageDetails,
   PackageScore,
+  Registries,
+  Registry,
 } from "./types.ts";
 export { jsr } from "./jsr.ts";
 export { npm } from "./npm.ts";

--- a/www/lib/registries/npm.ts
+++ b/www/lib/registries/npm.ts
@@ -1,5 +1,5 @@
 import type { Operation } from "effection";
-import type { Registry, PackageDetails, PackageScore } from "./types.ts";
+import type { PackageDetails, PackageScore, Registry } from "./types.ts";
 
 export const npm: Registry = {
   name: "npm",

--- a/www/lib/remove-description-hr.ts
+++ b/www/lib/remove-description-hr.ts
@@ -11,7 +11,7 @@ export function removeDescriptionHR() {
         node.type === "element" && node.tagName === "hr" &&
         parent?.type === "root"
       ) {
-        const beforeHR = parent.children
+        let beforeHR = parent.children
           .slice(0, index)
           .filter((node: Nodes) =>
             !(node.type === "text" && node.value === "\n")

--- a/www/lib/replace-all.ts
+++ b/www/lib/replace-all.ts
@@ -6,17 +6,17 @@ export function* replaceAll(
   replacement: (match: RegExpMatchArray) => Operation<string>,
 ): Operation<string> {
   // replace all implies global, so append if it is missing
-  const addGlobal = !regex.flags.includes("g");
+  let addGlobal = !regex.flags.includes("g");
   let flags = regex.flags;
   if (addGlobal) flags += "g";
 
   // get matches
   let matcher = new RegExp(regex.source, flags);
-  const matches = Array.from(input.matchAll(matcher));
+  let matches = Array.from(input.matchAll(matcher));
 
   if (matches.length == 0) return input;
 
-  // construct all replacements
+  // letruct all replacements
   let replacements: Array<string>;
   replacements = new Array<string>();
   for (let m of matches) {
@@ -29,7 +29,7 @@ export function* replaceAll(
   let source = regex.source.replace(/(?<!\\)\((?!\?:)/g, "(?:");
   let splitter = new RegExp(source, flags);
 
-  const parts = input.split(splitter);
+  let parts = input.split(splitter);
 
   // stitch everything back together
   let result = parts[0];

--- a/www/lib/semver.ts
+++ b/www/lib/semver.ts
@@ -3,7 +3,7 @@ export { compare, major, minor, rsort } from "semver";
 import { rsort } from "semver";
 
 export function extractVersion(input: string) {
-  const parts = input.match(
+  let parts = input.match(
     // @source: https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
     /(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?/,
   );
@@ -22,6 +22,6 @@ export function extractVersion(input: string) {
 export function findLatestSemverTag<T extends { name: string }>(
   tags: T[],
 ): T | undefined {
-  const [latest] = rsort(tags.map((tag) => tag.name).map(extractVersion));
+  let [latest] = rsort(tags.map((tag) => tag.name).map(extractVersion));
   return tags.find((tag) => tag.name.endsWith(latest));
 }

--- a/www/lib/shift-headings.ts
+++ b/www/lib/shift-headings.ts
@@ -6,7 +6,7 @@ export function shiftHeadings(amount: number) {
   return (tree: Root) => {
     visit(tree, (node: Nodes) => {
       if (node.type === "heading") {
-        const depth = node.depth + amount;
+        let depth = node.depth + amount;
         if (depth < 1) {
           node.depth = 1;
         } else if (depth > 6) {

--- a/www/lib/toc.ts
+++ b/www/lib/toc.ts
@@ -8,7 +8,7 @@ import type { Nodes } from "hast";
 import { JSXElement } from "revolution/jsx-runtime";
 
 export function createToc(root: Nodes, options?: Options): JSXElement {
-  const _options = new NormalizedOptions(
+  let _options = new NormalizedOptions(
     options ?? {
       cssClasses: {
         toc:

--- a/www/lib/workspaces/mod.ts
+++ b/www/lib/workspaces/mod.ts
@@ -40,7 +40,7 @@ function detectWorkspaceType(
  * Hidden packages start with "." (e.g., ".internal")
  */
 function isHiddenPackage(pathOrName: string): boolean {
-  const name = pathOrName.split("/").pop() ?? pathOrName;
+  let name = pathOrName.split("/").pop() ?? pathOrName;
   return name.startsWith(".");
 }
 
@@ -53,9 +53,9 @@ function* expandPatterns(
   rootPath: string,
   patterns: string[],
 ): Operation<string[]> {
-  const dirs: string[] = [];
+  let dirs: string[] = [];
 
-  for (const pattern of patterns) {
+  for (let pattern of patterns) {
     // Skip hidden/internal package patterns
     if (isHiddenPackage(pattern)) {
       continue;
@@ -63,11 +63,11 @@ function* expandPatterns(
 
     if (pattern.endsWith("/*")) {
       // Simple glob: packages/* -> list directories in packages/
-      const basePath = pattern.slice(0, -2);
-      const fullPath = resolve(rootPath, basePath);
+      let basePath = pattern.slice(0, -2);
+      let fullPath = resolve(rootPath, basePath);
 
       try {
-        for (const entry of Deno.readDirSync(fullPath)) {
+        for (let entry of Deno.readDirSync(fullPath)) {
           // Skip hidden directories (internal packages)
           if (entry.isDirectory && !entry.name.startsWith(".")) {
             dirs.push(`${basePath}/${entry.name}`);
@@ -92,8 +92,8 @@ function* expandPatterns(
  * Get workspace patterns from a Deno monorepo (from deno.json workspace field).
  */
 function* getDenoPatterns(rootPath: string): Operation<string[]> {
-  const content = yield* until(Deno.readTextFile(`${rootPath}/deno.json`));
-  const denoJson = DenoJsonSchema.parse(JSON.parse(content));
+  let content = yield* until(Deno.readTextFile(`${rootPath}/deno.json`));
+  let denoJson = DenoJsonSchema.parse(JSON.parse(content));
   return denoJson.workspace ?? [];
 }
 
@@ -101,11 +101,11 @@ function* getDenoPatterns(rootPath: string): Operation<string[]> {
  * Get workspace patterns from a Node/PNPM monorepo.
  */
 function* getNodePatterns(rootPath: string): Operation<string[]> {
-  const content = yield* until(
+  let content = yield* until(
     Deno.readTextFile(`${rootPath}/pnpm-workspace.yaml`),
   );
-  const parsed = parseYaml(content);
-  const workspace = PnpmWorkspaceSchema.parse(parsed);
+  let parsed = parseYaml(content);
+  let workspace = PnpmWorkspaceSchema.parse(parsed);
   return workspace.packages;
 }
 
@@ -115,8 +115,8 @@ function* getNodePatterns(rootPath: string): Operation<string[]> {
  * @param nameWithOwner - GitHub repo in "owner/repo" format
  */
 export function* useWorkspaces(nameWithOwner: string): Operation<Workspaces> {
-  const rootPath = yield* useClone(nameWithOwner);
-  const type = detectWorkspaceType(rootPath);
+  let rootPath = yield* useClone(nameWithOwner);
+  let type = detectWorkspaceType(rootPath);
 
   if (!type) {
     throw new Error(
@@ -125,32 +125,30 @@ export function* useWorkspaces(nameWithOwner: string): Operation<Workspaces> {
     );
   }
 
-  const url = `https://github.com/${nameWithOwner}`;
-  const refName = "main";
+  let url = `https://github.com/${nameWithOwner}`;
+  let refName = "main";
 
   // Get workspace patterns based on type
-  const patterns =
-    type === "deno"
-      ? yield* getDenoPatterns(rootPath)
-      : yield* getNodePatterns(rootPath);
+  let patterns = type === "deno"
+    ? yield* getDenoPatterns(rootPath)
+    : yield* getNodePatterns(rootPath);
 
   // Expand patterns to actual directories
-  const workspaceDirs = yield* expandPatterns(rootPath, patterns);
+  let workspaceDirs = yield* expandPatterns(rootPath, patterns);
 
   // Create ref builder
-  const createRef = (workspacePath: string): Ref => ({
+  let createRef = (workspacePath: string): Ref => ({
     name: refName,
     nameWithOwner,
     url: `${url}/tree/${refName}/${workspacePath}`,
   });
 
   // Create package factory based on type
-  const createPackage =
-    type === "deno"
-      ? (path: string, name: string, workspacePath: string, ref: Ref) =>
-          createDenoPackage(path, name, workspacePath, ref)
-      : (path: string, name: string, workspacePath: string, ref: Ref) =>
-          createNodePackage(path, name, workspacePath, ref);
+  let createPackage = type === "deno"
+    ? (path: string, name: string, workspacePath: string, ref: Ref) =>
+      createDenoPackage(path, name, workspacePath, ref)
+    : (path: string, name: string, workspacePath: string, ref: Ref) =>
+      createNodePackage(path, name, workspacePath, ref);
 
   // Build lookup caches lazily
   let packagesByWorkspace: Map<string, Package> | undefined;
@@ -162,17 +160,17 @@ export function* useWorkspaces(nameWithOwner: string): Operation<Workspaces> {
     packagesByWorkspace = new Map();
     packagesByName = new Map();
 
-    for (const workspacePath of workspaceDirs) {
-      const fullPath = resolve(rootPath, workspacePath);
-      const workspaceName = workspacePath.split("/").pop()!;
-      const ref = createRef(workspacePath);
+    for (let workspacePath of workspaceDirs) {
+      let fullPath = resolve(rootPath, workspacePath);
+      let workspaceName = workspacePath.split("/").pop()!;
+      let ref = createRef(workspacePath);
 
-      const pkg = createPackage(fullPath, workspaceName, workspacePath, ref);
+      let pkg = createPackage(fullPath, workspaceName, workspacePath, ref);
       packagesByWorkspace.set(workspaceName, pkg);
 
       // Get package name for the name lookup
       try {
-        const manifest = yield* pkg.getManifest();
+        let manifest = yield* pkg.getManifest();
         if (manifest.name) {
           packagesByName.set(manifest.name, pkg);
         }
@@ -182,7 +180,7 @@ export function* useWorkspaces(nameWithOwner: string): Operation<Workspaces> {
     }
   }
 
-  const workspaces: Workspaces = {
+  let workspaces: Workspaces = {
     url,
     nameWithOwner,
     workspacePatterns: patterns,

--- a/www/main.tsx
+++ b/www/main.tsx
@@ -29,7 +29,7 @@ import { currentRequestPlugin } from "./plugins/current-request.ts";
 // Learn more at https://docs.deno.com/runtime/manual/examples/module_metadata#concepts
 if (import.meta.main) {
   await main(function* () {
-    const { current, series } = yield* useConfig();
+    let { current, series } = yield* useConfig();
 
     yield* initClones("build/clones");
     yield* initWorktrees("build/worktrees");
@@ -51,7 +51,7 @@ if (import.meta.main) {
         route("/docs", redirectIndexRoute(firstPage(current))),
         route("/docs/:id", redirectDocsRoute(current)),
         ...series.map((s) =>
-          route(`/guides/${s}`, redirectIndexRoute(firstPage(s))),
+          route(`/guides/${s}`, redirectIndexRoute(firstPage(s)))
         ),
         route("/guides/:series/:id", guidesRoute({ search: true })),
         route("/contrib", xIndexRedirect()),
@@ -60,7 +60,7 @@ if (import.meta.main) {
         route("/x/:workspacePath", xPackageRoute({ search: true })),
         route("/api", apiIndexRoute({ search: true })),
         ...series.map((s) =>
-          route(`/api/${s}/:symbol`, apiReferenceRoute(s, { search: true })),
+          route(`/api/${s}/:symbol`, apiReferenceRoute(s, { search: true }))
         ),
         route(
           "/pagefind{/*path}",
@@ -70,7 +70,7 @@ if (import.meta.main) {
       ],
       plugins: [
         yield* tailwindPlugin({ input: "main.css", outdir: "tailwind" }),
-	currentRequestPlugin(),
+        currentRequestPlugin(),
         etagPlugin(),
         sitemapPlugin(),
       ],

--- a/www/plugins/current-request.ts
+++ b/www/plugins/current-request.ts
@@ -8,8 +8,8 @@ export function currentRequestPlugin(): RevolutionPlugin {
     *http(request, next) {
       yield* CurrentRequest.set(request);
       return yield* next(request);
-    }
-  }
+    },
+  };
 }
 
 /**
@@ -23,14 +23,14 @@ export function* useAbsoluteUrl(path: string = "/"): Operation<string> {
 }
 
 export function* useAbsoluteUrlFactory(): Operation<(path: string) => string> {
-  let request = yield* CurrentRequest.expect()
+  let request = yield* CurrentRequest.expect();
 
   return (path) => {
     let normalizedPath = posixNormalize(path);
     if (normalizedPath.startsWith("/")) {
       let url = new URL(request.url);
-      url.pathname = normalizedPath
-      url.search = '';
+      url.pathname = normalizedPath;
+      url.search = "";
       return url.toString();
     } else {
       return new URL(path, request.url).toString();
@@ -41,8 +41,8 @@ export function* useAbsoluteUrlFactory(): Operation<(path: string) => string> {
 /**
  * Get the canonical url for the current path.
  */
-export function* useCanonicalUrl(options: { base: string; }): Operation<string> {
-  let request = yield* CurrentRequest.expect()
+export function* useCanonicalUrl(options: { base: string }): Operation<string> {
+  let request = yield* CurrentRequest.expect();
 
   let req = new URL(request.url);
   let url = new URL(options.base);

--- a/www/plugins/sitemap.ts
+++ b/www/plugins/sitemap.ts
@@ -104,7 +104,7 @@ export function route<T>(
   if (isSitemapRoute<T>(middleware)) {
     let handler = revolutionRoute(pattern, middleware.handler);
     if (middleware.routemap) {
-      const { routemap } = middleware;
+      let { routemap } = middleware;
       Object.defineProperty(handler, "sitemapExtension", {
         value(request: Request) {
           let generate = compile(pattern);

--- a/www/plugins/tailwind.ts
+++ b/www/plugins/tailwind.ts
@@ -64,8 +64,8 @@ npm:@tailwindcss/cli@^4.0.0 \
 
   if (yield* until(exists(output))) {
     let content = yield* until(Deno.readFile(output));
-    const buffer = yield* until(crypto.subtle.digest("SHA-256", content));
-    const hash = encodeHex(buffer);
+    let buffer = yield* until(crypto.subtle.digest("SHA-256", content));
+    let hash = encodeHex(buffer);
     return {
       filepath: output,
       csspath: `/${output}`,

--- a/www/resources/guides.ts
+++ b/www/resources/guides.ts
@@ -65,7 +65,7 @@ export type GuidesOptions = {
 };
 
 export function* initGuides(options: GuidesOptions): Operation<void> {
-  const guides = new Map<string, Guides>();
+  let guides = new Map<string, Guides>();
 
   let path = yield* useGitRoot();
   guides.set(options.current, yield* loadGuides(path));
@@ -134,7 +134,7 @@ export function loadGuides(dirpath: string): Operation<Guides> {
               Deno.readTextFile(`${dirpath}/${meta.filename}`),
             );
 
-            const content = yield* useMarkdown(source);
+            let content = yield* useMarkdown(source);
 
             return {
               ...meta,
@@ -149,7 +149,7 @@ export function loadGuides(dirpath: string): Operation<Guides> {
 
     yield* provide({
       *first() {
-        const [[_id, task]] = loaders.entries();
+        let [[_id, task]] = loaders.entries();
         return yield* task;
       },
       *all() {

--- a/www/resources/jsr-client.ts
+++ b/www/resources/jsr-client.ts
@@ -58,7 +58,7 @@ export function createJSRClient(token: string): Operation<JSRClient> {
   return resource<JSRClient>(function* (provide) {
     yield* provide({
       *getPackageScore(params) {
-        const response = yield* call(() =>
+        let response = yield* call(() =>
           fetch(
             `https://api.jsr.io/scopes/${params.scope}/packages/${params.package}/score`,
             {
@@ -70,7 +70,7 @@ export function createJSRClient(token: string): Operation<JSRClient> {
         );
 
         if (response.ok) {
-          const json = yield* call(() => response.json());
+          let json = yield* call(() => response.json());
           return yield* call(() => PackageScore.safeParseAsync(json));
         }
 
@@ -82,7 +82,7 @@ export function createJSRClient(token: string): Operation<JSRClient> {
         );
       },
       *getPackageDetails(params) {
-        const response = yield* call(() =>
+        let response = yield* call(() =>
           fetch(
             `https://api.jsr.io/scopes/${params.scope}/packages/${params.package}`,
             {
@@ -94,7 +94,7 @@ export function createJSRClient(token: string): Operation<JSRClient> {
         );
 
         if (response.ok) {
-          const json = yield* call(() => response.json());
+          let json = yield* call(() => response.json());
           return yield* call(() => PackageDetails.safeParseAsync(json));
         }
 

--- a/www/routes/api-index-route.tsx
+++ b/www/routes/api-index-route.tsx
@@ -31,7 +31,7 @@ export function apiIndexRoute(
         v4: yield* v4.docs(),
       };
 
-      const AppHtml = yield* useAppHtml({
+      let AppHtml = yield* useAppHtml({
         title: `API Reference | Effection`,
         description: `API Reference for Effection`,
       });
@@ -89,10 +89,10 @@ function* listPages({
   pages: DocPage[];
   linkResolver: ResolveLinkFunction;
 }) {
-  const elements = [];
+  let elements = [];
 
-  for (const page of pages.sort((a, b) => a.name.localeCompare(b.name))) {
-    const link = yield* linkResolver(page.name);
+  for (let page of pages.sort((a, b) => a.name.localeCompare(b.name))) {
+    let link = yield* linkResolver(page.name);
     elements.push(
       <li class="list-none pb-1">
         <a class="text-blue-700 dark:text-blue-400" href={link}>

--- a/www/routes/api-reference-route.tsx
+++ b/www/routes/api-reference-route.tsx
@@ -42,13 +42,13 @@ export function apiReferenceRoute(series: SiteConfig["series"][number], {
 
       let docs = yield* pkg.docs();
 
-      const pages = docs["."];
+      let pages = docs["."];
 
-      const page = pages.find((node) => node.name === symbol);
+      let page = pages.find((node) => node.name === symbol);
 
       if (!page) throw new Error(`Could not find a doc page for ${symbol}`);
 
-      const AppHtml = yield* useAppHtml({
+      let AppHtml = yield* useAppHtml({
         title: `${symbol} | API Reference | Effection`,
         description: page.description,
       });

--- a/www/routes/app.html.tsx
+++ b/www/routes/app.html.tsx
@@ -27,9 +27,11 @@ export function* useAppHtml({
     "/assets/images/meta-effection.png",
   );
 
-  let canonicalURL = yield* useCanonicalUrl({ base: "https://frontside.com/effection" });
+  let canonicalURL = yield* useCanonicalUrl({
+    base: "https://frontside.com/effection",
+  });
 
-  const header = yield* Header({ hasLeftSidebar });
+  let header = yield* Header({ hasLeftSidebar });
 
   return ({ children, search }) => (
     <html lang="en-US" dir="ltr">
@@ -67,7 +69,12 @@ export function* useAppHtml({
         </noscript>
         <script type="module" src="https://esm.sh/@11ty/is-land@4.0.0" />
         <script type="module" src="/assets/search.js" />
-        <link rel="alternate" type="text/plain" href="/assets/llms.txt" title="LLM Documentation" />
+        <link
+          rel="alternate"
+          type="text/plain"
+          href="/assets/llms.txt"
+          title="LLM Documentation"
+        />
         {head ?? <></>}
       </head>
       <body class="flex flex-col bg-white text-gray-900 dark:bg-gray-900 dark:text-gray-200">

--- a/www/routes/guides-route.tsx
+++ b/www/routes/guides-route.tsx
@@ -16,9 +16,9 @@ import { useConfig } from "../context/config.ts";
 
 export function firstPage(series: string): () => Operation<string> {
   return function* () {
-    const pages = yield* useGuides(series);
+    let pages = yield* useGuides(series);
 
-    const page = yield* pages.first();
+    let page = yield* pages.first();
     return yield* createChildURL()(page.id);
   };
 }
@@ -30,11 +30,11 @@ export function guidesRoute({
 }): SitemapRoute<JSXElement> {
   return {
     *routemap(pathname) {
-      const { series: SERIES } = yield* useConfig();
-      const paths = SERIES.map(function* (series) {
+      let { series: SERIES } = yield* useConfig();
+      let paths = SERIES.map(function* (series) {
         let paths: RoutePath[] = [];
 
-        const pages = yield* useGuides(series);
+        let pages = yield* useGuides(series);
 
         for (let page of yield* pages.all()) {
           paths.push({
@@ -46,7 +46,7 @@ export function guidesRoute({
       return (yield* all(paths)).flat();
     },
     *handler(req) {
-      const { series: SERIES, current } = yield* useConfig();
+      let { series: SERIES, current } = yield* useConfig();
 
       let { id, series = current } = yield* useParams<{
         id: string | undefined;
@@ -56,14 +56,14 @@ export function guidesRoute({
       let pages = yield* useGuides(series);
 
       if (!id) {
-        const page = yield* pages.first();
+        let page = yield* pages.first();
         return yield* softRedirect(
           req,
           yield* createChildURL()(`${series}/${page.id}`),
         );
       }
 
-      const page = yield* pages.get(id);
+      let page = yield* pages.get(id);
 
       if (!page) {
         return yield* respondNotFound();
@@ -71,7 +71,7 @@ export function guidesRoute({
 
       let { topics } = page;
 
-      const description = yield* useDescription(page.markdown);
+      let description = yield* useDescription(page.markdown);
 
       let AppHtml = yield* useAppHtml({
         title: `${page.title} | Docs | Effection`,
@@ -79,25 +79,27 @@ export function guidesRoute({
         hasLeftSidebar: true,
       });
 
-      const topicsList = [];
+      let topicsList = [];
 
-      for (const topic of topics) {
-        const items = [];
-        for (const item of topic.items) {
+      for (let topic of topics) {
+        let items = [];
+        for (let item of topic.items) {
           items.push(
             <li class="mt-1">
-              {page.id !== item.id ? (
-                <a
-                  class="rounded px-4 block w-full py-2 hover:bg-gray-100 dark:hover:bg-gray-800 text-gray-800 dark:text-gray-200 focus:outline-none focus:ring-2 focus:ring-blue-500"
-                  href={yield* createSibling(item.id)}
-                >
-                  {item.title}
-                </a>
-              ) : (
-                <a class="rounded px-4 block w-full py-2 bg-gray-100 dark:bg-gray-800 text-gray-800 dark:text-gray-200 cursor-default">
-                  {item.title}
-                </a>
-              )}
+              {page.id !== item.id
+                ? (
+                  <a
+                    class="rounded px-4 block w-full py-2 hover:bg-gray-100 dark:hover:bg-gray-800 text-gray-800 dark:text-gray-200 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    href={yield* createSibling(item.id)}
+                  >
+                    {item.title}
+                  </a>
+                )
+                : (
+                  <a class="rounded px-4 block w-full py-2 bg-gray-100 dark:bg-gray-800 text-gray-800 dark:text-gray-200 cursor-default">
+                    {item.title}
+                  </a>
+                )}
             </li>,
           );
         }
@@ -111,16 +113,20 @@ export function guidesRoute({
         );
       }
 
-      const versionToggle = yield* all(
+      let versionToggle = yield* all(
         SERIES.map(function* (s) {
-          const target = yield* useGuides(s);
-          const targetPage = yield* target.get(page.id);
-          const base = current === s ? "docs" : `guides/${s}`;
-          const url = yield* createRootUrl(base)(targetPage ? page.id : '/') ;
+          let target = yield* useGuides(s);
+          let targetPage = yield* target.get(page.id);
+          let base = current === s ? "docs" : `guides/${s}`;
+          let url = yield* createRootUrl(base)(targetPage ? page.id : "/");
           return (
             <a
               href={url}
-              class={`text-base ${s === series ? "font-bold text-sky-500" : "text-gray-600 dark:text-gray-400 hover:text-sky-500"}`}
+              class={`text-base ${
+                s === series
+                  ? "font-bold text-sky-500"
+                  : "text-gray-600 dark:text-gray-400 hover:text-sky-500"
+              }`}
             >
               {s}
             </a>
@@ -168,20 +174,20 @@ export function guidesRoute({
               data-series={series}
             >
               <h1>{page.title}</h1>
-              {series !== current ? (
-                <div class="mb-4 px-4 py-3 bg-gray-100 dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded-lg text-gray-800 dark:text-gray-200">
-                  You're viewing documentation for an older version. Effection
-                  {current} is now available.{" "}
-                  <a
-                    href={yield* createRootUrl("docs")(page.id)}
-                    class="font-medium text-sky-500 hover:underline"
-                  >
-                    View {current} docs →
-                  </a>
-                </div>
-              ) : (
-                <></>
-              )}
+              {series !== current
+                ? (
+                  <div class="mb-4 px-4 py-3 bg-gray-100 dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded-lg text-gray-800 dark:text-gray-200">
+                    You're viewing documentation for an older version. Effection
+                    {current} is now available.{" "}
+                    <a
+                      href={yield* createRootUrl("docs")(page.id)}
+                      class="font-medium text-sky-500 hover:underline"
+                    >
+                      View {current} docs →
+                    </a>
+                  </div>
+                )
+                : <></>}
               <>{page.content}</>
               {yield* NextPrevLinks({ page })}
             </article>
@@ -202,32 +208,32 @@ function* NextPrevLinks({ page }: { page: GuidesMeta }): Operation<JSXElement> {
   let { next, prev } = page;
   return (
     <menu class="grid grid-cols-2 my-10 gap-x-2 xl:gap-x-20 2xl:gap-x-40 text-lg">
-      {prev ? (
-        <li class="col-start-1 text-left font-light border-1 rounded-lg p-4">
-          Previous
-          <a
-            class="py-2 block text-xl font-bold text-blue-primary no-underline tracking-wide leading-5 before:content-['«&nbsp;'] before:font-normal"
-            href={yield* createSibling(prev.id)}
-          >
-            {prev.title}
-          </a>
-        </li>
-      ) : (
-        <li />
-      )}
-      {next ? (
-        <li class="col-start-2 text-right font-light border-1 rounded-lg p-4">
-          Next
-          <a
-            class="py-2 block text-xl font-bold text-blue-primary no-underline tracking-wide leading-5 after:content-['&nbsp;»'] after:font-normal"
-            href={yield* createSibling(next.id)}
-          >
-            {next.title}
-          </a>
-        </li>
-      ) : (
-        <li />
-      )}
+      {prev
+        ? (
+          <li class="col-start-1 text-left font-light border-1 rounded-lg p-4">
+            Previous
+            <a
+              class="py-2 block text-xl font-bold text-blue-primary no-underline tracking-wide leading-5 before:content-['«&nbsp;'] before:font-normal"
+              href={yield* createSibling(prev.id)}
+            >
+              {prev.title}
+            </a>
+          </li>
+        )
+        : <li />}
+      {next
+        ? (
+          <li class="col-start-2 text-right font-light border-1 rounded-lg p-4">
+            Next
+            <a
+              class="py-2 block text-xl font-bold text-blue-primary no-underline tracking-wide leading-5 after:content-['&nbsp;»'] after:font-normal"
+              href={yield* createSibling(next.id)}
+            >
+              {next.title}
+            </a>
+          </li>
+        )
+        : <li />}
     </menu>
   );
 }

--- a/www/routes/pagefind-route.ts
+++ b/www/routes/pagefind-route.ts
@@ -8,12 +8,12 @@ import { exists } from "../lib/fs.ts";
 export function pagefindRoute(
   { pagefindDir, publicDir }: { pagefindDir: string; publicDir: string },
 ) {
-  const assets = assetsRoute(pagefindDir);
+  let assets = assetsRoute(pagefindDir);
   let task: Task<void>;
   return GET<Response>(function* (request, next) {
     if (!((yield* exists(publicDir)) && (yield* exists(pagefindDir)))) {
       if (!task) {
-        const host = new URL(new URL(request.url).origin);
+        let host = new URL(new URL(request.url).origin);
         task = yield* spawn(function* () {
           yield* call(generate({
             host,

--- a/www/routes/redirect-docs-route.tsx
+++ b/www/routes/redirect-docs-route.tsx
@@ -8,9 +8,9 @@ import { softRedirect } from "./redirect.tsx";
 export function redirectDocsRoute(series: string): SitemapRoute<JSXElement> {
   return {
     *routemap(pathname) {
-      const pages = yield* useGuides(series);
+      let pages = yield* useGuides(series);
 
-      const paths = [];
+      let paths = [];
       for (let page of yield* pages.all()) {
         paths.push({
           pathname: pathname({ id: page.id, series }),
@@ -20,7 +20,7 @@ export function redirectDocsRoute(series: string): SitemapRoute<JSXElement> {
       return paths;
     },
     *handler(req) {
-      const { id } = yield* useParams<{ id: string }>();
+      let { id } = yield* useParams<{ id: string }>();
 
       return yield* softRedirect(
         req,

--- a/www/routes/redirect.tsx
+++ b/www/routes/redirect.tsx
@@ -7,7 +7,7 @@ import { useAppHtml } from "./app.html.tsx";
  * @returns
  */
 export function* softRedirect(req: Request, to: string) {
-  const url = new URL(to, new URL(req.url).origin);
+  let url = new URL(to, new URL(req.url).origin);
 
   let AppHtml = yield* useAppHtml({
     title: `Redirect to ${to} | Effection`,

--- a/www/routes/x-index-route.tsx
+++ b/www/routes/x-index-route.tsx
@@ -31,13 +31,13 @@ export function xIndexRoute({
       let workspaces = yield* useWorkspaces("thefrontside/effectionx");
       let packages = yield* workspaces.getAllPackages();
 
-      const AppHTML = yield* useAppHtml({
+      let AppHTML = yield* useAppHtml({
         title: "Extensions | Effection",
         description:
           "List of community contributed modules that represent emerging consensus on how to do common JavaScript tasks with Effection.",
       });
 
-      const makeChildUrl = createChildURL();
+      let makeChildUrl = createChildURL();
 
       return (
         <AppHTML search={search}>
@@ -85,8 +85,8 @@ export function xIndexRoute({
               <ul class="list-none px-0 divide-y-1 divide-solid divide-slate-200 dark:divide-slate-700">
                 {yield* all(
                   packages.map(function* (pkg) {
-                    const title = yield* pkg.getName();
-                    const description = yield* pkg.getDescription();
+                    let title = yield* pkg.getName();
+                    let description = yield* pkg.getDescription();
 
                     return (
                       <li>

--- a/www/routes/x-package-route.tsx
+++ b/www/routes/x-package-route.tsx
@@ -49,7 +49,7 @@ export function xPackageRedirect(): SitemapRoute<JSXElement> {
   return {
     routemap: routemap(),
     *handler(req) {
-      const params = yield* useParams<{ workspacePath: string }>();
+      let params = yield* useParams<{ workspacePath: string }>();
       return yield* softRedirect(
         req,
         yield* createSibling(params.workspacePath),
@@ -75,25 +75,25 @@ export function xPackageRoute({
       }
 
       try {
-        const docs = yield* pkg.getDocs();
-        const pkgName = yield* pkg.getName();
-        const pkgDescription = yield* pkg.getDescription();
+        let docs = yield* pkg.getDocs();
+        let pkgName = yield* pkg.getName();
+        let pkgDescription = yield* pkg.getDescription();
 
-        const AppHTML = yield* useAppHtml({
+        let AppHTML = yield* useAppHtml({
           title: `${pkgName} | Extensions | Effection`,
           description: pkgDescription,
         });
 
-        const linkResolver = function* (
+        let linkResolver = function* (
           symbol: string,
           connector?: string,
           method?: string,
         ) {
-          const internal = `#${symbol}_${method}`;
+          let internal = `#${symbol}_${method}`;
           if (connector === "_") {
             return internal;
           }
-          const page = docs["."].find(
+          let page = docs["."].find(
             (page) => page.name === symbol && page.kind !== "import",
           );
 
@@ -105,14 +105,14 @@ export function xPackageRoute({
           return symbol;
         };
 
-        const apiReference = [];
+        let apiReference = [];
 
-        const entrypoints = Object.entries(docs);
+        let entrypoints = Object.entries(docs);
 
-        for (const [entrypoint, pages] of entrypoints) {
-          const sections = [];
-          for (const page of pages) {
-            const content = yield* call(function* () {
+        for (let [entrypoint, pages] of entrypoints) {
+          let sections = [];
+          for (let page of pages) {
+            let content = yield* call(function* () {
               yield* DocPageContext.set(page);
               return yield* ApiBody({ page, linkResolver });
             });
@@ -136,7 +136,7 @@ export function xPackageRoute({
 
         apiReference.forEach((section) => shiftHeading(section, 1));
 
-        const content = (
+        let content = (
           <>
             {yield* useMarkdown(yield* pkg.getReadme(), { linkResolver })}
             <h2 id="api-reference">API Reference</h2>
@@ -144,7 +144,7 @@ export function xPackageRoute({
           </>
         );
 
-        const toc = createToc(content, {
+        let toc = createToc(content, {
           headings: ["h2", "h3"],
           cssClasses: {
             toc:
@@ -159,7 +159,7 @@ export function xPackageRoute({
               .filter(Boolean)
               .join("");
 
-            const ol = select("ol.toc-level-2, ol.toc-level-3", item as Nodes);
+            let ol = select("ol.toc-level-2, ol.toc-level-3", item as Nodes);
             if (ol) {
               ol.properties.className = `${ol.properties.className} ml-6`;
             }
@@ -168,7 +168,7 @@ export function xPackageRoute({
               heading.properties["data-name"]
             ) {
               item.properties.className += " mb-1";
-              const a = select("a", item as Nodes);
+              let a = select("a", item as Nodes);
               if (a) {
                 // deno-lint-ignore no-explicit-any
                 (a as any).children = [
@@ -179,7 +179,7 @@ export function xPackageRoute({
                 ];
               }
             } else {
-              const a = select("a", item as Nodes);
+              let a = select("a", item as Nodes);
               if (a) {
                 a.properties.className =
                   `hover:underline hover:underline-offset-2`;
@@ -226,7 +226,7 @@ export function xPackageRoute({
         );
       } catch (e) {
         console.error(e);
-        const AppHTML = yield* useAppHtml({
+        let AppHTML = yield* useAppHtml({
           title: `${params.workspacePath} not found`,
           description: `Failed to load ${params.workspacePath} due to error.`,
         });

--- a/www/testing.ts
+++ b/www/testing.ts
@@ -9,10 +9,10 @@ import { createTestAdapter, type TestAdapter } from "./testing/adapter.ts";
 let current: TestAdapter | undefined;
 
 export function describe(name: string, body: () => void) {
-  const isTop = !current;
-  const original = current;
+  let isTop = !current;
+  let original = current;
   try {
-    const child = current = createTestAdapter({ name, parent: original });
+    let child = current = createTestAdapter({ name, parent: original });
     if (isTop) {
       //
     }
@@ -34,12 +34,12 @@ export function beforeEach(body: () => Operation<void>) {
 }
 
 export function it(desc: string, body?: () => Operation<void>): void {
-  const adapter = current!;
+  let adapter = current!;
   if (!body) {
     return $it.skip(desc, () => {});
   }
   $it(desc, async () => {
-    const result = await adapter.runTest(body);
+    let result = await adapter.runTest(body);
     if (!result.ok) {
       throw result.error;
     }
@@ -47,14 +47,14 @@ export function it(desc: string, body?: () => Operation<void>): void {
 }
 
 it.skip = (...args: Parameters<typeof it>): ReturnType<typeof it> => {
-  const [desc] = args;
+  let [desc] = args;
   $it.skip(desc, () => {});
 };
 
 it.only = (desc: string, body: () => Operation<void>): void => {
-  const adapter = current!;
+  let adapter = current!;
   $it.only(desc, async () => {
-    const result = await adapter.runTest(body);
+    let result = await adapter.runTest(body);
     if (!result.ok) {
       throw result.error;
     }

--- a/www/testing/adapter.ts
+++ b/www/testing/adapter.ts
@@ -87,18 +87,18 @@ const anonymousNames: Iterator<string, never> = (function* () {
 export function createTestAdapter(
   options: TestAdapterOptions = {},
 ): TestAdapter {
-  const setups: TestOperation[] = [];
-  const { parent, name = anonymousNames.next().value } = options;
+  let setups: TestOperation[] = [];
+  let { parent, name = anonymousNames.next().value } = options;
 
-  const [scope, destroy] = createScope(parent?.scope);
+  let [scope, destroy] = createScope(parent?.scope);
 
-  const adapter: TestAdapter = {
+  let adapter: TestAdapter = {
     parent,
     name,
     scope,
     setups,
     get lineage() {
-      const lineage = [adapter];
+      let lineage = [adapter];
       for (let current = parent; current; current = current.parent) {
         lineage.unshift(current);
       }
@@ -112,12 +112,12 @@ export function createTestAdapter(
     },
     runTest(op) {
       return scope.run(function* () {
-        const allSetups = adapter.lineage.reduce(
+        let allSetups = adapter.lineage.reduce(
           (all, adapter) => all.concat(adapter.setups),
           [] as TestOperation[],
         );
         try {
-          for (const setup of allSetups) {
+          for (let setup of allSetups) {
             yield* setup();
           }
           yield* op();

--- a/www/testing/helpers.ts
+++ b/www/testing/helpers.ts
@@ -26,22 +26,20 @@ export interface GitCommit {
  */
 export function* getGitHistory(): Operation<GitCommit[]> {
   // Get commit history with hash and message
-  const historyResult = yield* $(`git log --format="%H|%s" --reverse`);
+  let historyResult = yield* $(`git log --format="%H|%s" --reverse`);
 
-  const lines = historyResult.stdout.split("\n").filter((line) =>
+  let lines = historyResult.stdout.split("\n").filter((line) =>
     line.length > 0
   );
-  const commits: GitCommit[] = [];
+  let commits: GitCommit[] = [];
 
-  for (const line of lines) {
-    const [sha, message] = line.split("|");
+  for (let line of lines) {
+    let [sha, message] = line.split("|");
 
     // Get tags for this commit using $ shell utility
     try {
-      const tagsResult = yield* $(`git tag --points-at ${sha}`);
-      const tags = tagsResult.stdout.split("\n").filter((tag) =>
-        tag.length > 0
-      );
+      let tagsResult = yield* $(`git tag --points-at ${sha}`);
+      let tags = tagsResult.stdout.split("\n").filter((tag) => tag.length > 0);
       commits.push({ sha, message, tags });
     } catch {
       // No tags for this commit

--- a/www/testing/logging.ts
+++ b/www/testing/logging.ts
@@ -10,8 +10,8 @@ type LogEvent =
   | { type: "error"; args: unknown[] };
 
 export function* setupLogging(level: (typeof levels)[number] | false) {
-  const queue = yield* resource<Queue<LogEvent, void>>(function* (provide) {
-    const queue = createQueue<LogEvent, void>();
+  let queue = yield* resource<Queue<LogEvent, void>>(function* (provide) {
+    let queue = createQueue<LogEvent, void>();
     try {
       yield* provide(queue);
     } finally {

--- a/www/testing/temp-dir.ts
+++ b/www/testing/temp-dir.ts
@@ -6,7 +6,7 @@ function* writeFiles(
   dir: string,
   files: Record<string, string>,
 ): Operation<void> {
-  for (const [path, content] of Object.entries(files)) {
+  for (let [path, content] of Object.entries(files)) {
     yield* until(ensureFile(join(dir, path)));
     yield* until(Deno.writeTextFile(join(dir, path), content));
   }
@@ -30,7 +30,7 @@ export function createTempDir(
   params?: CreateTempDirParams,
 ): Operation<TempDir> {
   return resource(function* (provide) {
-    const {
+    let {
       baseDir,
       autoClean,
     } = params || {};
@@ -39,9 +39,9 @@ export function createTempDir(
     if (baseDir) {
       // Create directory in specified base directory
       yield* until(ensureDir(baseDir));
-      const timestamp = Date.now().toString(36);
-      const randomSuffix = Math.random().toString(36).substring(2, 8);
-      const dirName = `${timestamp}-${randomSuffix}`;
+      let timestamp = Date.now().toString(36);
+      let randomSuffix = Math.random().toString(36).substring(2, 8);
+      let dirName = `${timestamp}-${randomSuffix}`;
       dir = join(baseDir, dirName);
       yield* until(ensureDir(dir));
     } else {


### PR DESCRIPTION
## Motivation
The www/ webapp was a bit of wild west because linting and formatting were turned off resulting in the style in the web app being all over the place.

## Approach
This turns it back on and fixes and formats the code. There were two files that were causing `deno lint` to crash, so they've been excluded.

- routes/guides-route.tsx
- components/api/api-page.tsx

We can follow up with the deno team to find out why these are crashing later.

