### PR TITLE
Fix structured concurrency post: clarify await vs caller lifetime

### DIFF
--- a/www/blog/2026-02-06-structured-concurrency-for-javascript/index.md
+++ b/www/blog/2026-02-06-structured-concurrency-for-javascript/index.md
@@ -44,10 +44,11 @@ In synchronous JavaScript, lifetimes are boring in a good way: a function runs
 to completion unless it throws, and `finally {}` runs when control leaves the
 `try` block. When the function returns, the work is over.
 
-Async changes that. Once you cross an `await` boundary, the caller has two bad
-options: await (and block) or move on while the work keeps running past its
-lifetime boundary. Either way, there's nothing built in that can halt it and
-force cleanup to run.
+Async changes that. Once you start async work by creating a Promise, the caller
+has two bad options: await it (possibly forever), or move on while the work
+keeps running past the caller's lifetime boundary. Either way, there's nothing
+built in that can halt it and force cleanup to run — unless you explicitly
+thread cancellation through the call chain.
 
 Here's the shape of the problem in plain `async` code:
 

--- a/www/blog/2026-02-06-structured-concurrency-for-javascript/index.md
+++ b/www/blog/2026-02-06-structured-concurrency-for-javascript/index.md
@@ -44,10 +44,10 @@ In synchronous JavaScript, lifetimes are boring in a good way: a function runs
 to completion unless it throws, and `finally {}` runs when control leaves the
 `try` block. When the function returns, the work is over.
 
-Async changes that. The moment you `await`, the work you started no longer has
-to finish inside the scope that started it — your caller can move on while your
-effects keep running. And there's nothing built in that makes that work stop and
-unwind just because the caller is done.
+Async changes that. Once you cross an `await` boundary, the caller has two bad
+options: await (and block) or move on while the work keeps running past its
+lifetime boundary. Either way, there's nothing built in that can halt it and
+force cleanup to run.
 
 Here's the shape of the problem in plain `async` code:
 


### PR DESCRIPTION
## Motivation

The original wording conflated two distinct failure modes into one sentence tied to `await`:

> "The moment you `await`, the work you started no longer has to finish inside the scope that started it — your caller can move on while your effects keep running."

When you `await`, the caller actually *blocks* — it doesn't move on. The real "damned if you do, damned if you don't" is:

1. **Await (and block)** — no guarantee control returns (hard exit, signal, etc.)
2. **Don't await (fire and forget)** — caller moves on, effects outlive it

The original sentence attributed both damnations to `await`. This PR separates them.

## Approach

One paragraph rewrite in `www/blog/2026-02-06-structured-concurrency-for-javascript/index.md`:

> "Async changes that. Once you cross an `await` boundary, the caller has two bad options: await (and block) or move on while the work keeps running past its lifetime boundary. Either way, there's nothing built in that can halt it and force cleanup to run."