### PR TITLE
feat(bench): add cancellation cascade benchmarks (Phase 2)

### DIFF
--- a/tasks/bench.ts
+++ b/tasks/bench.ts
@@ -16,8 +16,11 @@ import type {
   BenchmarkJsonOutput,
   BenchmarkOptions,
   BenchmarkResultEntry,
-  BenchmarkStats,
+  BenchmarkStatsByKind,
   BenchmarkWorkerEvent,
+  CancellationBenchmarkOptions,
+  CancellationResultEntry,
+  LegacyBenchmarkOptions,
   WorkerCommand,
 } from "./bench/types.ts";
 
@@ -30,6 +33,7 @@ interface BenchmarkCliOptions {
   repeat: number;
   depth: number;
   warmup: number;
+  tasks: number;
   json: boolean;
 }
 
@@ -62,6 +66,11 @@ await main(function* (args) {
         description: "number of warmup runs to discard",
         alias: "w",
       },
+      tasks: {
+        type: z.number().positive().default(10),
+        description: "number of concurrent tasks for cancellation benchmarks",
+        alias: "t",
+      },
       json: {
         type: z.boolean().default(false),
         description: "output results as JSON",
@@ -69,29 +78,50 @@ await main(function* (args) {
     })
     .parse(args) as BenchmarkCliOptions;
 
-  let { include, exclude, repeat, depth, warmup, json } = options;
+  let { include, exclude, repeat, depth, warmup, tasks: taskCount, json } = options;
 
-  let tasks: Task<BenchmarkDoneEvent>[] = [];
+  let benchTasks: Task<BenchmarkDoneEvent>[] = [];
 
   for (let scenario of filter(scenarios, { include, exclude })) {
-    tasks.push(
-      yield* spawn(() =>
-        runBenchmark(scenario, {
-          type: "benchmark",
-          repeat,
-          depth,
-          warmup,
-        })
-      ),
-    );
+    // Determine if this is a cancellation benchmark
+    const isCancellation = scenario.includes(".cancellation.");
+
+    if (isCancellation) {
+      // Cancellation benchmarks need the full CancellationBenchmarkOptions
+      benchTasks.push(
+        yield* spawn(() =>
+          runBenchmark(scenario, {
+            type: "benchmark",
+            kind: "cancellation",
+            repeat,
+            depth,
+            warmup,
+            tasks: taskCount,
+          })
+        ),
+      );
+    } else {
+      // Legacy benchmarks (recursion/events) use LegacyBenchmarkOptions
+      benchTasks.push(
+        yield* spawn(() =>
+          runBenchmark(scenario, {
+            type: "benchmark",
+            repeat,
+            depth,
+            warmup,
+          } as LegacyBenchmarkOptions)
+        ),
+      );
+    }
   }
 
-  let results = yield* all(tasks);
+  let results = yield* all(benchTasks);
 
-  let events = results.filter((result) => result.name.match("events"));
-  let recursion = results.filter((result) => result.name.match("recursion"));
+  let events = results.filter((result: BenchmarkDoneEvent) => result.name.match("events"));
+  let recursion = results.filter((result: BenchmarkDoneEvent) => result.name.match("recursion"));
+  let cancellation = results.filter((result: BenchmarkDoneEvent) => result.name.match("cancellation"));
 
-  if (events.length == 0 && recursion.length === 0) {
+  if (events.length === 0 && recursion.length === 0 && cancellation.length === 0) {
     console.log("no benchmarks run");
     return;
   }
@@ -104,24 +134,29 @@ await main(function* (args) {
         repeat,
         warmup,
         depth,
+        ...(cancellation.length > 0 ? { tasks: taskCount } : {}),
       },
       results: {
         recursion: recursion.map(toJsonEntry).filter(notNull),
         events: events.map(toJsonEntry).filter(notNull),
+        ...(cancellation.length > 0 ? {
+          cancellation: cancellation.map(toCancellationJsonEntry).filter(notNull),
+        } : {}),
       },
     };
     console.log(JSON.stringify(output, null, 2));
   } else {
-    renderTable(recursion, events, { repeat, warmup, depth });
+    renderTable(recursion, events, cancellation, { repeat, warmup, depth, tasks: taskCount });
   }
 });
 
 function renderTable(
   recursion: BenchmarkDoneEvent[],
   events: BenchmarkDoneEvent[],
-  options: { repeat?: number; warmup?: number; depth?: number },
+  cancellation: BenchmarkDoneEvent[],
+  options: { repeat?: number; warmup?: number; depth?: number; tasks?: number },
 ) {
-  const headers = [
+  const timingHeaders = [
     "Library",
     "Avg",
     "Min",
@@ -131,22 +166,42 @@ function renderTable(
     "p95",
     "p99",
   ];
+
+  const cancellationHeaders = [
+    "Library",
+    "Avg",
+    "Min",
+    "Max",
+    "StdDev",
+    "Alloc",
+    "Released",
+    "Leaked",
+  ];
+
   let rows = [];
 
   if (recursion.length > 0) {
     const title =
       `Basic Recursion (${options.repeat} reps, ${options.warmup} warmup, depth ${options.depth})`;
-    rows.push(Row.from([new Cell(title).colSpan(headers.length).border()]));
-    rows.push(Row.from<Cell | string>(headers).border());
+    rows.push(Row.from([new Cell(title).colSpan(timingHeaders.length).border()]));
+    rows.push(Row.from<Cell | string>(timingHeaders).border());
     rows.push(...recursion.map((event) => Row.from(toTableRow(event))));
   }
 
   if (events.length > 0) {
     const title =
       `Recursive Events (${options.repeat} reps, ${options.warmup} warmup, depth ${options.depth})`;
-    rows.push(Row.from([new Cell(title).colSpan(headers.length).border()]));
-    rows.push(Row.from<Cell | string>(headers).border());
+    rows.push(Row.from([new Cell(title).colSpan(timingHeaders.length).border()]));
+    rows.push(Row.from<Cell | string>(timingHeaders).border());
     rows.push(...events.map((event) => Row.from(toTableRow(event))));
+  }
+
+  if (cancellation.length > 0) {
+    const title =
+      `Cancellation Cascade (${options.repeat} reps, ${options.warmup} warmup, ${options.tasks} tasks, depth ${options.depth})`;
+    rows.push(Row.from([new Cell(title).colSpan(cancellationHeaders.length).border()]));
+    rows.push(Row.from<Cell | string>(cancellationHeaders).border());
+    rows.push(...cancellation.map((event) => Row.from(toCancellationTableRow(event))));
   }
 
   Table.from(rows).render();
@@ -154,7 +209,7 @@ function renderTable(
 
 function* runBenchmark(
   scenario: string,
-  options: BenchmarkOptions,
+  options: BenchmarkOptions | LegacyBenchmarkOptions,
 ): Operation<BenchmarkDoneEvent> {
   let results = createQueue<BenchmarkDoneEvent, never>();
   let worker = yield* useWorker<WorkerCommand, BenchmarkWorkerEvent>(scenario);
@@ -233,6 +288,36 @@ function toJsonEntry(event: BenchmarkDoneEvent): BenchmarkResultEntry | null {
     };
   }
   return null;
+}
+
+function toCancellationJsonEntry(event: BenchmarkDoneEvent): CancellationResultEntry | null {
+  let [name = event.name] = event.name.split(".");
+  if (event.result.ok && "correctness" in event.result.value) {
+    return {
+      name,
+      stats: event.result.value as BenchmarkStatsByKind["cancellation"],
+    };
+  }
+  return null;
+}
+
+function toCancellationTableRow(event: BenchmarkDoneEvent): string[] {
+  let [name = event.name] = event.name.split(".");
+  if (event.result.ok) {
+    const stats = event.result.value as BenchmarkStatsByKind["cancellation"];
+    return [
+      name,
+      formatMs(stats.avgTime),
+      formatMs(stats.minTime),
+      formatMs(stats.maxTime),
+      formatMs(stats.stdDev),
+      String(stats.correctness.allocated),
+      String(stats.correctness.released),
+      stats.correctness.leaked === 0 ? "0" : `${stats.correctness.leaked}`,
+    ];
+  } else {
+    return [name, "", "", "", "", "", "", ""];
+  }
 }
 
 function notNull<T>(value: T | null): value is T {

--- a/tasks/bench.ts
+++ b/tasks/bench.ts
@@ -78,7 +78,8 @@ await main(function* (args) {
     })
     .parse(args) as BenchmarkCliOptions;
 
-  let { include, exclude, repeat, depth, warmup, tasks: taskCount, json } = options;
+  let { include, exclude, repeat, depth, warmup, tasks: taskCount, json } =
+    options;
 
   let benchTasks: Task<BenchmarkDoneEvent>[] = [];
 
@@ -117,11 +118,19 @@ await main(function* (args) {
 
   let results = yield* all(benchTasks);
 
-  let events = results.filter((result: BenchmarkDoneEvent) => result.name.match("events"));
-  let recursion = results.filter((result: BenchmarkDoneEvent) => result.name.match("recursion"));
-  let cancellation = results.filter((result: BenchmarkDoneEvent) => result.name.match("cancellation"));
+  let events = results.filter((result: BenchmarkDoneEvent) =>
+    result.name.match("events")
+  );
+  let recursion = results.filter((result: BenchmarkDoneEvent) =>
+    result.name.match("recursion")
+  );
+  let cancellation = results.filter((result: BenchmarkDoneEvent) =>
+    result.name.match("cancellation")
+  );
 
-  if (events.length === 0 && recursion.length === 0 && cancellation.length === 0) {
+  if (
+    events.length === 0 && recursion.length === 0 && cancellation.length === 0
+  ) {
     console.log("no benchmarks run");
     return;
   }
@@ -139,14 +148,23 @@ await main(function* (args) {
       results: {
         recursion: recursion.map(toJsonEntry).filter(notNull),
         events: events.map(toJsonEntry).filter(notNull),
-        ...(cancellation.length > 0 ? {
-          cancellation: cancellation.map(toCancellationJsonEntry).filter(notNull),
-        } : {}),
+        ...(cancellation.length > 0
+          ? {
+            cancellation: cancellation.map(toCancellationJsonEntry).filter(
+              notNull,
+            ),
+          }
+          : {}),
       },
     };
     console.log(JSON.stringify(output, null, 2));
   } else {
-    renderTable(recursion, events, cancellation, { repeat, warmup, depth, tasks: taskCount });
+    renderTable(recursion, events, cancellation, {
+      repeat,
+      warmup,
+      depth,
+      tasks: taskCount,
+    });
   }
 });
 
@@ -183,7 +201,9 @@ function renderTable(
   if (recursion.length > 0) {
     const title =
       `Basic Recursion (${options.repeat} reps, ${options.warmup} warmup, depth ${options.depth})`;
-    rows.push(Row.from([new Cell(title).colSpan(timingHeaders.length).border()]));
+    rows.push(
+      Row.from([new Cell(title).colSpan(timingHeaders.length).border()]),
+    );
     rows.push(Row.from<Cell | string>(timingHeaders).border());
     rows.push(...recursion.map((event) => Row.from(toTableRow(event))));
   }
@@ -191,7 +211,9 @@ function renderTable(
   if (events.length > 0) {
     const title =
       `Recursive Events (${options.repeat} reps, ${options.warmup} warmup, depth ${options.depth})`;
-    rows.push(Row.from([new Cell(title).colSpan(timingHeaders.length).border()]));
+    rows.push(
+      Row.from([new Cell(title).colSpan(timingHeaders.length).border()]),
+    );
     rows.push(Row.from<Cell | string>(timingHeaders).border());
     rows.push(...events.map((event) => Row.from(toTableRow(event))));
   }
@@ -199,9 +221,13 @@ function renderTable(
   if (cancellation.length > 0) {
     const title =
       `Cancellation Cascade (${options.repeat} reps, ${options.warmup} warmup, ${options.tasks} tasks, depth ${options.depth})`;
-    rows.push(Row.from([new Cell(title).colSpan(cancellationHeaders.length).border()]));
+    rows.push(
+      Row.from([new Cell(title).colSpan(cancellationHeaders.length).border()]),
+    );
     rows.push(Row.from<Cell | string>(cancellationHeaders).border());
-    rows.push(...cancellation.map((event) => Row.from(toCancellationTableRow(event))));
+    rows.push(
+      ...cancellation.map((event) => Row.from(toCancellationTableRow(event))),
+    );
   }
 
   Table.from(rows).render();
@@ -290,7 +316,9 @@ function toJsonEntry(event: BenchmarkDoneEvent): BenchmarkResultEntry | null {
   return null;
 }
 
-function toCancellationJsonEntry(event: BenchmarkDoneEvent): CancellationResultEntry | null {
+function toCancellationJsonEntry(
+  event: BenchmarkDoneEvent,
+): CancellationResultEntry | null {
   let [name = event.name] = event.name.split(".");
   if (event.result.ok && "correctness" in event.result.value) {
     return {

--- a/tasks/bench.ts
+++ b/tasks/bench.ts
@@ -4,6 +4,7 @@ import {
   all,
   createQueue,
   each,
+  exit,
   main,
   type Operation,
   spawn,
@@ -38,6 +39,15 @@ interface BenchmarkCliOptions {
 }
 
 await main(function* (args) {
+  try {
+    yield* runBench(args);
+  } catch (e) {
+    console.error(`error: ${(e as Error).message}`);
+    yield* exit(1);
+  }
+});
+
+function* runBench(args: string[]): Operation<void> {
   let options = parser()
     .name("bench")
     .description("Run Effection benchmarks")
@@ -80,6 +90,14 @@ await main(function* (args) {
 
   let { include, exclude, repeat, depth, warmup, tasks: taskCount, json } =
     options;
+
+  // Validate regex patterns early (throws with friendly message if invalid)
+  if (include) {
+    validateRegex(include, "--include");
+  }
+  if (exclude) {
+    validateRegex(exclude, "--exclude");
+  }
 
   // Filter scenarios and build typed benchmark options
   const filteredScenarios = filterScenarios(scenarios, { include, exclude });
@@ -157,7 +175,7 @@ await main(function* (args) {
       tasks: taskCount,
     });
   }
-});
+}
 
 function renderTable(
   recursion: BenchmarkDoneEvent[],
@@ -244,6 +262,15 @@ function* runBenchmark(
   });
 
   yield* spawn(function* () {
+    for (let event of yield* each(worker.messageerrors)) {
+      throw new Error(
+        `Worker message serialization failed: ${event.data ?? "unknown error"}`,
+      );
+      // Note: each.next() is unreachable after throw
+    }
+  });
+
+  yield* spawn(function* () {
     for (let event of yield* each(worker.messages)) {
       if (event.data.type === "done") {
         // Validate that worker returned expected kind (prevents silent deadlock)
@@ -273,7 +300,22 @@ function* runBenchmark(
 }
 
 /**
+ * Validate a regex pattern and return the compiled RegExp.
+ * Throws a user-friendly error if the pattern is invalid.
+ */
+function validateRegex(pattern: string, flagName: string): RegExp {
+  try {
+    return new RegExp(pattern);
+  } catch (e) {
+    throw new Error(
+      `Invalid ${flagName} pattern "${pattern}": ${(e as Error).message}`,
+    );
+  }
+}
+
+/**
  * Filter scenarios by include/exclude regex patterns.
+ * Assumes patterns have already been validated via validateRegex().
  */
 function filterScenarios(
   entries: ScenarioEntry[],

--- a/tasks/bench.ts
+++ b/tasks/bench.ts
@@ -14,13 +14,13 @@ import scenarios from "./bench/scenarios.ts";
 import type {
   BenchmarkDoneEvent,
   BenchmarkJsonOutput,
+  BenchmarkKind,
   BenchmarkOptions,
   BenchmarkResultEntry,
   BenchmarkStatsByKind,
   BenchmarkWorkerEvent,
-  CancellationBenchmarkOptions,
   CancellationResultEntry,
-  LegacyBenchmarkOptions,
+  ScenarioEntry,
   WorkerCommand,
 } from "./bench/types.ts";
 
@@ -81,52 +81,43 @@ await main(function* (args) {
   let { include, exclude, repeat, depth, warmup, tasks: taskCount, json } =
     options;
 
-  let benchTasks: Task<BenchmarkDoneEvent>[] = [];
+  // Filter scenarios and build typed benchmark options
+  const filteredScenarios = filterScenarios(scenarios, { include, exclude });
 
-  for (let scenario of filter(scenarios, { include, exclude })) {
-    // Determine if this is a cancellation benchmark
-    const isCancellation = scenario.includes(".cancellation.");
+  // Track results by kind for proper grouping
+  const resultsByKind: Record<BenchmarkKind, BenchmarkDoneEvent[]> = {
+    recursion: [],
+    events: [],
+    cancellation: [],
+  };
 
-    if (isCancellation) {
-      // Cancellation benchmarks need the full CancellationBenchmarkOptions
-      benchTasks.push(
-        yield* spawn(() =>
-          runBenchmark(scenario, {
-            type: "benchmark",
-            kind: "cancellation",
-            repeat,
-            depth,
-            warmup,
-            tasks: taskCount,
-          })
-        ),
-      );
-    } else {
-      // Legacy benchmarks (recursion/events) use LegacyBenchmarkOptions
-      benchTasks.push(
-        yield* spawn(() =>
-          runBenchmark(scenario, {
-            type: "benchmark",
-            repeat,
-            depth,
-            warmup,
-          } as LegacyBenchmarkOptions)
-        ),
-      );
-    }
+  let benchTasks: Task<{ kind: BenchmarkKind; event: BenchmarkDoneEvent }>[] =
+    [];
+
+  for (const entry of filteredScenarios) {
+    const benchOptions = buildOptions(entry.kind, {
+      repeat,
+      depth,
+      warmup,
+      tasks: taskCount,
+    });
+
+    benchTasks.push(
+      yield* spawn(function* () {
+        const event = yield* runBenchmark(entry.path, entry.kind, benchOptions);
+        return { kind: entry.kind, event };
+      }),
+    );
   }
 
-  let results = yield* all(benchTasks);
+  const results = yield* all(benchTasks);
 
-  let events = results.filter((result: BenchmarkDoneEvent) =>
-    result.name.match("events")
-  );
-  let recursion = results.filter((result: BenchmarkDoneEvent) =>
-    result.name.match("recursion")
-  );
-  let cancellation = results.filter((result: BenchmarkDoneEvent) =>
-    result.name.match("cancellation")
-  );
+  // Group results by kind (using the typed entry, not filename regex)
+  for (const { kind, event } of results) {
+    resultsByKind[kind].push(event);
+  }
+
+  const { recursion, events, cancellation } = resultsByKind;
 
   if (
     events.length === 0 && recursion.length === 0 && cancellation.length === 0
@@ -234,11 +225,14 @@ function renderTable(
 }
 
 function* runBenchmark(
-  scenario: string,
-  options: BenchmarkOptions | LegacyBenchmarkOptions,
+  scenarioPath: string,
+  expectedKind: BenchmarkKind,
+  options: BenchmarkOptions,
 ): Operation<BenchmarkDoneEvent> {
   let results = createQueue<BenchmarkDoneEvent, never>();
-  let worker = yield* useWorker<WorkerCommand, BenchmarkWorkerEvent>(scenario);
+  let worker = yield* useWorker<WorkerCommand, BenchmarkWorkerEvent>(
+    scenarioPath,
+  );
 
   yield* spawn(function* () {
     for (let event of yield* each(worker.errors)) {
@@ -252,6 +246,13 @@ function* runBenchmark(
   yield* spawn(function* () {
     for (let event of yield* each(worker.messages)) {
       if (event.data.type === "done") {
+        // Validate that worker returned expected kind (prevents silent deadlock)
+        const actualKind = event.data.kind;
+        if (actualKind && actualKind !== expectedKind) {
+          throw new Error(
+            `Benchmark kind mismatch: expected "${expectedKind}", got "${actualKind}" from ${event.data.name}`,
+          );
+        }
         results.add(event.data);
       } else if (event.data.type === "closed") {
         if (!event.data.result.ok) {
@@ -271,19 +272,50 @@ function* runBenchmark(
   }
 }
 
-function filter(
-  strings: string[],
+/**
+ * Filter scenarios by include/exclude regex patterns.
+ */
+function filterScenarios(
+  entries: ScenarioEntry[],
   options: { include?: string; exclude?: string },
-): string[] {
+): ScenarioEntry[] {
   let { include, exclude } = options;
-  let result = strings;
+  let result = entries;
   if (include) {
-    result = result.filter((s) => basename(s).match(new RegExp(include)));
+    const regex = new RegExp(include);
+    result = result.filter((e) => basename(e.path).match(regex));
   }
   if (exclude) {
-    result = result.filter((s) => !basename(s).match(new RegExp(exclude)));
+    const regex = new RegExp(exclude);
+    result = result.filter((e) => !basename(e.path).match(regex));
   }
   return result;
+}
+
+/**
+ * Build typed benchmark options based on kind.
+ */
+function buildOptions(
+  kind: BenchmarkKind,
+  params: { repeat: number; depth: number; warmup: number; tasks: number },
+): BenchmarkOptions {
+  const { repeat, depth, warmup, tasks } = params;
+
+  switch (kind) {
+    case "recursion":
+      return { type: "benchmark", kind: "recursion", repeat, depth, warmup };
+    case "events":
+      return { type: "benchmark", kind: "events", repeat, depth, warmup };
+    case "cancellation":
+      return {
+        type: "benchmark",
+        kind: "cancellation",
+        repeat,
+        depth,
+        warmup,
+        tasks,
+      };
+  }
 }
 
 function toTableRow(event: BenchmarkDoneEvent): string[] {

--- a/tasks/bench/scenarios.ts
+++ b/tasks/bench/scenarios.ts
@@ -1,11 +1,18 @@
 export default [
+  // Recursion benchmarks
   "./scenarios/effection.recursion.ts",
   "./scenarios/rxjs.recursion.ts",
   "./scenarios/co.recursion.ts",
   "./scenarios/async+await.recursion.ts",
   "./scenarios/effect.recursion.ts",
+  // Events benchmarks
   "./scenarios/effection.events.ts",
   "./scenarios/rxjs.events.ts",
   "./scenarios/add-event-listener.events.ts",
   "./scenarios/effect.events.ts",
+  // Cancellation benchmarks
+  "./scenarios/cancellation/effection-structured.cancellation.ts",
+  "./scenarios/cancellation/async+abort.cancellation.ts",
+  "./scenarios/cancellation/effect.cancellation.ts",
+  "./scenarios/cancellation/rxjs.cancellation.ts",
 ].map((mod) => import.meta.resolve(mod));

--- a/tasks/bench/scenarios.ts
+++ b/tasks/bench/scenarios.ts
@@ -1,18 +1,41 @@
-export default [
+import type { ScenarioEntry } from "./types.ts";
+
+/**
+ * Typed scenario registry.
+ * Each entry explicitly declares its kind, avoiding fragile filename-based classification.
+ */
+const scenarios: ScenarioEntry[] = [
   // Recursion benchmarks
-  "./scenarios/effection.recursion.ts",
-  "./scenarios/rxjs.recursion.ts",
-  "./scenarios/co.recursion.ts",
-  "./scenarios/async+await.recursion.ts",
-  "./scenarios/effect.recursion.ts",
+  { path: "./scenarios/effection.recursion.ts", kind: "recursion" },
+  { path: "./scenarios/rxjs.recursion.ts", kind: "recursion" },
+  { path: "./scenarios/co.recursion.ts", kind: "recursion" },
+  { path: "./scenarios/async+await.recursion.ts", kind: "recursion" },
+  { path: "./scenarios/effect.recursion.ts", kind: "recursion" },
   // Events benchmarks
-  "./scenarios/effection.events.ts",
-  "./scenarios/rxjs.events.ts",
-  "./scenarios/add-event-listener.events.ts",
-  "./scenarios/effect.events.ts",
+  { path: "./scenarios/effection.events.ts", kind: "events" },
+  { path: "./scenarios/rxjs.events.ts", kind: "events" },
+  { path: "./scenarios/add-event-listener.events.ts", kind: "events" },
+  { path: "./scenarios/effect.events.ts", kind: "events" },
   // Cancellation benchmarks
-  "./scenarios/cancellation/effection-structured.cancellation.ts",
-  "./scenarios/cancellation/async+abort.cancellation.ts",
-  "./scenarios/cancellation/effect.cancellation.ts",
-  "./scenarios/cancellation/rxjs.cancellation.ts",
-].map((mod) => import.meta.resolve(mod));
+  {
+    path: "./scenarios/cancellation/effection-structured.cancellation.ts",
+    kind: "cancellation",
+  },
+  {
+    path: "./scenarios/cancellation/async+abort.cancellation.ts",
+    kind: "cancellation",
+  },
+  {
+    path: "./scenarios/cancellation/effect.cancellation.ts",
+    kind: "cancellation",
+  },
+  {
+    path: "./scenarios/cancellation/rxjs.cancellation.ts",
+    kind: "cancellation",
+  },
+];
+
+export default scenarios.map((entry) => ({
+  ...entry,
+  path: import.meta.resolve(entry.path),
+}));

--- a/tasks/bench/scenarios/cancellation/async+abort.cancellation.ts
+++ b/tasks/bench/scenarios/cancellation/async+abort.cancellation.ts
@@ -14,8 +14,12 @@
  */
 
 import { call } from "../../../../mod.ts";
-import { cancellationScenario, type CancellationParams } from "./scenario.ts";
-import { createBarrier, type Barrier, type ResourceTracker } from "./tracker.ts";
+import { type CancellationParams, cancellationScenario } from "./scenario.ts";
+import {
+  type Barrier,
+  createBarrier,
+  type ResourceTracker,
+} from "./tracker.ts";
 
 await cancellationScenario(
   "async+abort.cancellation",

--- a/tasks/bench/scenarios/cancellation/async+abort.cancellation.ts
+++ b/tasks/bench/scenarios/cancellation/async+abort.cancellation.ts
@@ -1,0 +1,132 @@
+/**
+ * Async/Await + AbortController Cancellation Benchmark
+ *
+ * Demonstrates the manual approach to cancellation without structured concurrency.
+ * This shows what developers must write when using vanilla async/await:
+ *
+ * 1. Create and manage AbortController hierarchy manually
+ * 2. Thread AbortSignal through every function call
+ * 3. Check signal.aborted at every suspension point
+ * 4. Register cleanup callbacks with signal.addEventListener
+ * 5. Remember to call controller.abort() to trigger cancellation
+ *
+ * Contrast with Effection: scope exit = automatic cascade, no signal threading.
+ */
+
+import { call } from "../../../../mod.ts";
+import { cancellationScenario, type CancellationParams } from "./scenario.ts";
+import { createBarrier, type Barrier, type ResourceTracker } from "./tracker.ts";
+
+await cancellationScenario(
+  "async+abort.cancellation",
+  (params) => call(() => runBenchmark(params)),
+);
+
+async function runBenchmark(params: CancellationParams): Promise<void> {
+  const { tasks, depth, tracker } = params;
+
+  // Calculate total expected allocations
+  const totalAllocations = tasks * depth;
+  const barrier = createBarrier(totalAllocations);
+
+  // Manual: Create a root AbortController
+  const controller = new AbortController();
+  const { signal } = controller;
+
+  // Manual: Track all worker promises so we can wait for cleanup
+  const workers: Promise<void>[] = [];
+
+  // Spawn all workers, threading the signal through
+  for (let i = 0; i < tasks; i++) {
+    workers.push(worker(depth, tracker, barrier, signal));
+  }
+
+  // Wait for all workers to allocate their resources
+  await barrier.wait();
+
+  // Manual: Trigger cancellation by aborting the controller
+  controller.abort();
+
+  // Manual: Wait for all workers to complete cleanup
+  // This is critical and easy to forget - if we don't wait,
+  // cleanup may not complete before we check the tracker
+  await Promise.allSettled(workers);
+}
+
+/**
+ * A worker that allocates a resource and spawns nested sub-workers.
+ * Must manually:
+ * 1. Accept AbortSignal as parameter
+ * 2. Check signal.aborted at suspension points
+ * 3. Register cleanup with signal.addEventListener
+ * 4. Thread signal to child workers
+ */
+async function worker(
+  depth: number,
+  tracker: ResourceTracker,
+  barrier: Barrier,
+  signal: AbortSignal,
+): Promise<void> {
+  // Allocate a resource
+  tracker.allocate();
+
+  // Manual: Track child workers for cleanup
+  const children: Promise<void>[] = [];
+
+  // Manual: Set up cleanup handler - must use addEventListener pattern
+  // because there's no finally block for async functions that handles abort
+  let cleanedUp = false;
+  const cleanup = () => {
+    if (!cleanedUp) {
+      cleanedUp = true;
+      tracker.release();
+    }
+  };
+
+  // Manual: Register cleanup for abort
+  signal.addEventListener("abort", cleanup, { once: true });
+
+  try {
+    // Manual: Check if already aborted before doing work
+    if (signal.aborted) {
+      cleanup();
+      return;
+    }
+
+    if (depth > 1) {
+      // Manual: Thread the signal to child workers
+      children.push(worker(depth - 1, tracker, barrier, signal));
+    }
+
+    // Signal that this worker has allocated its resource
+    await barrier.arrive();
+
+    // Manual: Check if aborted after each await
+    if (signal.aborted) {
+      cleanup();
+      await Promise.allSettled(children);
+      return;
+    }
+
+    // Simulate indefinite wait - in real code this would be actual async work
+    // We use a pattern that responds to abort
+    await new Promise<void>((resolve) => {
+      if (signal.aborted) {
+        resolve();
+        return;
+      }
+      signal.addEventListener("abort", () => resolve(), { once: true });
+    });
+
+    // Manual: Wait for children to clean up
+    await Promise.allSettled(children);
+  } finally {
+    // Manual: Cleanup - but note this may not run if we don't await properly!
+    // The cleanup() call here is redundant with the signal handler,
+    // but demonstrates the complexity of getting cleanup right.
+    cleanup();
+
+    // Manual: Remove the event listener to avoid memory leaks
+    signal.removeEventListener("abort", cleanup);
+  }
+}

--- a/tasks/bench/scenarios/cancellation/effect.cancellation.ts
+++ b/tasks/bench/scenarios/cancellation/effect.cancellation.ts
@@ -18,8 +18,12 @@
 
 import { Effect, Fiber, type Scope } from "npm:effect";
 import { call } from "../../../../mod.ts";
-import { cancellationScenario, type CancellationParams } from "./scenario.ts";
-import { createBarrier, type Barrier, type ResourceTracker } from "./tracker.ts";
+import { type CancellationParams, cancellationScenario } from "./scenario.ts";
+import {
+  type Barrier,
+  createBarrier,
+  type ResourceTracker,
+} from "./tracker.ts";
 
 await cancellationScenario(
   "effect.cancellation",

--- a/tasks/bench/scenarios/cancellation/effect.cancellation.ts
+++ b/tasks/bench/scenarios/cancellation/effect.cancellation.ts
@@ -16,7 +16,7 @@
  * - Effect.acquireRelease for resource cleanup
  */
 
-import { Effect, Fiber, Deferred, type Scope } from "npm:effect";
+import { Effect, Fiber, type Scope } from "npm:effect";
 import { call } from "../../../../mod.ts";
 import { cancellationScenario, type CancellationParams } from "./scenario.ts";
 import { createBarrier, type Barrier, type ResourceTracker } from "./tracker.ts";
@@ -34,9 +34,6 @@ async function runBenchmark(params: CancellationParams): Promise<void> {
   const barrier = createBarrier(totalAllocations);
 
   const program = Effect.gen(function* () {
-    // Create a deferred to signal when all workers have started
-    const allStarted = yield* Deferred.make<void>();
-
     // Track fibers for the final wait
     const fibers: Fiber.RuntimeFiber<void, never>[] = [];
 

--- a/tasks/bench/scenarios/cancellation/effect.cancellation.ts
+++ b/tasks/bench/scenarios/cancellation/effect.cancellation.ts
@@ -1,0 +1,99 @@
+/**
+ * Effect.js Fiber Interruption Cancellation Benchmark
+ *
+ * Demonstrates Effect's approach to cancellation using fiber interruption.
+ * Effect has structured concurrency via its fiber model:
+ *
+ * 1. Fibers form a hierarchy (parent-child relationships)
+ * 2. Interrupting a parent fiber cascades to children
+ * 3. Finalizers run on interruption
+ * 4. Effect.acquireRelease manages resource lifecycle
+ *
+ * This is conceptually similar to Effection but with different ergonomics:
+ * - Effect uses Effect.gen with yield* (similar to Effection generators)
+ * - Effect.fork spawns concurrent fibers
+ * - Effect.interrupt/Fiber.interrupt for cancellation
+ * - Effect.acquireRelease for resource cleanup
+ */
+
+import { Effect, Fiber, Deferred, type Scope } from "npm:effect";
+import { call } from "../../../../mod.ts";
+import { cancellationScenario, type CancellationParams } from "./scenario.ts";
+import { createBarrier, type Barrier, type ResourceTracker } from "./tracker.ts";
+
+await cancellationScenario(
+  "effect.cancellation",
+  (params) => call(() => runBenchmark(params)),
+);
+
+async function runBenchmark(params: CancellationParams): Promise<void> {
+  const { tasks, depth, tracker } = params;
+
+  // Calculate total expected allocations
+  const totalAllocations = tasks * depth;
+  const barrier = createBarrier(totalAllocations);
+
+  const program = Effect.gen(function* () {
+    // Create a deferred to signal when all workers have started
+    const allStarted = yield* Deferred.make<void>();
+
+    // Track fibers for the final wait
+    const fibers: Fiber.RuntimeFiber<void, never>[] = [];
+
+    // Fork all worker fibers
+    for (let i = 0; i < tasks; i++) {
+      const fiber = yield* Effect.fork(worker(depth, tracker, barrier));
+      fibers.push(fiber);
+    }
+
+    // Wait for all workers to allocate resources
+    yield* Effect.promise(() => barrier.wait());
+
+    // Interrupt all fibers - this cascades to children
+    // Effect's structured concurrency ensures finalizers run
+    yield* Effect.forEach(
+      fibers,
+      (fiber: Fiber.RuntimeFiber<void, never>) => Fiber.interrupt(fiber),
+      { concurrency: "unbounded" },
+    );
+  });
+
+  // Run with a scope that handles cleanup
+  await Effect.runPromise(Effect.scoped(program));
+}
+
+/**
+ * Worker effect that allocates a resource and spawns nested children.
+ * Uses Effect.acquireRelease for resource lifecycle management.
+ */
+function worker(
+  depth: number,
+  tracker: ResourceTracker,
+  barrier: Barrier,
+): Effect.Effect<void, never, Scope.Scope> {
+  return Effect.gen(function* () {
+    // Acquire resource with guaranteed release
+    yield* Effect.acquireRelease(
+      // Acquire: allocate the resource
+      Effect.sync(() => {
+        tracker.allocate();
+      }),
+      // Release: runs on success, failure, or interruption
+      () =>
+        Effect.sync(() => {
+          tracker.release();
+        }),
+    );
+
+    if (depth > 1) {
+      // Fork a child fiber - it inherits the scope
+      yield* Effect.fork(worker(depth - 1, tracker, barrier));
+    }
+
+    // Signal that this worker has allocated
+    yield* Effect.promise(() => barrier.arrive());
+
+    // Suspend indefinitely - will be interrupted
+    yield* Effect.never;
+  });
+}

--- a/tasks/bench/scenarios/cancellation/effection-structured.cancellation.ts
+++ b/tasks/bench/scenarios/cancellation/effection-structured.cancellation.ts
@@ -1,0 +1,92 @@
+/**
+ * Effection Structured Cancellation Benchmark
+ *
+ * Demonstrates Effection's core value proposition: automatic cancellation
+ * through structured concurrency. When a scope exits, all spawned tasks
+ * are automatically halted and their cleanup runs.
+ *
+ * Scenario:
+ * - Spawn N concurrent worker tasks
+ * - Each worker spawns nested sub-tasks up to depth D
+ * - Each task allocates a "resource" (tracked via tracker.allocate())
+ * - Cancel all by exiting the parent scope
+ * - Verify all resources are released via finally blocks
+ *
+ * Key insight: No manual AbortController, no signal threading, no cleanup lists.
+ * Scope exit = automatic cancellation cascade.
+ */
+
+import {
+  call,
+  type Operation,
+  scoped,
+  spawn,
+  suspend,
+} from "../../../../mod.ts";
+import { cancellationScenario, type CancellationParams } from "./scenario.ts";
+import { createBarrier, type Barrier, type ResourceTracker } from "./tracker.ts";
+
+await cancellationScenario("effection-structured.cancellation", runBenchmark);
+
+function* runBenchmark(params: CancellationParams): Operation<void> {
+  const { tasks, depth, tracker } = params;
+  
+  // Calculate total expected allocations: each task allocates 1 resource per depth level
+  // tasks * depth = total resources
+  const totalAllocations = tasks * depth;
+  const barrier = createBarrier(totalAllocations);
+
+  // Use scoped() to create an explicit cancellation boundary.
+  // When we exit this scope, all spawned work is automatically cancelled.
+  yield* scoped(function* () {
+    // Spawn all worker tasks
+    for (let i = 0; i < tasks; i++) {
+      yield* spawn(function* () {
+        yield* worker(depth, tracker, barrier);
+      });
+    }
+
+    // Wait for all workers (and their nested sub-workers) to allocate resources
+    yield* call(() => barrier.wait());
+
+    // Now cancel everything by exiting the scoped() block.
+    // This is the key demonstration: we don't call halt() on each task,
+    // we don't thread AbortSignals, we just... exit.
+    // Effection's structured concurrency ensures all spawned tasks are halted
+    // and their finally blocks run.
+  });
+
+  // At this point, all tasks have been cancelled and cleanup has run.
+  // The tracker should show allocated === released (no leaks).
+}
+
+/**
+ * A worker that allocates a resource and spawns nested sub-workers.
+ * Cleanup happens in finally, which runs on normal exit, error, OR halt.
+ */
+function* worker(
+  depth: number,
+  tracker: ResourceTracker,
+  barrier: Barrier,
+): Operation<void> {
+  // Allocate a resource
+  tracker.allocate();
+
+  try {
+    if (depth > 1) {
+      // Spawn a nested sub-worker (simulates task tree)
+      yield* spawn(function* () {
+        yield* worker(depth - 1, tracker, barrier);
+      });
+    }
+
+    // Signal that this worker has allocated its resource
+    yield* call(() => barrier.arrive());
+
+    // Suspend indefinitely - this task will be halted by parent scope exit
+    yield* suspend();
+  } finally {
+    // Release resource on cleanup (runs on halt, error, or normal exit)
+    tracker.release();
+  }
+}

--- a/tasks/bench/scenarios/cancellation/effection-structured.cancellation.ts
+++ b/tasks/bench/scenarios/cancellation/effection-structured.cancellation.ts
@@ -23,14 +23,18 @@ import {
   spawn,
   suspend,
 } from "../../../../mod.ts";
-import { cancellationScenario, type CancellationParams } from "./scenario.ts";
-import { createBarrier, type Barrier, type ResourceTracker } from "./tracker.ts";
+import { type CancellationParams, cancellationScenario } from "./scenario.ts";
+import {
+  type Barrier,
+  createBarrier,
+  type ResourceTracker,
+} from "./tracker.ts";
 
 await cancellationScenario("effection-structured.cancellation", runBenchmark);
 
 function* runBenchmark(params: CancellationParams): Operation<void> {
   const { tasks, depth, tracker } = params;
-  
+
   // Calculate total expected allocations: each task allocates 1 resource per depth level
   // tasks * depth = total resources
   const totalAllocations = tasks * depth;

--- a/tasks/bench/scenarios/cancellation/rxjs.cancellation.ts
+++ b/tasks/bench/scenarios/cancellation/rxjs.cancellation.ts
@@ -1,0 +1,106 @@
+/**
+ * RxJS TakeUntil Cancellation Benchmark
+ *
+ * Demonstrates RxJS's approach to cancellation using the takeUntil pattern.
+ * RxJS doesn't have built-in structured concurrency, but provides:
+ *
+ * 1. Subscription management with subscriber.add() for child cleanup
+ * 2. takeUntil() operator for signal-based completion
+ * 3. finalize() operator for cleanup side effects
+ * 4. Subject as a cancellation signal source
+ *
+ * Key differences from Effection:
+ * - Manual subscription management (subscriber.add)
+ * - Explicit cancellation signal (Subject + takeUntil)
+ * - No automatic scope hierarchy - must wire everything manually
+ * - Cleanup via finalize() or subscription teardown
+ */
+
+import {
+  Observable,
+  Subject,
+  type Subscriber,
+} from "npm:rxjs";
+import { call } from "../../../../mod.ts";
+import { cancellationScenario, type CancellationParams } from "./scenario.ts";
+import { createBarrier, type Barrier, type ResourceTracker } from "./tracker.ts";
+
+await cancellationScenario(
+  "rxjs.cancellation",
+  (params) => call(() => runBenchmark(params)),
+);
+
+async function runBenchmark(params: CancellationParams): Promise<void> {
+  const { tasks, depth, tracker } = params;
+
+  // Calculate total expected allocations
+  const totalAllocations = tasks * depth;
+  const barrier = createBarrier(totalAllocations);
+
+  // Manual: Create a subject to act as the cancellation signal
+  const cancel$ = new Subject<void>();
+
+  // Create worker observables
+  const workers: Observable<void>[] = [];
+  for (let i = 0; i < tasks; i++) {
+    workers.push(worker(depth, tracker, barrier, cancel$));
+  }
+
+  // Subscribe to all workers
+  const subscriptions = workers.map((w) => w.subscribe());
+
+  // Wait for all workers to allocate
+  await barrier.wait();
+
+  // Trigger cancellation - this completes all observables using takeUntil
+  cancel$.next();
+  cancel$.complete();
+
+  // Unsubscribe all (this triggers finalize callbacks)
+  subscriptions.forEach((s) => s.unsubscribe());
+}
+
+/**
+ * Worker observable that allocates a resource and spawns nested children.
+ * Uses finalize() for cleanup and subscriber.add() for child management.
+ */
+function worker(
+  depth: number,
+  tracker: ResourceTracker,
+  barrier: Barrier,
+  cancel$: Subject<void>,
+): Observable<void> {
+  return new Observable<void>((subscriber: Subscriber<void>) => {
+    // Allocate resource
+    tracker.allocate();
+
+    // Track if we've cleaned up to avoid double-release
+    let cleanedUp = false;
+    const cleanup = () => {
+      if (!cleanedUp) {
+        cleanedUp = true;
+        tracker.release();
+      }
+    };
+
+    // Manual: Set up cleanup via finalize or teardown
+    subscriber.add(() => cleanup());
+
+    if (depth > 1) {
+      // Manual: Create and manage child subscription
+      const child = worker(depth - 1, tracker, barrier, cancel$);
+      subscriber.add(child.subscribe());
+    }
+
+    // Signal that this worker has allocated
+    barrier.arrive();
+
+    // Add takeUntil to respond to cancellation
+    // But since we're inside Observable constructor, we need to handle this differently
+    const cancellation = cancel$.subscribe(() => {
+      cleanup();
+      subscriber.complete();
+    });
+    subscriber.add(cancellation);
+  });
+}

--- a/tasks/bench/scenarios/cancellation/rxjs.cancellation.ts
+++ b/tasks/bench/scenarios/cancellation/rxjs.cancellation.ts
@@ -16,14 +16,14 @@
  * - Cleanup via finalize() or subscription teardown
  */
 
-import {
-  Observable,
-  Subject,
-  type Subscriber,
-} from "npm:rxjs";
+import { Observable, Subject, type Subscriber } from "npm:rxjs";
 import { call } from "../../../../mod.ts";
-import { cancellationScenario, type CancellationParams } from "./scenario.ts";
-import { createBarrier, type Barrier, type ResourceTracker } from "./tracker.ts";
+import { type CancellationParams, cancellationScenario } from "./scenario.ts";
+import {
+  type Barrier,
+  createBarrier,
+  type ResourceTracker,
+} from "./tracker.ts";
 
 await cancellationScenario(
   "rxjs.cancellation",

--- a/tasks/bench/scenarios/cancellation/rxjs.cancellation.ts
+++ b/tasks/bench/scenarios/cancellation/rxjs.cancellation.ts
@@ -1,22 +1,28 @@
 /**
  * RxJS TakeUntil Cancellation Benchmark
  *
- * Demonstrates RxJS's approach to cancellation using the takeUntil pattern.
+ * Demonstrates RxJS's idiomatic approach to cancellation using takeUntil + finalize.
  * RxJS doesn't have built-in structured concurrency, but provides:
  *
- * 1. Subscription management with subscriber.add() for child cleanup
- * 2. takeUntil() operator for signal-based completion
- * 3. finalize() operator for cleanup side effects
- * 4. Subject as a cancellation signal source
+ * 1. takeUntil() operator for signal-based completion
+ * 2. finalize() operator for cleanup side effects (runs on complete/error/unsubscribe)
+ * 3. Subject as a cancellation signal source
+ * 4. merge() for concurrent subscription management
  *
  * Key differences from Effection:
- * - Manual subscription management (subscriber.add)
  * - Explicit cancellation signal (Subject + takeUntil)
- * - No automatic scope hierarchy - must wire everything manually
- * - Cleanup via finalize() or subscription teardown
+ * - No automatic scope hierarchy - must wire takeUntil to each observable
+ * - Cleanup via finalize() operator
  */
 
-import { Observable, Subject, type Subscriber } from "npm:rxjs";
+import {
+  finalize,
+  merge,
+  NEVER,
+  Observable,
+  Subject,
+  takeUntil,
+} from "npm:rxjs";
 import { call } from "../../../../mod.ts";
 import { type CancellationParams, cancellationScenario } from "./scenario.ts";
 import {
@@ -37,70 +43,75 @@ async function runBenchmark(params: CancellationParams): Promise<void> {
   const totalAllocations = tasks * depth;
   const barrier = createBarrier(totalAllocations);
 
-  // Manual: Create a subject to act as the cancellation signal
+  // Cancellation signal - when this emits, all workers complete via takeUntil
   const cancel$ = new Subject<void>();
 
-  // Create worker observables
+  // Create worker observables - each pipes through takeUntil(cancel$)
   const workers: Observable<void>[] = [];
   for (let i = 0; i < tasks; i++) {
-    workers.push(worker(depth, tracker, barrier, cancel$));
+    workers.push(createWorkerTree(depth, tracker, barrier, cancel$));
   }
 
-  // Subscribe to all workers
-  const subscriptions = workers.map((w) => w.subscribe());
+  // Merge all workers into a single subscription
+  // This is idiomatic RxJS for concurrent execution
+  await new Promise<void>((resolve) => {
+    const subscription = merge(...workers).subscribe({
+      complete: () => resolve(),
+    });
 
-  // Wait for all workers to allocate
-  await barrier.wait();
+    // Wait for all workers to allocate, then trigger cancellation
+    barrier.wait().then(() => {
+      cancel$.next();
+      cancel$.complete();
+    });
 
-  // Trigger cancellation - this completes all observables using takeUntil
-  cancel$.next();
-  cancel$.complete();
-
-  // Unsubscribe all (this triggers finalize callbacks)
-  subscriptions.forEach((s) => s.unsubscribe());
+    // Cleanup subscription after cancellation completes
+    cancel$.subscribe({
+      complete: () => subscription.unsubscribe(),
+    });
+  });
 }
 
 /**
- * Worker observable that allocates a resource and spawns nested children.
- * Uses finalize() for cleanup and subscriber.add() for child management.
+ * Creates a worker observable tree with nested children.
+ *
+ * Uses idiomatic RxJS pattern:
+ * - NEVER as the base (suspends indefinitely)
+ * - takeUntil(cancel$) to respond to cancellation
+ * - finalize() for cleanup (runs on complete/error/unsubscribe)
+ * - merge() for concurrent child workers
  */
-function worker(
+function createWorkerTree(
   depth: number,
   tracker: ResourceTracker,
   barrier: Barrier,
   cancel$: Subject<void>,
 ): Observable<void> {
-  return new Observable<void>((subscriber: Subscriber<void>) => {
-    // Allocate resource
+  return new Observable<void>((subscriber) => {
+    // Allocate resource on subscription
     tracker.allocate();
-
-    // Track if we've cleaned up to avoid double-release
-    let cleanedUp = false;
-    const cleanup = () => {
-      if (!cleanedUp) {
-        cleanedUp = true;
-        tracker.release();
-      }
-    };
-
-    // Manual: Set up cleanup via finalize or teardown
-    subscriber.add(() => cleanup());
-
-    if (depth > 1) {
-      // Manual: Create and manage child subscription
-      const child = worker(depth - 1, tracker, barrier, cancel$);
-      subscriber.add(child.subscribe());
-    }
 
     // Signal that this worker has allocated
     barrier.arrive();
 
-    // Add takeUntil to respond to cancellation
-    // But since we're inside Observable constructor, we need to handle this differently
-    const cancellation = cancel$.subscribe(() => {
-      cleanup();
-      subscriber.complete();
-    });
-    subscriber.add(cancellation);
+    // Create child worker if depth > 1
+    if (depth > 1) {
+      const child$ = createWorkerTree(depth - 1, tracker, barrier, cancel$);
+      // Subscribe to child and add to teardown
+      subscriber.add(child$.subscribe());
+    }
+
+    // Never emit, just suspend - takeUntil will complete us
+    subscriber.add(
+      NEVER.pipe(
+        takeUntil(cancel$),
+        finalize(() => {
+          // Release resource on any termination (complete/error/unsubscribe)
+          tracker.release();
+        }),
+      ).subscribe({
+        complete: () => subscriber.complete(),
+      }),
+    );
   });
 }

--- a/tasks/bench/scenarios/cancellation/scenario.ts
+++ b/tasks/bench/scenarios/cancellation/scenario.ts
@@ -70,7 +70,9 @@ export interface CancellationParams {
  * Must spawn `tasks` concurrent workers, each with nested sub-tasks up to `depth`,
  * then cancel them all. Uses `tracker` to record resource allocations and releases.
  */
-export type CancellationBenchmark = (params: CancellationParams) => Operation<void>;
+export type CancellationBenchmark = (
+  params: CancellationParams,
+) => Operation<void>;
 
 /**
  * Entry point for cancellation benchmark scenarios.
@@ -87,7 +89,7 @@ export function cancellationScenario(
     try {
       yield* callcc<void>(function* (exit) {
         const work = createChannel<CancellationBenchmarkOptions, never>();
-        
+
         yield* spawn(function* () {
           for (const command of yield* each(commands)) {
             if (command.type === "close") {
@@ -122,7 +124,7 @@ export function cancellationScenario(
             // Reset tracker per-run to accumulate across all runs
             // (We'll aggregate stats at the end)
             const runTracker = createTracker();
-            
+
             const start = performance.now();
 
             yield* encapsulate(() =>

--- a/tasks/bench/scenarios/cancellation/scenario.ts
+++ b/tasks/bench/scenarios/cancellation/scenario.ts
@@ -1,0 +1,177 @@
+import { callcc } from "../../../../lib/callcc.ts";
+import { Err, Ok } from "../../../../lib/result.ts";
+import { encapsulate } from "../../../../lib/task-group.ts";
+import {
+  createChannel,
+  each,
+  main,
+  type Operation,
+  spawn,
+} from "../../../../mod.ts";
+import type {
+  BenchmarkStatsByKind,
+  BenchmarkWorkerEvent,
+  CancellationBenchmarkOptions,
+  TimingStats,
+  WorkerCommand,
+} from "../../types.ts";
+import { messages } from "../../worker.ts";
+import { createTracker, type ResourceTracker } from "./tracker.ts";
+
+const commands = messages<WorkerCommand>();
+
+const send = (event: BenchmarkWorkerEvent) => self.postMessage(event);
+
+/**
+ * Calculate statistical metrics from an array of timing samples.
+ */
+function calculateStats(
+  times: number[],
+): Omit<TimingStats, "reps" | "times"> {
+  const sorted = [...times].sort((a, b) => a - b);
+  const sum = times.reduce((a, b) => a + b, 0);
+  const avg = sum / times.length;
+  const variance = times.reduce((acc, t) => acc + (t - avg) ** 2, 0) /
+    times.length;
+
+  return {
+    avgTime: avg,
+    minTime: sorted[0],
+    maxTime: sorted[sorted.length - 1],
+    stdDev: Math.sqrt(variance),
+    p50: percentile(sorted, 50),
+    p95: percentile(sorted, 95),
+    p99: percentile(sorted, 99),
+  };
+}
+
+/**
+ * Calculate the p-th percentile from a sorted array.
+ */
+function percentile(sorted: number[], p: number): number {
+  const index = Math.ceil((p / 100) * sorted.length) - 1;
+  return sorted[Math.max(0, index)];
+}
+
+/**
+ * Parameters passed to cancellation benchmark implementations.
+ */
+export interface CancellationParams {
+  /** Number of concurrent tasks to spawn */
+  tasks: number;
+  /** Nesting depth for sub-tasks */
+  depth: number;
+  /** Resource tracker for correctness verification */
+  tracker: ResourceTracker;
+}
+
+/**
+ * A cancellation benchmark function.
+ * Must spawn `tasks` concurrent workers, each with nested sub-tasks up to `depth`,
+ * then cancel them all. Uses `tracker` to record resource allocations and releases.
+ */
+export type CancellationBenchmark = (params: CancellationParams) => Operation<void>;
+
+/**
+ * Entry point for cancellation benchmark scenarios.
+ * Similar to the base `scenario()` but:
+ * - Expects CancellationBenchmarkOptions with `tasks` parameter
+ * - Tracks resource allocation/release for correctness verification
+ * - Reports correctness stats alongside timing stats
+ */
+export function cancellationScenario(
+  name: string,
+  perform: CancellationBenchmark,
+) {
+  return main(function* () {
+    try {
+      yield* callcc<void>(function* (exit) {
+        const work = createChannel<CancellationBenchmarkOptions, never>();
+        
+        yield* spawn(function* () {
+          for (const command of yield* each(commands)) {
+            if (command.type === "close") {
+              yield* exit();
+            } else if ("kind" in command && command.kind === "cancellation") {
+              yield* work.send(command);
+            }
+            yield* each.next();
+          }
+        });
+
+        for (const options of yield* each(work)) {
+          const tracker = createTracker();
+
+          // Warmup runs: execute but don't time or report
+          for (let i = 0; i < options.warmup; i++) {
+            tracker.reset();
+            yield* encapsulate(() =>
+              perform({
+                tasks: options.tasks,
+                depth: options.depth,
+                tracker,
+              })
+            );
+          }
+
+          // Measured runs
+          const times: number[] = [];
+          tracker.reset(); // Reset for actual measurements
+
+          for (let i = 0; i < options.repeat; i++) {
+            // Reset tracker per-run to accumulate across all runs
+            // (We'll aggregate stats at the end)
+            const runTracker = createTracker();
+            
+            const start = performance.now();
+
+            yield* encapsulate(() =>
+              perform({
+                tasks: options.tasks,
+                depth: options.depth,
+                tracker: runTracker,
+              })
+            );
+
+            const time = performance.now() - start;
+            send({ type: "repeat", name, time, rep: i + 1 });
+            times.push(time);
+
+            // Accumulate correctness stats across runs
+            const runStats = runTracker.stats();
+            for (let j = 0; j < runStats.allocated; j++) tracker.allocate();
+            for (let j = 0; j < runStats.released; j++) tracker.release();
+          }
+
+          const timingStats = calculateStats(times);
+          const correctnessStats = tracker.stats();
+
+          const result: BenchmarkStatsByKind["cancellation"] = {
+            reps: options.repeat,
+            times,
+            ...timingStats,
+            correctness: correctnessStats,
+          };
+
+          send({
+            type: "done",
+            kind: "cancellation",
+            name,
+            result: Ok(result),
+          });
+
+          yield* each.next();
+        }
+      });
+    } catch (error) {
+      send({
+        type: "done",
+        kind: "cancellation",
+        name,
+        result: Err(error as Error),
+      });
+    } finally {
+      send({ type: "closed", result: Ok() });
+    }
+  });
+}

--- a/tasks/bench/scenarios/cancellation/scenario.ts
+++ b/tasks/bench/scenarios/cancellation/scenario.ts
@@ -139,10 +139,9 @@ export function cancellationScenario(
             send({ type: "repeat", name, time, rep: i + 1 });
             times.push(time);
 
-            // Accumulate correctness stats across runs
+            // Accumulate correctness stats across runs (O(1) instead of O(n))
             const runStats = runTracker.stats();
-            for (let j = 0; j < runStats.allocated; j++) tracker.allocate();
-            for (let j = 0; j < runStats.released; j++) tracker.release();
+            tracker.addCounts(runStats.allocated, runStats.released);
           }
 
           const timingStats = calculateStats(times);

--- a/tasks/bench/scenarios/cancellation/tracker.ts
+++ b/tasks/bench/scenarios/cancellation/tracker.ts
@@ -20,6 +20,8 @@ export interface ResourceTracker {
   allocate(): void;
   /** Record a resource release */
   release(): void;
+  /** Add counts in bulk (O(1) instead of O(n) loop) */
+  addCounts(allocated: number, released: number): void;
   /** Get current correctness statistics */
   stats(): CorrectnessStats;
   /** Reset all counters to zero */
@@ -40,6 +42,10 @@ export function createTracker(): ResourceTracker {
     },
     release() {
       released++;
+    },
+    addCounts(allocCount: number, releaseCount: number) {
+      allocated += allocCount;
+      released += releaseCount;
     },
     stats(): CorrectnessStats {
       return {

--- a/tasks/bench/scenarios/cancellation/tracker.ts
+++ b/tasks/bench/scenarios/cancellation/tracker.ts
@@ -1,0 +1,135 @@
+import type { CorrectnessStats } from "../../types.ts";
+
+/**
+ * A simple resource tracker for verifying cleanup correctness in cancellation benchmarks.
+ *
+ * Usage:
+ * ```ts
+ * const tracker = createTracker();
+ * tracker.allocate();  // Call when resource is acquired
+ * try {
+ *   // ... use resource
+ * } finally {
+ *   tracker.release();  // Call in finally to ensure cleanup is tracked
+ * }
+ * const stats = tracker.stats();  // { allocated, released, leaked }
+ * ```
+ */
+export interface ResourceTracker {
+  /** Record a resource allocation */
+  allocate(): void;
+  /** Record a resource release */
+  release(): void;
+  /** Get current correctness statistics */
+  stats(): CorrectnessStats;
+  /** Reset all counters to zero */
+  reset(): void;
+}
+
+/**
+ * Creates a new resource tracker instance.
+ * Thread-safe for single-threaded JS execution (no atomics needed).
+ */
+export function createTracker(): ResourceTracker {
+  let allocated = 0;
+  let released = 0;
+
+  return {
+    allocate() {
+      allocated++;
+    },
+    release() {
+      released++;
+    },
+    stats(): CorrectnessStats {
+      return {
+        allocated,
+        released,
+        leaked: allocated - released,
+      };
+    },
+    reset() {
+      allocated = 0;
+      released = 0;
+    },
+  };
+}
+
+/**
+ * Barrier for synchronizing task startup.
+ * Ensures all tasks have started before proceeding, providing deterministic benchmarks.
+ *
+ * Usage:
+ * ```ts
+ * const barrier = createBarrier(taskCount);
+ *
+ * // In each task:
+ * await barrier.arrive();  // Blocks until all tasks arrive
+ *
+ * // Externally (if needed):
+ * await barrier.wait();    // Wait for all arrivals without incrementing
+ * ```
+ */
+export interface Barrier {
+  /** Signal arrival and wait for all others */
+  arrive(): Promise<void>;
+  /** Wait for all arrivals without incrementing the counter */
+  wait(): Promise<void>;
+  /** Reset the barrier for reuse */
+  reset(): void;
+}
+
+/**
+ * Creates a barrier that releases when `count` tasks have arrived.
+ */
+export function createBarrier(count: number): Barrier {
+  let arrived = 0;
+  let resolvers: Array<() => void> = [];
+  let allArrived: Promise<void> | null = null;
+  let resolveAll: (() => void) | null = null;
+
+  function checkRelease() {
+    if (arrived >= count && resolveAll) {
+      resolveAll();
+      for (const resolve of resolvers) {
+        resolve();
+      }
+      resolvers = [];
+    }
+  }
+
+  return {
+    arrive(): Promise<void> {
+      arrived++;
+      if (!allArrived) {
+        allArrived = new Promise((resolve) => {
+          resolveAll = resolve;
+        });
+      }
+      if (arrived >= count) {
+        checkRelease();
+        return Promise.resolve();
+      }
+      return new Promise((resolve) => {
+        resolvers.push(resolve);
+      });
+    },
+    wait(): Promise<void> {
+      if (!allArrived) {
+        allArrived = new Promise((resolve) => {
+          resolveAll = resolve;
+        });
+      }
+      if (arrived >= count) {
+        return Promise.resolve();
+      }
+      return allArrived;
+    },
+    reset() {
+      arrived = 0;
+      resolvers = [];
+      allArrived = null;
+      resolveAll = null;
+    },
+  };
+}

--- a/tasks/bench/scenarios/cancellation/tracker.ts
+++ b/tasks/bench/scenarios/cancellation/tracker.ts
@@ -62,80 +62,161 @@ export function createTracker(): ResourceTracker {
 }
 
 /**
+ * Error thrown when a barrier times out waiting for arrivals.
+ */
+export class BarrierTimeoutError extends Error {
+  constructor(
+    public readonly arrived: number,
+    public readonly expected: number,
+    public readonly timeoutMs: number,
+  ) {
+    super(
+      `Barrier timed out waiting for ${arrived}/${expected} arrivals after ${timeoutMs}ms`,
+    );
+    this.name = "BarrierTimeoutError";
+  }
+}
+
+/**
  * Barrier for synchronizing task startup.
  * Ensures all tasks have started before proceeding, providing deterministic benchmarks.
  *
  * Usage:
  * ```ts
- * const barrier = createBarrier(taskCount);
+ * const barrier = createBarrier(taskCount, 30000);  // 30s timeout
  *
  * // In each task:
- * await barrier.arrive();  // Blocks until all tasks arrive
+ * await barrier.arrive();  // Blocks until all tasks arrive (or timeout/abort)
  *
  * // Externally (if needed):
  * await barrier.wait();    // Wait for all arrivals without incrementing
+ *
+ * // On failure (e.g., worker error):
+ * barrier.abort(error);    // Reject all pending waiters
  * ```
  */
 export interface Barrier {
-  /** Signal arrival and wait for all others */
+  /** Signal arrival and wait for all others. Rejects if aborted or timed out. */
   arrive(): Promise<void>;
-  /** Wait for all arrivals without incrementing the counter */
+  /** Wait for all arrivals without incrementing the counter. Rejects if aborted or timed out. */
   wait(): Promise<void>;
+  /** Abort the barrier, rejecting all pending waiters with the given error. */
+  abort(error: Error): void;
   /** Reset the barrier for reuse */
   reset(): void;
 }
 
+/** Default timeout for barrier (30 seconds) */
+const DEFAULT_BARRIER_TIMEOUT_MS = 30_000;
+
 /**
  * Creates a barrier that releases when `count` tasks have arrived.
+ * @param count Number of arrivals required to release the barrier
+ * @param timeoutMs Maximum time to wait for all arrivals (default: 30000ms)
  */
-export function createBarrier(count: number): Barrier {
+export function createBarrier(
+  count: number,
+  timeoutMs: number = DEFAULT_BARRIER_TIMEOUT_MS,
+): Barrier {
   let arrived = 0;
-  let resolvers: Array<() => void> = [];
+  let resolvers: Array<{ resolve: () => void; reject: (e: Error) => void }> =
+    [];
+  let allArrivedResolve: (() => void) | null = null;
+  let allArrivedReject: ((e: Error) => void) | null = null;
   let allArrived: Promise<void> | null = null;
-  let resolveAll: (() => void) | null = null;
+  let aborted: Error | null = null;
+  let timeoutId: number | null = null;
+
+  function startTimeout() {
+    if (timeoutId === null && timeoutMs > 0) {
+      timeoutId = setTimeout(() => {
+        const error = new BarrierTimeoutError(arrived, count, timeoutMs);
+        rejectAll(error);
+      }, timeoutMs);
+    }
+  }
+
+  function clearTimeoutIfSet() {
+    if (timeoutId !== null) {
+      clearTimeout(timeoutId);
+      timeoutId = null;
+    }
+  }
+
+  function rejectAll(error: Error) {
+    aborted = error;
+    clearTimeoutIfSet();
+    if (allArrivedReject) {
+      allArrivedReject(error);
+    }
+    for (const { reject } of resolvers) {
+      reject(error);
+    }
+    resolvers = [];
+  }
 
   function checkRelease() {
-    if (arrived >= count && resolveAll) {
-      resolveAll();
-      for (const resolve of resolvers) {
+    if (arrived >= count) {
+      clearTimeoutIfSet();
+      if (allArrivedResolve) {
+        allArrivedResolve();
+      }
+      for (const { resolve } of resolvers) {
         resolve();
       }
       resolvers = [];
     }
   }
 
+  function ensurePromise(): Promise<void> {
+    if (!allArrived) {
+      allArrived = new Promise((resolve, reject) => {
+        allArrivedResolve = resolve;
+        allArrivedReject = reject;
+      });
+      startTimeout();
+    }
+    return allArrived;
+  }
+
   return {
     arrive(): Promise<void> {
-      arrived++;
-      if (!allArrived) {
-        allArrived = new Promise((resolve) => {
-          resolveAll = resolve;
-        });
+      if (aborted) {
+        return Promise.reject(aborted);
       }
+      arrived++;
+      ensurePromise();
       if (arrived >= count) {
         checkRelease();
         return Promise.resolve();
       }
-      return new Promise((resolve) => {
-        resolvers.push(resolve);
+      return new Promise((resolve, reject) => {
+        resolvers.push({ resolve, reject });
       });
     },
     wait(): Promise<void> {
-      if (!allArrived) {
-        allArrived = new Promise((resolve) => {
-          resolveAll = resolve;
-        });
+      if (aborted) {
+        return Promise.reject(aborted);
       }
+      ensurePromise();
       if (arrived >= count) {
         return Promise.resolve();
       }
-      return allArrived;
+      return allArrived!;
+    },
+    abort(error: Error): void {
+      if (!aborted) {
+        rejectAll(error);
+      }
     },
     reset() {
+      clearTimeoutIfSet();
       arrived = 0;
       resolvers = [];
       allArrived = null;
-      resolveAll = null;
+      allArrivedResolve = null;
+      allArrivedReject = null;
+      aborted = null;
     },
   };
 }

--- a/tasks/bench/scenarios/scenario.ts
+++ b/tasks/bench/scenarios/scenario.ts
@@ -59,7 +59,10 @@ export function scenario(
   return main(function* () {
     try {
       yield* callcc<void>(function* (exit) {
-        let work = createChannel<BenchmarkOptions | LegacyBenchmarkOptions, never>();
+        let work = createChannel<
+          BenchmarkOptions | LegacyBenchmarkOptions,
+          never
+        >();
         yield* spawn(function* () {
           for (let command of yield* each(commands)) {
             if (command.type === "close") {

--- a/tasks/bench/scenarios/scenario.ts
+++ b/tasks/bench/scenarios/scenario.ts
@@ -12,6 +12,7 @@ import type {
   BenchmarkOptions,
   BenchmarkStats,
   BenchmarkWorkerEvent,
+  LegacyBenchmarkOptions,
   WorkerCommand,
 } from "../types.ts";
 import { messages } from "../worker.ts";
@@ -58,7 +59,7 @@ export function scenario(
   return main(function* () {
     try {
       yield* callcc<void>(function* (exit) {
-        let work = createChannel<BenchmarkOptions, never>();
+        let work = createChannel<BenchmarkOptions | LegacyBenchmarkOptions, never>();
         yield* spawn(function* () {
           for (let command of yield* each(commands)) {
             if (command.type === "close") {

--- a/tasks/bench/scenarios/scenario.ts
+++ b/tasks/bench/scenarios/scenario.ts
@@ -9,10 +9,10 @@ import {
   spawn,
 } from "../../../mod.ts";
 import type {
+  BenchmarkKind,
   BenchmarkOptions,
   BenchmarkStats,
   BenchmarkWorkerEvent,
-  LegacyBenchmarkOptions,
   WorkerCommand,
 } from "../types.ts";
 import { messages } from "../worker.ts";
@@ -60,21 +60,23 @@ export function scenario(
     try {
       yield* callcc<void>(function* (exit) {
         let work = createChannel<
-          BenchmarkOptions | LegacyBenchmarkOptions,
+          { options: BenchmarkOptions; kind: BenchmarkKind },
           never
         >();
         yield* spawn(function* () {
           for (let command of yield* each(commands)) {
             if (command.type === "close") {
               yield* exit();
-            } else {
-              yield* work.send(command);
+            } else if ("kind" in command) {
+              // Typed options - extract kind
+              yield* work.send({ options: command, kind: command.kind });
             }
+            // Ignore legacy options without kind (shouldn't happen with new CLI)
             yield* each.next();
           }
         });
 
-        for (let options of yield* each(work)) {
+        for (let { options, kind } of yield* each(work)) {
           // Warmup runs: execute but don't time or report
           for (let i = 0; i < options.warmup; i++) {
             yield* encapsulate(() => perform(options.depth));
@@ -99,12 +101,13 @@ export function scenario(
             ...stats,
           });
 
-          send({ type: "done", name, result });
+          send({ type: "done", kind, name, result });
 
           yield* each.next();
         }
       });
     } catch (error) {
+      // On error, we don't have a kind available, so omit it
       send({ type: "done", name, result: Err(error as Error) });
     } finally {
       send({ type: "closed", result: Ok() });

--- a/tasks/bench/types.ts
+++ b/tasks/bench/types.ts
@@ -1,10 +1,20 @@
 import type { Result } from "../../lib/result.ts";
 
+// =============================================================================
+// Benchmark Categories
+// =============================================================================
+
+export type BenchmarkKind = "recursion" | "events" | "cancellation";
+
+// =============================================================================
+// Timing Stats (shared base for all benchmarks)
+// =============================================================================
+
 /**
- * Statistical metrics for benchmark results.
+ * Statistical metrics for benchmark timing results.
  * All time values are in milliseconds.
  */
-export interface BenchmarkStats {
+export interface TimingStats {
   readonly reps: number;
   readonly times: readonly number[];
   readonly avgTime: number;
@@ -16,12 +26,79 @@ export interface BenchmarkStats {
   readonly p99: number;
 }
 
-export interface BenchmarkOptions {
+// =============================================================================
+// Correctness Stats (for cancellation benchmarks)
+// =============================================================================
+
+/**
+ * Resource tracking stats for verifying cleanup correctness.
+ */
+export interface CorrectnessStats {
+  readonly allocated: number;
+  readonly released: number;
+  readonly leaked: number; // allocated - released
+}
+
+// =============================================================================
+// Kind-to-Stats Mapping
+// =============================================================================
+
+export type BenchmarkStatsByKind = {
+  recursion: TimingStats;
+  events: TimingStats;
+  cancellation: TimingStats & { readonly correctness: CorrectnessStats };
+};
+
+/**
+ * @deprecated Use TimingStats or BenchmarkStatsByKind[K] instead
+ */
+export type BenchmarkStats = TimingStats;
+
+// =============================================================================
+// Benchmark Options
+// =============================================================================
+
+interface BaseBenchmarkOptions {
+  readonly type: "benchmark";
+  readonly repeat: number;
+  readonly warmup: number;
+}
+
+export interface RecursionBenchmarkOptions extends BaseBenchmarkOptions {
+  readonly kind: "recursion";
+  readonly depth: number;
+}
+
+export interface EventsBenchmarkOptions extends BaseBenchmarkOptions {
+  readonly kind: "events";
+  readonly depth: number;
+}
+
+export interface CancellationBenchmarkOptions extends BaseBenchmarkOptions {
+  readonly kind: "cancellation";
+  readonly depth: number;
+  readonly tasks: number;
+}
+
+export type BenchmarkOptions =
+  | RecursionBenchmarkOptions
+  | EventsBenchmarkOptions
+  | CancellationBenchmarkOptions;
+
+/**
+ * Legacy options format (for backward compatibility with existing scenarios)
+ * @deprecated Use BenchmarkOptions with explicit kind instead
+ */
+export interface LegacyBenchmarkOptions {
   readonly type: "benchmark";
   readonly repeat: number;
   readonly depth: number;
   readonly warmup: number;
 }
+
+// =============================================================================
+// Worker Commands
+// =============================================================================
 
 export interface CloseCommand {
   readonly type: "close";
@@ -32,12 +109,11 @@ export interface ClosedEvent {
   readonly result: Result<void>;
 }
 
-export type WorkerCommand = BenchmarkOptions | CloseCommand;
+export type WorkerCommand = BenchmarkOptions | LegacyBenchmarkOptions | CloseCommand;
 
-export type BenchmarkWorkerEvent =
-  | BenchmarkRepeatEvent
-  | BenchmarkDoneEvent
-  | ClosedEvent;
+// =============================================================================
+// Worker Events
+// =============================================================================
 
 export interface BenchmarkRepeatEvent {
   readonly type: "repeat";
@@ -46,13 +122,21 @@ export interface BenchmarkRepeatEvent {
   readonly time: number;
 }
 
-export interface BenchmarkDoneEvent {
+export interface BenchmarkDoneEvent<K extends BenchmarkKind = BenchmarkKind> {
   readonly type: "done";
+  readonly kind?: K; // Optional for backward compat with existing scenarios
   readonly name: string;
-  readonly result: Result<BenchmarkStats>;
+  readonly result: Result<BenchmarkStatsByKind[K]>;
 }
 
-// JSON output types
+export type BenchmarkWorkerEvent =
+  | BenchmarkRepeatEvent
+  | BenchmarkDoneEvent
+  | ClosedEvent;
+
+// =============================================================================
+// JSON Output Types
+// =============================================================================
 
 export interface BenchmarkJsonOutput {
   readonly metadata: BenchmarkMetadata;
@@ -65,14 +149,21 @@ export interface BenchmarkMetadata {
   readonly repeat: number;
   readonly warmup: number;
   readonly depth: number;
+  readonly tasks?: number; // For cancellation benchmarks
 }
 
 export interface BenchmarkResultGroups {
   readonly recursion: readonly BenchmarkResultEntry[];
   readonly events: readonly BenchmarkResultEntry[];
+  readonly cancellation?: readonly CancellationResultEntry[];
 }
 
 export interface BenchmarkResultEntry {
   readonly name: string;
-  readonly stats: BenchmarkStats;
+  readonly stats: TimingStats;
+}
+
+export interface CancellationResultEntry {
+  readonly name: string;
+  readonly stats: TimingStats & { readonly correctness: CorrectnessStats };
 }

--- a/tasks/bench/types.ts
+++ b/tasks/bench/types.ts
@@ -109,7 +109,10 @@ export interface ClosedEvent {
   readonly result: Result<void>;
 }
 
-export type WorkerCommand = BenchmarkOptions | LegacyBenchmarkOptions | CloseCommand;
+export type WorkerCommand =
+  | BenchmarkOptions
+  | LegacyBenchmarkOptions
+  | CloseCommand;
 
 // =============================================================================
 // Worker Events

--- a/tasks/bench/types.ts
+++ b/tasks/bench/types.ts
@@ -170,3 +170,16 @@ export interface CancellationResultEntry {
   readonly name: string;
   readonly stats: TimingStats & { readonly correctness: CorrectnessStats };
 }
+
+// =============================================================================
+// Scenario Registry Types
+// =============================================================================
+
+/**
+ * A typed scenario entry in the registry.
+ * Using explicit kind avoids fragile filename-based classification.
+ */
+export interface ScenarioEntry {
+  readonly path: string;
+  readonly kind: BenchmarkKind;
+}


### PR DESCRIPTION
# Motivation

Implements Phase 2 of the benchmark analysis plan (issue #1112): "Cost of Correctness" benchmarks that demonstrate Effection's value proposition for cancellation guarantees.

The goal is to show potential adopters:
1. How Effection's structured concurrency automatically handles cancellation
2. The performance cost vs manual approaches (the "cost of correctness")
3. That all implementations correctly clean up resources (leaked = 0)

# Approach

## New Cancellation Benchmark Scenario

Spawns N concurrent worker tasks, each with nested sub-tasks up to depth D. Each task allocates a tracked "resource" and registers cleanup. Then cancels all tasks and verifies cleanup.

## Four Implementations Compared

| Library | Approach | Ergonomics |
|---------|----------|------------|
| **effection-structured** | Automatic cancellation via `scoped()` exit | Best - no manual wiring |
| **async+abort** | Manual AbortController threading | Verbose, error-prone |
| **effect** | Effect.js fiber interruption | Good, but heavier runtime |
| **rxjs** | Subscription teardown (idiomatic `takeUntil` + `finalize`) | Fast, but manual management |

## Benchmark Results

### Small Scale (10 tasks × 5 depth = 50 resources)
| Library | Avg (ms) | Correctness |
|---------|----------|-------------|
| effection-structured | 2.3 | ✅ 0 leaked |
| async+abort | 0.5 | ✅ 0 leaked |
| effect | 4.7 | ✅ 0 leaked |
| rxjs | 0.3 | ✅ 0 leaked |

### Medium Scale (50 tasks × 10 depth = 500 resources)
| Library | Avg (ms) | Correctness |
|---------|----------|-------------|
| effection-structured | 21.9 | ✅ 0 leaked |
| async+abort | 4.2 | ✅ 0 leaked |
| effect | 45.0 | ✅ 0 leaked |
| rxjs | 1.2 | ✅ 0 leaked |

### Large Scale (100 tasks × 20 depth = 2000 resources)
| Library | Avg (ms) | Correctness |
|---------|----------|-------------|
| effection-structured | 85.0 | ✅ 0 leaked |
| async+abort | 59.2 | ✅ 0 leaked |
| effect | 297.9 | ✅ 0 leaked |
| rxjs | 6.8 | ✅ 0 leaked |

## Key Findings

1. **Effection beats Effect.js** for cancellation: 2-3.5x faster at all scales
2. **Cost of correctness**: ~5x overhead vs manual abort at small scale, converging to ~1.5x at large scale
3. **All implementations verify cleanup**: leaked = 0 across all runs
4. **RxJS is fastest** but requires manual subscription management

## Implementation Details

### Core Files
- `tasks/bench/scenarios/cancellation/tracker.ts` - Resource tracker + barrier with timeout
- `tasks/bench/scenarios/cancellation/scenario.ts` - Cancellation scenario helper
- `tasks/bench/scenarios/cancellation/*.cancellation.ts` - Four implementations
- `tasks/bench.ts` - CLI with `--tasks/-t` option, correctness stats, regex validation
- `tasks/bench/types.ts` - `BenchmarkKind`, `CorrectnessStats`, `ScenarioEntry`
- `tasks/bench/scenarios.ts` - Typed scenario registry

### Harness Reliability Improvements
- **Barrier timeout**: Prevents hangs if workers fail before reaching barrier (30s default)
- **Worker messageerror handling**: Surfaces serialization failures as hard errors
- **Regex validation**: User-friendly errors for invalid `--include`/`--exclude` patterns
- **Typed scenario registry**: Eliminates fragile filename-based classification
- **Kind validation**: Worker response validation prevents silent mismatches

## Usage

```bash
# Run only cancellation benchmarks
deno task bench --include cancellation -t 50 -d 10

# Full suite with JSON output
deno task bench --json -t 50 -d 100

# Test invalid regex handling (should fail gracefully)
deno task bench --include "+" --repeat 1
# error: Invalid --include pattern "+": Invalid regular expression: /+/: Nothing to repeat
```

## Commits in this PR

- `feat(bench): add cancellation cascade benchmarks (Phase 2)` - Core implementation
- `fix: address PR feedback` - TS2345 fix, remove unused Deferred
- `style: fix formatting` - deno fmt
- `refactor(bench): typed scenario registry and improved correctness` - Eliminate filename regex, O(1) aggregation, idiomatic RxJS
- `fix(bench): improve harness reliability` - Barrier timeout, messageerror handling, regex validation

Closes part of #1112 (Phase 2)