### PR TITLE
feat(bench): add statistical metrics, warmup runs, and JSON output

### DIFF
--- a/tasks/bench.ts
+++ b/tasks/bench.ts
@@ -121,18 +121,29 @@ function renderTable(
   events: BenchmarkDoneEvent[],
   options: { repeat?: number; warmup?: number; depth?: number },
 ) {
-  const headers = ["Library", "Avg", "Min", "Max", "StdDev", "p50", "p95", "p99"];
+  const headers = [
+    "Library",
+    "Avg",
+    "Min",
+    "Max",
+    "StdDev",
+    "p50",
+    "p95",
+    "p99",
+  ];
   let rows = [];
 
   if (recursion.length > 0) {
-    const title = `Basic Recursion (${options.repeat} reps, ${options.warmup} warmup, depth ${options.depth})`;
+    const title =
+      `Basic Recursion (${options.repeat} reps, ${options.warmup} warmup, depth ${options.depth})`;
     rows.push(Row.from([new Cell(title).colSpan(headers.length).border()]));
     rows.push(Row.from<Cell | string>(headers).border());
     rows.push(...recursion.map((event) => Row.from(toTableRow(event))));
   }
 
   if (events.length > 0) {
-    const title = `Recursive Events (${options.repeat} reps, ${options.warmup} warmup, depth ${options.depth})`;
+    const title =
+      `Recursive Events (${options.repeat} reps, ${options.warmup} warmup, depth ${options.depth})`;
     rows.push(Row.from([new Cell(title).colSpan(headers.length).border()]));
     rows.push(Row.from<Cell | string>(headers).border());
     rows.push(...events.map((event) => Row.from(toTableRow(event))));

--- a/tasks/bench.ts
+++ b/tasks/bench.ts
@@ -8,26 +8,35 @@ import {
   type Operation,
   spawn,
   type Task,
-  withResolvers,
 } from "../mod.ts";
 import { useWorker } from "./bench/worker.ts";
 import scenarios from "./bench/scenarios.ts";
 import type {
   BenchmarkDoneEvent,
+  BenchmarkJsonOutput,
   BenchmarkOptions,
+  BenchmarkResultEntry,
+  BenchmarkStats,
   BenchmarkWorkerEvent,
   WorkerCommand,
 } from "./bench/types.ts";
-import { Ok } from "../lib/result.ts";
 
 import { Cell, Row, Table } from "jsr:@cliffy/table@1.0.0-rc.7";
+import { basename } from "jsr:@std/path";
+
+interface BenchmarkCliOptions {
+  include?: string;
+  exclude?: string;
+  repeat: number;
+  depth: number;
+  warmup: number;
+  json: boolean;
+}
 
 await main(function* (args) {
   let options = parser()
     .name("bench")
-    .description(
-      "Run Effection benchmarks",
-    )
+    .description("Run Effection benchmarks")
     .version("0.0.0")
     .options({
       include: {
@@ -36,7 +45,7 @@ await main(function* (args) {
       },
       exclude: {
         type: z.string().optional(),
-        description: "exclude all scenanios matching REGEXP",
+        description: "exclude all scenarios matching REGEXP",
       },
       repeat: {
         type: z.number().positive().default(10),
@@ -48,17 +57,31 @@ await main(function* (args) {
         description: "number of levels of recursion to run",
         alias: "d",
       },
+      warmup: {
+        type: z.number().nonnegative().default(3),
+        description: "number of warmup runs to discard",
+        alias: "w",
+      },
+      json: {
+        type: z.boolean().default(false),
+        description: "output results as JSON",
+      },
     })
-    .parse(args);
+    .parse(args) as BenchmarkCliOptions;
 
-  let { include, exclude } = options;
+  let { include, exclude, repeat, depth, warmup, json } = options;
 
   let tasks: Task<BenchmarkDoneEvent>[] = [];
 
   for (let scenario of filter(scenarios, { include, exclude })) {
     tasks.push(
       yield* spawn(() =>
-        runBenchmark(scenario, { ...options, type: "benchmark" })
+        runBenchmark(scenario, {
+          type: "benchmark",
+          repeat,
+          depth,
+          warmup,
+        })
       ),
     );
   }
@@ -73,35 +96,64 @@ await main(function* (args) {
     return;
   }
 
+  if (json) {
+    const output: BenchmarkJsonOutput = {
+      metadata: {
+        date: new Date().toISOString(),
+        deno: Deno.version.deno,
+        repeat,
+        warmup,
+        depth,
+      },
+      results: {
+        recursion: recursion.map(toJsonEntry).filter(notNull),
+        events: events.map(toJsonEntry).filter(notNull),
+      },
+    };
+    console.log(JSON.stringify(output, null, 2));
+  } else {
+    renderTable(recursion, events, { repeat, warmup, depth });
+  }
+});
+
+function renderTable(
+  recursion: BenchmarkDoneEvent[],
+  events: BenchmarkDoneEvent[],
+  options: { repeat?: number; warmup?: number; depth?: number },
+) {
+  const headers = ["Library", "Avg", "Min", "Max", "StdDev", "p50", "p95", "p99"];
   let rows = [];
 
   if (recursion.length > 0) {
-    rows.push(Row.from([new Cell("Basic Recursion").colSpan(2).border()]));
-    rows.push(Row.from<Cell | string>(["Library", "Avg (ms)"]).border());
+    const title = `Basic Recursion (${options.repeat} reps, ${options.warmup} warmup, depth ${options.depth})`;
+    rows.push(Row.from([new Cell(title).colSpan(headers.length).border()]));
+    rows.push(Row.from<Cell | string>(headers).border());
     rows.push(...recursion.map((event) => Row.from(toTableRow(event))));
   }
 
   if (events.length > 0) {
-    rows.push(Row.from([new Cell("Recursive Events").colSpan(2).border()]));
-    rows.push(Row.from<Cell | string>(["Library", "Avg (ms)"]).border());
+    const title = `Recursive Events (${options.repeat} reps, ${options.warmup} warmup, depth ${options.depth})`;
+    rows.push(Row.from([new Cell(title).colSpan(headers.length).border()]));
+    rows.push(Row.from<Cell | string>(headers).border());
     rows.push(...events.map((event) => Row.from(toTableRow(event))));
   }
 
   Table.from(rows).render();
-});
+}
 
 function* runBenchmark(
   scenario: string,
   options: BenchmarkOptions,
 ): Operation<BenchmarkDoneEvent> {
   let results = createQueue<BenchmarkDoneEvent, never>();
-  let closed = withResolvers<void>();
   let worker = yield* useWorker<WorkerCommand, BenchmarkWorkerEvent>(scenario);
 
   yield* spawn(function* () {
     for (let event of yield* each(worker.errors)) {
       event.preventDefault();
       throw event.error;
+      // Note: each.next() is unreachable after throw, but the loop will
+      // terminate when the worker scope is destroyed
     }
   });
 
@@ -109,12 +161,9 @@ function* runBenchmark(
     for (let event of yield* each(worker.messages)) {
       if (event.data.type === "done") {
         results.add(event.data);
-      } else if (event.data.type === "close") {
-        console.log(event.data);
+      } else if (event.data.type === "closed") {
         if (!event.data.result.ok) {
           throw event.data.result.error;
-        } else {
-          closed.resolve();
         }
       }
       yield* each.next();
@@ -126,11 +175,9 @@ function* runBenchmark(
     let value = (yield* results.next()).value;
     return value;
   } finally {
-    yield* worker.postMessage({ type: "close", result: Ok() });
+    yield* worker.postMessage({ type: "close" });
   }
 }
-
-import { basename } from "jsr:@std/path";
 
 function filter(
   strings: string[],
@@ -150,9 +197,37 @@ function filter(
 function toTableRow(event: BenchmarkDoneEvent): string[] {
   let [name = event.name] = event.name.split(".");
   if (event.result.ok) {
-    let { avgTime } = event.result.value;
-    return [name, String(avgTime)];
+    const stats = event.result.value;
+    return [
+      name,
+      formatMs(stats.avgTime),
+      formatMs(stats.minTime),
+      formatMs(stats.maxTime),
+      formatMs(stats.stdDev),
+      formatMs(stats.p50),
+      formatMs(stats.p95),
+      formatMs(stats.p99),
+    ];
   } else {
-    return [name, "❌"];
+    return [name, "❌", "", "", "", "", "", ""];
   }
+}
+
+function toJsonEntry(event: BenchmarkDoneEvent): BenchmarkResultEntry | null {
+  let [name = event.name] = event.name.split(".");
+  if (event.result.ok) {
+    return {
+      name,
+      stats: event.result.value,
+    };
+  }
+  return null;
+}
+
+function notNull<T>(value: T | null): value is T {
+  return value !== null;
+}
+
+function formatMs(ms: number): string {
+  return ms.toFixed(2);
 }

--- a/tasks/bench/scenarios/scenario.ts
+++ b/tasks/bench/scenarios/scenario.ts
@@ -29,8 +29,8 @@ function calculateStats(
   const sorted = [...times].sort((a, b) => a - b);
   const sum = times.reduce((a, b) => a + b, 0);
   const avg = sum / times.length;
-  const variance =
-    times.reduce((acc, t) => acc + (t - avg) ** 2, 0) / times.length;
+  const variance = times.reduce((acc, t) => acc + (t - avg) ** 2, 0) /
+    times.length;
 
   return {
     avgTime: avg,

--- a/tasks/bench/scenarios/scenario.ts
+++ b/tasks/bench/scenarios/scenario.ts
@@ -10,6 +10,7 @@ import {
 } from "../../../mod.ts";
 import type {
   BenchmarkOptions,
+  BenchmarkStats,
   BenchmarkWorkerEvent,
   WorkerCommand,
 } from "../types.ts";
@@ -18,6 +19,37 @@ import { messages } from "../worker.ts";
 const commands = messages<WorkerCommand>();
 
 const send = (event: BenchmarkWorkerEvent) => self.postMessage(event);
+
+/**
+ * Calculate statistical metrics from an array of timing samples.
+ */
+function calculateStats(
+  times: number[],
+): Omit<BenchmarkStats, "reps" | "times"> {
+  const sorted = [...times].sort((a, b) => a - b);
+  const sum = times.reduce((a, b) => a + b, 0);
+  const avg = sum / times.length;
+  const variance =
+    times.reduce((acc, t) => acc + (t - avg) ** 2, 0) / times.length;
+
+  return {
+    avgTime: avg,
+    minTime: sorted[0],
+    maxTime: sorted[sorted.length - 1],
+    stdDev: Math.sqrt(variance),
+    p50: percentile(sorted, 50),
+    p95: percentile(sorted, 95),
+    p99: percentile(sorted, 99),
+  };
+}
+
+/**
+ * Calculate the p-th percentile from a sorted array.
+ */
+function percentile(sorted: number[], p: number): number {
+  const index = Math.ceil((p / 100) * sorted.length) - 1;
+  return sorted[Math.max(0, index)];
+}
 
 export function scenario(
   name: string,
@@ -39,6 +71,12 @@ export function scenario(
         });
 
         for (let options of yield* each(work)) {
+          // Warmup runs: execute but don't time or report
+          for (let i = 0; i < options.warmup; i++) {
+            yield* encapsulate(() => perform(options.depth));
+          }
+
+          // Measured runs
           let times: number[] = [];
           for (let i = 0; i < options.repeat; i++) {
             let start = performance.now();
@@ -50,9 +88,12 @@ export function scenario(
             times.push(time);
           }
 
-          let total = times.reduce((sum, time) => sum + time, 0);
-          let avgTime = total / times.length;
-          let result = Ok({ avgTime, reps: options.repeat });
+          const stats = calculateStats(times);
+          const result = Ok({
+            reps: options.repeat,
+            times,
+            ...stats,
+          });
 
           send({ type: "done", name, result });
 
@@ -62,7 +103,7 @@ export function scenario(
     } catch (error) {
       send({ type: "done", name, result: Err(error as Error) });
     } finally {
-      send({ type: "close", result: Ok() });
+      send({ type: "closed", result: Ok() });
     }
   });
 }

--- a/tasks/bench/types.ts
+++ b/tasks/bench/types.ts
@@ -1,35 +1,78 @@
 import type { Result } from "../../lib/result.ts";
 
-export type WorkerCommand = BenchmarkOptions | Close;
+/**
+ * Statistical metrics for benchmark results.
+ * All time values are in milliseconds.
+ */
+export interface BenchmarkStats {
+  readonly reps: number;
+  readonly times: readonly number[];
+  readonly avgTime: number;
+  readonly minTime: number;
+  readonly maxTime: number;
+  readonly stdDev: number;
+  readonly p50: number;
+  readonly p95: number;
+  readonly p99: number;
+}
 
 export interface BenchmarkOptions {
-  type: "benchmark";
-  repeat: number;
-  depth: number;
+  readonly type: "benchmark";
+  readonly repeat: number;
+  readonly depth: number;
+  readonly warmup: number;
 }
 
-export interface Close {
-  type: "close";
-  result: Result<void>;
+export interface CloseCommand {
+  readonly type: "close";
 }
+
+export interface ClosedEvent {
+  readonly type: "closed";
+  readonly result: Result<void>;
+}
+
+export type WorkerCommand = BenchmarkOptions | CloseCommand;
 
 export type BenchmarkWorkerEvent =
   | BenchmarkRepeatEvent
   | BenchmarkDoneEvent
-  | Close;
+  | ClosedEvent;
 
 export interface BenchmarkRepeatEvent {
-  type: "repeat";
-  name: string;
-  rep: number;
-  time: number;
+  readonly type: "repeat";
+  readonly name: string;
+  readonly rep: number;
+  readonly time: number;
 }
 
 export interface BenchmarkDoneEvent {
-  type: "done";
-  name: string;
-  result: Result<{
-    reps: number;
-    avgTime: number;
-  }>;
+  readonly type: "done";
+  readonly name: string;
+  readonly result: Result<BenchmarkStats>;
+}
+
+// JSON output types
+
+export interface BenchmarkJsonOutput {
+  readonly metadata: BenchmarkMetadata;
+  readonly results: BenchmarkResultGroups;
+}
+
+export interface BenchmarkMetadata {
+  readonly date: string; // ISO 8601
+  readonly deno: string;
+  readonly repeat: number;
+  readonly warmup: number;
+  readonly depth: number;
+}
+
+export interface BenchmarkResultGroups {
+  readonly recursion: readonly BenchmarkResultEntry[];
+  readonly events: readonly BenchmarkResultEntry[];
+}
+
+export interface BenchmarkResultEntry {
+  readonly name: string;
+  readonly stats: BenchmarkStats;
 }


### PR DESCRIPTION
# Motivation

Addresses Phase 1 of #1112 (Performance Benchmark Analysis).

The current benchmark infrastructure only reports average time, which lacks statistical rigor for credible performance comparisons. Potential adopters need confidence in benchmark results, and this requires:
- Warmup runs to stabilize JIT compilation before measurements
- Statistical metrics beyond just average (variance, percentiles)
- Machine-readable output for automation and historical tracking

# Approach

**New CLI options:**
- `--warmup, -w` (default: 3): Number of warmup runs to discard before measurement
- `--json`: Output results as JSON instead of table

**Statistical metrics added:**
- `minTime`, `maxTime`: Range of measurements
- `stdDev`: Standard deviation showing measurement stability
- `p50`, `p95`, `p99`: Percentiles for understanding distribution

**Type improvements:**
- Extracted `BenchmarkStats` as a reusable interface
- Split `Close` into `CloseCommand` and `ClosedEvent` for protocol direction clarity
- Added `readonly` modifiers to all message types

---

## Current Benchmark Results

**Run configuration:** 20 repetitions, 5 warmup runs, depth 100  
**System:** macOS, Deno 2.6.5

### Basic Recursion

Tests recursive operation depth (100 levels) with 100 Promise.resolve() calls at the leaf.

| Library | Avg (ms) | Min | Max | StdDev | p50 | p95 | p99 |
|---------|----------|-----|-----|--------|-----|-----|-----|
| async+await | 0.06 | 0.03 | 0.50 | 0.10 | 0.03 | 0.08 | 0.50 |
| rxjs | 0.16 | 0.08 | 0.52 | 0.10 | 0.13 | 0.27 | 0.52 |
| co | 0.18 | 0.05 | 0.53 | 0.14 | 0.11 | 0.42 | 0.53 |
| effect | 0.78 | 0.25 | 3.94 | 0.82 | 0.51 | 1.47 | 3.94 |
| **effection** | 0.93 | 0.45 | 3.04 | 0.60 | 0.61 | 1.75 | 3.04 |

### Recursive Events

Tests event propagation through 100 nested EventTarget listeners with 100 events dispatched.

| Library | Avg (ms) | Min | Max | StdDev | p50 | p95 | p99 |
|---------|----------|-----|-----|--------|-----|-----|-----|
| add-event-listener | 3.65 | 3.24 | 4.82 | 0.32 | 3.57 | 4.00 | 4.82 |
| rxjs | 143.13 | 128.16 | 242.55 | 26.31 | 132.50 | 183.42 | 242.55 |
| **effection** | 158.55 | 134.26 | 250.83 | 27.00 | 152.47 | 211.90 | 250.83 |
| effect | 534.85 | 514.44 | 561.23 | 10.94 | 533.87 | 549.29 | 561.23 |

---

## How to Interpret Results

### Column Meanings

| Column | Meaning |
|--------|---------|
| **Avg** | Mean time across all repetitions (lower is faster) |
| **Min** | Best-case performance (fastest run) |
| **Max** | Worst-case performance (slowest run) |
| **StdDev** | Standard deviation — lower means more consistent/stable |
| **p50** | Median — 50% of runs were faster than this |
| **p95** | 95th percentile — only 5% of runs were slower |
| **p99** | 99th percentile — tail latency indicator |

### What the Numbers Mean

**Basic Recursion:**
- Measures raw operation overhead (yield*, spawn, scope creation)
- Effection is ~15x slower than raw async/await — this is the cost of structured concurrency guarantees
- Effection is competitive with Effect.js (within 20%)

**Recursive Events:**
- Measures event handling with nested subscriptions and cleanup
- Effection beats Effect.js by 3.4x
- Effection is ~10% slower than RxJS
- Native `addEventListener` is fastest but provides no cleanup guarantees

### Key Takeaway

Effection trades raw throughput for structured concurrency guarantees (automatic cleanup, cancellation propagation, error boundaries). The overhead is the cost of those guarantees. For applications where correctness matters more than microsecond-level performance, this is a worthwhile tradeoff.

---

## Example Output

**Table mode (default):**
```
$ deno task bench -n 20 -w 5

┌───────────────────────────────────────────────────────────────────────────────────┐
│ Basic Recursion (20 reps, 5 warmup, depth 100)                                    │
├────────────────────┬────────┬────────┬────────┬────────┬────────┬────────┬────────┤
│ Library            │ Avg    │ Min    │ Max    │ StdDev │ p50    │ p95    │ p99    │
└────────────────────┴────────┴────────┴────────┴────────┴────────┴────────┴────────┘
  effection            0.93     0.45     3.04     0.60     0.61     1.75     3.04    
  effect               0.78     0.25     3.94     0.82     0.51     1.47     3.94    
```

**JSON mode:**
```
$ deno task bench --json > results.json
```

```json
{
  "metadata": {
    "date": "2026-02-14T...",
    "deno": "2.6.5",
    "repeat": 10,
    "warmup": 3,
    "depth": 100
  },
  "results": {
    "recursion": [{ "name": "effection", "stats": { "avgTime": 0.93, ... } }],
    "events": [{ "name": "effection", "stats": { "avgTime": 158.55, ... } }]
  }
}
```