### PR TITLE
feat: prefer package.json description over README-inferred

### DIFF
--- a/www/lib/package/node.ts
+++ b/www/lib/package/node.ts
@@ -40,6 +40,7 @@ const ExportsSchema = z.union([
 export const PackageJsonSchema = z.object({
   name: z.string().optional(),
   version: z.string().optional(),
+  description: z.string().optional(),
   exports: ExportsSchema.optional(),
   license: z.string().optional(),
   dependencies: z.record(z.string()).optional(),
@@ -193,6 +194,7 @@ export function createNodePackage(
       return {
         name: packageJson.name,
         version: packageJson.version,
+        description: packageJson.description,
         exports: normalizeExports(packageJson.exports),
         license: packageJson.license,
         imports: buildImports(packageJson),
@@ -284,6 +286,12 @@ export function createNodePackage(
     },
 
     *getDescription(): Operation<string> {
+      // Prefer manifest description over README-inferred description
+      let manifest = yield* this.getManifest();
+      if (manifest.description) {
+        return manifest.description;
+      }
+      // Fall back to README-inferred description
       let readme = yield* this.getReadme();
       return yield* useDescription(readme);
     },

--- a/www/lib/package/types.ts
+++ b/www/lib/package/types.ts
@@ -26,6 +26,9 @@ export interface PackageManifest {
   /** Package version */
   version?: string;
 
+  /** Package description from package.json */
+  description?: string;
+
   /**
    * Normalized exports - always Record<string, string>.
    * For Node packages, uses the "development" condition.


### PR DESCRIPTION
# Motivation

With [thefrontside/effectionx#151](https://github.com/thefrontside/effectionx/pull/151) merged, all `@effectionx/*` packages now have concise `description` fields in their `package.json` files. These descriptions are written specifically for npm search and AI agent discovery.

The current website reads descriptions from README files, parsing them through a rehype pipeline that extracts the first paragraph. This produces verbose, 200-character excerpts that aren't ideal for the `/llms.txt` route or package listings.

# Approach

Update the package abstraction to prefer `package.json` description over README-inferred description:

1. **Add `description` to schemas**:
   - `PackageJsonSchema` in `www/lib/package/node.ts`
   - `PackageManifest` interface in `www/lib/package/types.ts`

2. **Update `getManifest()`** to include description in returned manifest

3. **Update `getDescription()`** in both `node.ts` and `deno.ts` to:
   - Check manifest description first
   - Fall back to README-inferred description when not present

This ensures the `/llms.txt` route generates concise, agent-friendly descriptions like:

```
- [@effectionx/process](https://frontside.com/effection/x/process): Spawn and manage child processes with structured concurrency
- [@effectionx/websocket](https://frontside.com/effection/x/websocket): WebSocket client with stream-based message handling and automatic cleanup
```

Instead of verbose paragraph excerpts.