### PR TITLE
🤖 Add gitmoji directive to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -372,6 +372,12 @@ for (const item of yield * each(stream(asyncIterable))) {
 - After resolve/reject, yielding the `operation` always produces the same
   outcome; calling resolve/reject again has no effect.
 
+## Commit and PR conventions
+
+Use [gitmoji](https://gitmoji.dev) for commit and pull request subjects. For
+changes to files that direct the behavior of AI such as AGENTS.md or llms.txt
+use a robot emoji instead of the standard gitmoji for documentation
+
 ## Pre-commit workflow
 
 Before committing any changes to this repository:


### PR DESCRIPTION
## Motivation

gitmoji is faster to parse with the eye, less stodgy than standard commits, but equally (if not more) expressive.

## Approach

Add a "Commit and PR conventions" section to AGENTS.md to teach agents how to use gitmoji