### PR TITLE
fix: handle signal-killed subprocess exit codes in tests

### DIFF
--- a/test/suite.ts
+++ b/test/suite.ts
@@ -88,6 +88,17 @@ export interface TinyProcess extends Operation<Output> {
   kill(signal?: KillSignal): Operation<Output>;
 }
 
+// POSIX conventional exit codes for signals (128 + signal number).
+// Deno 2.6.9+ (denoland/deno#32081) sets ChildProcess.exitCode to null
+// for signal-killed processes (matching Node.js semantics), so tinyexec
+// returns exitCode: undefined. We derive the conventional code ourselves.
+const SIGNAL_EXIT_CODES: Record<string, number> = {
+  SIGHUP: 129,
+  SIGINT: 130,
+  SIGQUIT: 131,
+  SIGTERM: 143,
+};
+
 export function x(
   cmd: string,
   args: string[] = [],
@@ -112,7 +123,16 @@ export function x(
         ) {
           ctrlc(tinyexec.pid);
         }
-        return yield* output;
+        let result = yield* output;
+
+        if (result.exitCode === undefined && signal) {
+          let code = SIGNAL_EXIT_CODES[signal];
+          if (code !== undefined) {
+            return { ...result, exitCode: code };
+          }
+        }
+
+        return result;
       },
     };
 


### PR DESCRIPTION
## Motivation

Deno 2.6.9 changed `node:child_process` signal semantics to match Node.js (`denoland/deno#32081`): when a process exits due to a signal, `exitCode` is null and `signalCode` is set. Our `test/main.test.ts` assertions expect conventional signal exit codes (`130` for `SIGINT`, `143` for `SIGTERM`), but `tinyexec` only exposes `exitCode`, which becomes `undefined` in this case.

This causes `main` signal-shutdown tests to fail in CI when `deno-version: v2.x` resolves to 2.6.9+.

## Approach

Update the test helper in `test/suite.ts` so `TinyProcess.kill()` normalizes signal-killed outputs by deriving conventional POSIX exit codes when `tinyexec` returns `exitCode: undefined`.

- Add a `SIGNAL_EXIT_CODES` map for signal-to-code conversion
- Keep existing test assertions unchanged
- Preserve current behavior for non-signal exits