### PR TITLE
test: add cleanup regression test for 4.0.1

### DIFF
--- a/lib/scope-internal.ts
+++ b/lib/scope-internal.ts
@@ -8,6 +8,7 @@ export function createScopeInternal(
   parent?: Scope,
 ): [ScopeInternal, () => Operation<void>] {
   let destructors = new Set<() => Operation<void>>();
+  let finalizer: (() => Operation<void>) | undefined = undefined;
 
   let contexts: Record<string, unknown> = Object.create(
     parent ? (parent as ScopeInternal).contexts : null,
@@ -55,6 +56,12 @@ export function createScopeInternal(
       destructors.add(op);
       return () => destructors.delete(op);
     },
+
+    // Set a finalizer that runs BEFORE regular destructors.
+    // Used by tasks to close their delimiter before child tasks are destroyed.
+    setFinalizer(op: () => Operation<void>): void {
+      finalizer = op;
+    },
   });
 
   scope.set(Priority, scope.expect(Priority) + 1);
@@ -74,6 +81,17 @@ export function createScopeInternal(
     unbind();
     let outcome = Ok();
     try {
+      // Run the finalizer first (e.g., close the task's delimiter).
+      // This ensures the task's finally block runs while children are still alive.
+      if (finalizer) {
+        try {
+          yield* finalizer();
+        } catch (error) {
+          outcome = Err(error as Error);
+        }
+        finalizer = undefined;
+      }
+      // Then run regular destructors in reverse order (children first)
       for (let destructor of [...destructors].reverse()) {
         try {
           destructors.delete(destructor);
@@ -99,4 +117,5 @@ export function createScopeInternal(
 export interface ScopeInternal extends Scope {
   contexts: Record<string, unknown>;
   ensure(op: () => Operation<void>): () => void;
+  setFinalizer(op: () => Operation<void>): void;
 }

--- a/lib/task.ts
+++ b/lib/task.ts
@@ -75,7 +75,9 @@ export function createTask<T>(options: TaskOptions<T>): NewTask<T> {
   let boundary = owner.expect(ErrorContext);
   scope.set(ErrorContext, top);
 
-  scope.ensure(function* () {
+  // Use setFinalizer to ensure the delimiter closes BEFORE child destructors run.
+  // This allows the task's finally block to communicate with spawned children.
+  scope.setFinalizer(function* () {
     try {
       yield* top.close();
     } finally {

--- a/test/cleanup-regression.test.ts
+++ b/test/cleanup-regression.test.ts
@@ -1,11 +1,5 @@
 import { describe, expect, it } from "./suite.ts";
-import {
-  resource,
-  run,
-  spawn,
-  suspend,
-  withResolvers,
-} from "../mod.ts";
+import { resource, run, spawn, suspend, withResolvers } from "../mod.ts";
 
 // Helper to add timeout to async operations
 function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
@@ -15,7 +9,7 @@ function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
     new Promise<T>((_, reject) => {
       timeoutId = setTimeout(
         () => reject(new Error(`Timeout after ${ms}ms - cleanup deadlocked`)),
-        ms
+        ms,
       );
     }),
   ]);
@@ -36,10 +30,12 @@ describe("cleanup regression (4.0.1)", () => {
 
     let task = run(function* () {
       yield* resource(function* (provide) {
-        let { resolve: closeStream, operation: streamClosed } =
-          withResolvers<void>();
-        let { resolve: confirmClosed, operation: closed } =
-          withResolvers<void>();
+        let { resolve: closeStream, operation: streamClosed } = withResolvers<
+          void
+        >();
+        let { resolve: confirmClosed, operation: closed } = withResolvers<
+          void
+        >();
 
         // Spawned consumer task - like the message consumer in useWebSocket
         yield* spawn(function* () {
@@ -77,10 +73,12 @@ describe("cleanup regression (4.0.1)", () => {
 
     let task = run(function* () {
       yield* resource(function* (provide) {
-        let { resolve: closeStream, operation: streamClosed } =
-          withResolvers<void>();
-        let { resolve: confirmClosed, operation: closed } =
-          withResolvers<void>();
+        let { resolve: closeStream, operation: streamClosed } = withResolvers<
+          void
+        >();
+        let { resolve: confirmClosed, operation: closed } = withResolvers<
+          void
+        >();
 
         yield* spawn(function* () {
           yield* streamClosed;

--- a/test/cleanup-regression.test.ts
+++ b/test/cleanup-regression.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "./suite.ts";
+import {
+  resource,
+  run,
+  spawn,
+  suspend,
+  withResolvers,
+} from "../mod.ts";
+
+// Helper to add timeout to async operations
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  let timeoutId: number;
+  return Promise.race([
+    promise.finally(() => clearTimeout(timeoutId)),
+    new Promise<T>((_, reject) => {
+      timeoutId = setTimeout(
+        () => reject(new Error(`Timeout after ${ms}ms - cleanup deadlocked`)),
+        ms
+      );
+    }),
+  ]);
+}
+
+describe("cleanup regression (4.0.1)", () => {
+  // This pattern mirrors @effectionx/websocket's useWebSocket:
+  // 1. Resource with a spawned consumer task
+  // 2. Finally block signals the consumer to close (like socket.close())
+  // 3. Finally block waits for consumer to confirm it processed the close
+  //
+  // This worked in 4.0.0 but deadlocks in 4.0.1 due to changes in
+  // task finalization order (PRs #1081 and #1085)
+
+  it("finally block can signal spawned task and wait for response (sleep)", async () => {
+    let cleanupCompleted = false;
+    let consumerSawClose = false;
+
+    let task = run(function* () {
+      yield* resource(function* (provide) {
+        let { resolve: closeStream, operation: streamClosed } =
+          withResolvers<void>();
+        let { resolve: confirmClosed, operation: closed } =
+          withResolvers<void>();
+
+        // Spawned consumer task - like the message consumer in useWebSocket
+        yield* spawn(function* () {
+          // Simulate draining a stream until it closes
+          yield* streamClosed;
+          consumerSawClose = true;
+          confirmClosed();
+        });
+
+        try {
+          yield* provide(undefined);
+        } finally {
+          // Close the stream (like socket.close() in useWebSocket)
+          closeStream();
+          // Wait for consumer to confirm it saw the close
+          yield* closed;
+          cleanupCompleted = true;
+        }
+      });
+
+      yield* suspend();
+    });
+
+    // Timing gap before halt - this is important to reproduce the bug
+    await new Promise((r) => setTimeout(r, 50));
+    await withTimeout(task.halt(), 1000);
+
+    expect(consumerSawClose).toBe(true);
+    expect(cleanupCompleted).toBe(true);
+  });
+
+  it("finally block can signal spawned task and wait for response (no sleep)", async () => {
+    let cleanupCompleted = false;
+    let consumerSawClose = false;
+
+    let task = run(function* () {
+      yield* resource(function* (provide) {
+        let { resolve: closeStream, operation: streamClosed } =
+          withResolvers<void>();
+        let { resolve: confirmClosed, operation: closed } =
+          withResolvers<void>();
+
+        yield* spawn(function* () {
+          yield* streamClosed;
+          consumerSawClose = true;
+          confirmClosed();
+        });
+
+        try {
+          yield* provide(undefined);
+        } finally {
+          closeStream();
+          yield* closed;
+          cleanupCompleted = true;
+        }
+      });
+
+      yield* suspend();
+    });
+
+    // No timing gap - halt immediately
+    await withTimeout(task.halt(), 1000);
+
+    expect(consumerSawClose).toBe(true);
+    expect(cleanupCompleted).toBe(true);
+  });
+});


### PR DESCRIPTION
This PR was generated by Opus 4.5. I do not expect this PR to be merged. I just wanted to capture the context that accumulated while troubleshooting the `@effectionx/websocket` extension. 
---

## Summary

This PR adds a test that reproduces a regression introduced in 4.0.1 and includes the fix.

## Test Results

| Version | Result |
|---------|--------|
| v4.0.0 | ✅ PASS |
| v4.0.1 (before fix) | ❌ FAIL (cleanup deadlocks) |
| This PR | ✅ PASS |

## The Pattern

```typescript
yield* resource(function* (provide) {
  let { resolve: closeStream, operation: streamClosed } = withResolvers<void>();
  let { resolve: confirmClosed, operation: closed } = withResolvers<void>();

  // Spawned consumer task
  yield* spawn(function* () {
    yield* streamClosed;  // Wait for signal from finally block
    confirmClosed();      // Signal back that we processed it
  });

  try {
    yield* provide(undefined);
  } finally {
    closeStream();        // Signal the spawned task
    yield* closed;        // Wait for spawned task to confirm
  }
});
```

This pattern:
1. Resource spawns a consumer task that waits on a signal
2. Finally block resolves the signal to notify consumer
3. Finally block waits for consumer to confirm it processed the signal

**Works in 4.0.0, deadlocks in 4.0.1**

## Real-World Impact

This pattern is used by \`@effectionx/websocket\`'s \`useWebSocket\`, where:
- A spawned task consumes the WebSocket message stream
- Finally block calls \`socket.close()\` (triggering close event)
- Finally block waits for the consumer to see the close event

See: https://github.com/thefrontside/effectionx/pull/134

## Root Cause

The regression was introduced by PRs #1081 and #1085 which changed the task finalization order. In 4.0.1:
- \`destroy()\` runs destructors in reverse order
- Child task destructors (added via spawn) run BEFORE the parent's delimiter closes
- So by the time the parent's finally block runs, children are already destroyed

**Before (4.0.0):**
1. Parent's \`top.close()\` runs (triggers finally block)
2. Finally block signals children, children respond
3. Children get destroyed

**After (4.0.1, broken):**
1. Children get destroyed first (they were added to destructors last → run first in reverse)
2. Parent's \`top.close()\` runs
3. Finally block tries to signal children → deadlock (children are gone)

## The Fix

Added a \`setFinalizer()\` mechanism to \`ScopeInternal\` that runs **BEFORE** regular destructors during \`destroy()\`.

### Changes

**lib/scope-internal.ts:**
- Added \`finalizer\` variable and \`setFinalizer()\` method
- \`destroy()\` now runs the finalizer first, then regular destructors

**lib/task.ts:**
- Changed from \`scope.ensure()\` to \`scope.setFinalizer()\` for delimiter closing

### Why This Works

The finalizer ensures the task's own delimiter closes (running its finally block) **before** any child destructors run. This restores the 4.0.0 behavior where:
1. Parent's finally block executes while children are still alive
2. Finally block can communicate with children
3. Children are destroyed after the parent's finally block completes

### Diff

```diff
// scope-internal.ts
+  let finalizer: (() => Operation<void>) | undefined = undefined;

   // In scope object:
+  setFinalizer(op: () => Operation<void>): void {
+    finalizer = op;
+  },

   // In destroy():
+  // Run the finalizer first (e.g., close the task's delimiter).
+  if (finalizer) {
+    try {
+      yield* finalizer();
+    } catch (error) {
+      outcome = Err(error as Error);
+    }
+    finalizer = undefined;
+  }
+  // Then run regular destructors in reverse order (children first)

// task.ts
-  scope.ensure(function* () {
+  scope.setFinalizer(function* () {
     try {
       yield* top.close();
     } finally {
```

## Expected Behavior

When a task is halted, spawned tasks within that scope should still be able to:
1. Receive signals from the parent's finally block
2. Complete work in response to those signals
3. Signal back to the parent before being torn down