### PR TITLE
feat: export createApi from main module

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,8 +1,73 @@
-// deno-lint-ignore-file ban-types
-import type { Api, Context, Operation, Scope } from "./types.ts";
 import { createApiInternal } from "./api-internal.ts";
 import type { ScopeInternal } from "./scope-internal.ts";
+// deno-lint-ignore-file ban-types
+import type { Api, Context, Operation, Scope } from "./types.ts";
 
+/**
+ * Create an API object that provides middleware support for a set of operations.
+ *
+ * APIs enable context-sensitive functionality such as dependency injection,
+ * test mocking, and instrumentation by allowing middleware to be applied
+ * on a per-scope basis.
+ *
+ * @typeParam A - The shape of the core API object
+ * @param name - A unique identifier for this API (used for context naming)
+ * @param core - An object containing the core operations, functions, or values of the API
+ * @returns An {@link Api} object with `operations`, `around`, and `invoke` members
+ *
+ * @example
+ * ```ts
+ * import { createApi, run } from "effection";
+ *
+ * // Define an API with operations
+ * const mathApi = createApi("math", {
+ *   add: (a: number, b: number) => a + b,
+ *   *multiply(a: number, b: number) {
+ *     return a * b;
+ *   },
+ * });
+ *
+ * // Use the API operations
+ * await run(function*() {
+ *   let sum = yield* mathApi.operations.add(2, 3); // 5
+ *   let product = yield* mathApi.operations.multiply(2, 3); // 6
+ * });
+ * ```
+ *
+ * @example
+ * ```ts
+ * // Apply middleware for testing or instrumentation
+ * await run(function*() {
+ *   yield* mathApi.around({
+ *     add(args, next) {
+ *       console.log("Adding:", args);
+ *       return next(...args);
+ *     },
+ *   });
+ *
+ *   yield* mathApi.operations.add(2, 3); // logs "Adding: [2, 3]"
+ * });
+ * ```
+ *
+ * @example
+ * ```ts
+ * // Mock operations for testing
+ * await run(function*() {
+ *   yield* fetchApi.around({
+ *     *fetch() {
+ *       return { ok: true, json: () => ({ mocked: true }) };
+ *     },
+ *   });
+ *
+ *   // All fetch calls in this scope now return mocked data
+ * });
+ * ```
+ *
+ * @see {@link Api} for the returned API interface
+ * @see {@link Around} for the middleware type
+ * @see {@link Scope.around} for applying middleware from outside an operation
+ * @since 4.1
+ */
 export function createApi<A extends {}>(name: string, core: A): Api<A> {
   return createApiInternal(name, core);
 }
@@ -30,7 +95,7 @@ export const api: Apis = {
     },
     *destroy() {},
     set(scope, context, value) {
-      return (scope as ScopeInternal).contexts[context.name] = value;
+      return ((scope as ScopeInternal).contexts[context.name] = value);
     },
     delete(scope, context) {
       return delete (scope as ScopeInternal).contexts[context.name];

--- a/lib/mod.ts
+++ b/lib/mod.ts
@@ -26,3 +26,4 @@ export * from "./with-resolvers.ts";
 export * from "./async.ts";
 export * from "./scoped.ts";
 export * from "./until.ts";
+export { createApi } from "./api.ts";

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -1,7 +1,5 @@
-import { run } from "../mod.ts";
-import { createApi } from "../experimental.ts";
 import { constant } from "../lib/constant.ts";
-import { type Operation, spawn } from "../lib/mod.ts";
+import { type Operation, createApi, run, spawn } from "../mod.ts";
 import { describe, expect, it } from "./suite.ts";
 
 describe("api", () => {
@@ -168,13 +166,16 @@ describe("api", () => {
           return output.concat("/outermax");
         },
       });
-      yield* api.around({
-        *test(args, next) {
-          let [input] = args;
-          let output = yield* next(input.concat("outermin"));
-          return output.concat("/outermin");
+      yield* api.around(
+        {
+          *test(args, next) {
+            let [input] = args;
+            let output = yield* next(input.concat("outermin"));
+            return output.concat("/outermin");
+          },
         },
-      }, { at: "min" });
+        { at: "min" },
+      );
 
       let task = yield* spawn(function* inner() {
         yield* api.around({
@@ -184,13 +185,16 @@ describe("api", () => {
             return output.concat("/innermax");
           },
         });
-        yield* api.around({
-          *test(args, next) {
-            let [input] = args;
-            let output = yield* next(input.concat("innermin"));
-            return output.concat("/innermin");
+        yield* api.around(
+          {
+            *test(args, next) {
+              let [input] = args;
+              let output = yield* next(input.concat("innermin"));
+              return output.concat("/innermin");
+            },
           },
-        }, { at: "min" });
+          { at: "min" },
+        );
 
         return yield* api.operations.test([]);
       });


### PR DESCRIPTION
## Summary

Export the `createApi` function from the main effection module so users can create APIs with middleware support without importing from `experimental.ts`.

## Changes

- Add comprehensive JSDoc documentation with examples for `createApi`
- Export `createApi` from `lib/mod.ts`
- Update test to import `createApi` from main module instead of experimental

## Why

The `createApi` function enables:
- **Dependency injection**: Swap implementations based on context
- **Test mocking**: Replace real operations with test doubles
- **Instrumentation**: Add logging, metrics, or tracing middleware

This is now stable enough to be part of the public API.

## Usage

```ts
import { createApi, run } from "effection";

const myApi = createApi("myApi", {
  *fetch(url: string) {
    return yield* until(globalThis.fetch(url));
  }
});

// Use the API
await run(function*() {
  let response = yield* myApi.operations.fetch("/api/data");
});

// With middleware for testing
await run(function*() {
  yield* myApi.around({
    *fetch() {
      return { ok: true, json: () => ({ mocked: true }) };
    }
  });
  // All fetch calls now return mocked data
});
```

## Notes

Once this PR is merged and the preview package is published, we can update the `@effectionx/*` packages to use `createApi`.