### PR TITLE
Fix blog opening: SPA component unmount instead of full navigation

### DIFF
--- a/www/blog/2026-02-06-structured-concurrency-for-javascript/index.md
+++ b/www/blog/2026-02-06-structured-concurrency-for-javascript/index.md
@@ -8,9 +8,9 @@ image: "structured-concurrency-js.svg"
 
 You hit Ctrl-C. The CLI exits. And yet the port is still bound.
 
-Or you navigate away in the browser, and a request you no longer care about
-keeps running anyway — burning battery, holding sockets, and calling callbacks
-into code that has already moved on.
+Or a component unmounts in your SPA, and the requests it started keep running
+anyway — burning battery, holding sockets, and calling callbacks into code that
+has already moved on.
 
 This is the part of JavaScript async we all learn to tolerate: work that
 outlives the scope (the lifetime boundary) that started it.


### PR DESCRIPTION
## Motivation

A [r/javascript commenter](https://old.reddit.com/r/javascript/comments/1r09122/why_javascript_needs_structured_concurrency/o4gnw11/) correctly pointed out that the blog opening — "Or you navigate away in the browser, and a request you no longer care about keeps running anyway" — is not true for full page navigation. Modern browsers kill all running JS, pending requests, etc. on navigation.

The actual problem is in SPAs, where route changes and component unmounts happen while async work is still in flight. That's where you get unscoped async work unless you explicitly wire cancellation.

## Approach

One-line change in the opening of `www/blog/2026-02-06-structured-concurrency-for-javascript/index.md`:

> "Or a component unmounts in your SPA, and the requests it started keep running anyway — burning battery, holding sockets, and calling callbacks into code that has already moved on."

This is technically accurate and preempts the nitpick.