### PR TITLE
🐛 remove banned triple slash

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,9 +10,22 @@ permissions:
   id-token: write
 
 jobs:
-  publish-npm:
+  verify-jsr:
     runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
 
+      - name: setup deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: dry run publish
+        run: deno publish --dry-run
+
+  verify-npm:
+    runs-on: ubuntu-latest
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -34,11 +47,38 @@ jobs:
       - name: Build NPM
         run: deno task build:npm ${{steps.vars.outputs.version}}
 
+      - name: dry run publish
+        run: npm publish --dry-run --tag=verify
+        working-directory: ./build/npm
+
+      - name: upload build
+        uses: actions/upload-artifact@v4
+        with:
+          name: npm-build
+          path: ./build/npm
+
+  publish-npm:
+    needs: [verify-jsr, verify-npm]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: download build
+        uses: actions/download-artifact@v4
+        with:
+          name: npm-build
+          path: ./build/npm
+
       - name: Publish NPM
         run: npm publish --access=public --tag=latest
         working-directory: ./build/npm
 
   publish-jsr:
+    needs: [verify-jsr, verify-npm]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -40,6 +40,45 @@ jobs:
         if: runner.os != 'Windows'
         run: deno task test
 
+  jsr:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: setup deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: dry run publish
+        run: deno publish --dry-run
+
+  npm:
+    needs: test-node
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: setup deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Build NPM
+        run: deno task build:npm 4.0.0-verify.0
+
+      - name: dry run publish
+        run: npm publish --dry-run --tag=verify
+        working-directory: ./build/npm
+
   test-node:
     runs-on: ubuntu-latest
     strategy:

--- a/lib/task.ts
+++ b/lib/task.ts
@@ -1,4 +1,3 @@
-/// <reference lib="esnext" />
 // deno-lint-ignore-file no-unsafe-finally
 import { DelimiterContext, ErrorContext } from "./delimiter.ts";
 import { createCoroutine } from "./coroutine.ts";


### PR DESCRIPTION
# Motivation

jsr.io does not allow triple slashes. 

# Approach

This remove it since it can be set by the consuming library. This also adds validation checks after tests have successfully run to see if publication would succeed on both npm and jsr.

<img width="967" height="412" alt="image" src="https://github.com/user-attachments/assets/e5d6a764-c794-42a5-946d-658c888ec49a" />

This also adds these same pre-flight checks to the actual publication workflow. It ensures that _both_ JSR _and_ NPM will work before attempting _either_. That way we don't end up in a situation where we have the package on one registry and not another.
