### PR TITLE
✨ Export reducer internals via experimental and label infrastructure effects

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -74,7 +74,7 @@ jobs:
           path: ./build/npm
 
       - name: Publish NPM
-        run: npm publish --access=public --tag=latest
+        run: npm publish --access=public --tag=next
         working-directory: ./build/npm
 
   publish-jsr:

--- a/deno.json
+++ b/deno.json
@@ -2,7 +2,7 @@
   "name": "@effection/effection",
   "exports": "./mod.ts",
   "license": "ISC",
-  "publish": { "include": ["lib", "mod.ts", "README.md"] },
+  "publish": { "include": ["lib", "mod.ts", "experimental.ts", "README.md"] },
   "lock": false,
   "tasks": {
     "test": "deno test --allow-run --allow-read --allow-env --allow-ffi",
@@ -28,6 +28,10 @@
     "ctrlc-windows": "npm:ctrlc-windows@2.2.0",
     "tinyexec": "npm:tinyexec@1.0.1",
     "https://deno.land/x/path_to_regexp@v6.2.1/index.ts": "npm:path-to-regexp@8.2.0"
+  },
+  "exports": {
+    ".": "./mod.ts",
+    "./experimental": "./experimental.ts"
   },
   "nodeModulesDir": "auto",
   "workspace": [

--- a/deno.json
+++ b/deno.json
@@ -12,7 +12,7 @@
     "build:jsr": "deno run -A tasks/build-jsr.ts"
   },
   "lint": {
-    "rules": { "exclude": ["prefer-const", "require-yield"] },
+    "rules": { "exclude": ["prefer-const", "require-yield", "ban-types"] },
     "exclude": ["build", "docs", "tasks"],
     "plugins": ["lint/prefer-let.ts"]
   },

--- a/experimental.ts
+++ b/experimental.ts
@@ -1,1 +1,6 @@
 export * from "./lib/api.ts";
+export {
+  InstructionQueue,
+  type Instruction,
+} from "./lib/reducer.ts";
+export { DelimiterContext } from "./lib/delimiter.ts";

--- a/experimental.ts
+++ b/experimental.ts
@@ -1,0 +1,1 @@
+export * from "./lib/api.ts";

--- a/lib/api-internal.ts
+++ b/lib/api-internal.ts
@@ -1,0 +1,142 @@
+// deno-lint-ignore-file ban-types no-explicit-any
+import { createContext } from "./context.ts";
+import { useScope } from "./scope.ts";
+import type {
+  Api,
+  Around,
+  Context,
+  Middleware,
+  Operation,
+  Scope,
+} from "./types.ts";
+import type { ScopeInternal } from "./scope-internal.ts";
+
+export interface ApiInternal<A> extends Api<A> {
+  context: Context<{
+    max: Partial<Around<A>>[];
+    min: Partial<Around<A>>[];
+  }>;
+  core: A;
+}
+
+export function createApiInternal<A extends {}>(
+  name: string,
+  core: A,
+): ApiInternal<A> {
+  let fields = Object.keys(core) as (keyof A)[];
+
+  let context = createContext(`api::${name}`) as ApiInternal<A>["context"];
+
+  let api: ApiInternal<A> = {
+    core,
+    context,
+    invoke: (scope, key, args) => {
+      let handle = createHandle(api, scope);
+      let member = handle[key];
+      if (typeof member === "function") {
+        return member(...args);
+      } else {
+        return member;
+      }
+    },
+    around: (decorator, options = { at: "max" }) => ({
+      *[Symbol.iterator]() {
+        let scope = yield* useScope();
+        scope.around(api, decorator, options);
+      },
+    }),
+    operations: fields.reduce((sum, field) => {
+      if (typeof core[field] === "function") {
+        return Object.assign(sum, {
+          [field]: (...args: any) => ({
+            *[Symbol.iterator]() {
+              let scope = yield* useScope();
+              let target = api.invoke(scope, field, args);
+
+              return isOperation(target) ? yield* target : target;
+            },
+          }),
+        });
+      } else {
+        return Object.assign(sum, {
+          [field]: {
+            *[Symbol.iterator]() {
+              let scope = yield* useScope();
+              let target = api.invoke(scope, field, [] as any);
+              return isOperation(target) ? yield* target : target;
+            },
+          },
+        });
+      }
+    }, {} as Api<A>["operations"]),
+  };
+  return api;
+}
+
+function createHandle<A extends {}>(api: ApiInternal<A>, scope: Scope): A {
+  let handle = Object.create(api.core);
+  let $scope = scope as ScopeInternal;
+  for (let key of Object.keys(api.core) as Array<keyof A>) {
+    let dispatch = (args: unknown[], next: (...args: unknown[]) => unknown) => {
+      let { min, max } = $scope.reduce(api.context, (sum, current) => {
+        let min = current.min.flatMap((around) =>
+          around[key] ? [around[key]] : []
+        );
+        let max = current.max.flatMap((around) =>
+          around[key] ? [around[key]] : []
+        );
+
+        sum.min.push(...min);
+        sum.max.unshift(...max);
+
+        return sum;
+      }, {
+        min: [] as Around<A>[typeof key][],
+        max: [] as Around<A>[typeof key][],
+      });
+
+      let stack = combine(
+        max.concat(min) as Middleware<unknown[], unknown>[],
+      );
+      return stack(args, next);
+    };
+
+    if (typeof api.core[key] === "function") {
+      handle[key] = (...args: unknown[]) =>
+        dispatch(args, api.core[key] as (...args: unknown[]) => unknown);
+    } else {
+      Object.defineProperty(handle, key, {
+        enumerable: true,
+        get() {
+          return dispatch([], () => api.core[key]);
+        },
+      });
+    }
+  }
+  return handle;
+}
+
+function isOperation<T>(
+  target: Operation<T> | T,
+): target is Operation<T> {
+  return target && !isNativeIterable(target) &&
+    typeof (target as Operation<T>)[Symbol.iterator] === "function";
+}
+
+function isNativeIterable(target: unknown): boolean {
+  return (
+    typeof target === "string" || Array.isArray(target) ||
+    target instanceof Map || target instanceof Set
+  );
+}
+
+function combine<TArgs extends unknown[], TReturn>(
+  middlewares: Middleware<TArgs, TReturn>[],
+): Middleware<TArgs, TReturn> {
+  if (middlewares.length === 0) {
+    return (args, next) => next(...args);
+  }
+  return middlewares.reduceRight((sum, middleware) => (args, next) =>
+    middleware(args, (...args) => sum(args, next))
+  );
+}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -2,6 +2,7 @@
 import type { Api, Context, Operation, Scope } from "./types.ts";
 import { createApiInternal } from "./api-internal.ts";
 import type { ScopeInternal } from "./scope-internal.ts";
+import type { Instruction } from "./reducer.ts";
 
 export function createApi<A extends {}>(name: string, core: A): Api<A> {
   return createApiInternal(name, core);
@@ -18,9 +19,14 @@ interface MainApi {
   main(body: (args: string[]) => Operation<void>): Promise<void>;
 }
 
+interface ReducerApi {
+  reduce(instruction: Instruction): void;
+}
+
 interface Apis {
   Scope: Api<ScopeApi>;
   Main: Api<MainApi>;
+  Reducer: Api<ReducerApi>;
 }
 
 export const api: Apis = {
@@ -39,6 +45,11 @@ export const api: Apis = {
   Main: createApi<MainApi>("Main", {
     main() {
       throw new TypeError(`missing handler for "main()"`);
+    },
+  }),
+  Reducer: createApi<ReducerApi>("Reducer", {
+    reduce() {
+      throw new TypeError(`no handler for Reducer.reduce()`);
     },
   }),
 };

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -14,8 +14,13 @@ interface ScopeApi {
   delete<T>(scope: Scope, context: Context<T>): boolean;
 }
 
+interface MainApi {
+  main(body: (args: string[]) => Operation<void>): Promise<void>;
+}
+
 interface Apis {
   Scope: Api<ScopeApi>;
+  Main: Api<MainApi>;
 }
 
 export const api: Apis = {
@@ -29,6 +34,11 @@ export const api: Apis = {
     },
     delete(scope, context) {
       return delete (scope as ScopeInternal).contexts[context.name];
+    },
+  }),
+  Main: createApi<MainApi>("Main", {
+    main() {
+      throw new TypeError(`missing handler for "main()"`);
     },
   }),
 };

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,0 +1,34 @@
+// deno-lint-ignore-file ban-types
+import type { Api, Context, Operation, Scope } from "./types.ts";
+import { createApiInternal } from "./api-internal.ts";
+import type { ScopeInternal } from "./scope-internal.ts";
+
+export function createApi<A extends {}>(name: string, core: A): Api<A> {
+  return createApiInternal(name, core);
+}
+
+interface ScopeApi {
+  create(parent: Scope): [Scope, () => Operation<void>];
+  destroy(scope: Scope): Operation<void>;
+  set<T>(scope: Scope, context: Context<T>, value: T): T;
+  delete<T>(scope: Scope, context: Context<T>): boolean;
+}
+
+interface Apis {
+  Scope: Api<ScopeApi>;
+}
+
+export const api: Apis = {
+  Scope: createApi<ScopeApi>("Scope", {
+    create() {
+      throw new TypeError(`no handler for Scope.create()`);
+    },
+    *destroy() {},
+    set(scope, context, value) {
+      return (scope as ScopeInternal).contexts[context.name] = value;
+    },
+    delete(scope, context) {
+      return delete (scope as ScopeInternal).contexts[context.name];
+    },
+  }),
+};

--- a/lib/attributes-internal.ts
+++ b/lib/attributes-internal.ts
@@ -1,0 +1,67 @@
+import { createContext } from "./context.ts";
+import { useScope } from "./scope.ts";
+import type { Operation, Scope } from "./types.ts";
+
+/**
+ * Serializable name/value pairs that can be used for visualizing and
+ * inpsecting Effection scopes. There will always be at least a name
+ * in the attributes.
+ */
+export type Attributes =
+  & { name: string }
+  & Record<string, string | number | boolean>;
+
+const AttributesContext = createContext<Attributes>(
+  "@effection/attributes",
+  { name: "anonymous" },
+);
+
+/**
+ * Add metadata to the current {@link Scope} that can be used for
+ * display and debugging purposes.
+ *
+ * Calling `useAttributes()` multiple times will add new attributes
+ * and overwrite attributes of the same name, but it will not erase
+ * old ones.
+ *
+ * @example
+ * ```ts
+ * function useServer(port: number): Operation<Server> {
+ *   return resource(function*(provide) {
+ *     yield* useAttributes({ name: "Server", port });
+ *     let server = createServer();
+ *     server.listen();
+ *     try {
+ *       yield* provide(server);
+ *     } finally {
+ *       server.close();
+ *     }
+ *   });
+ * }
+ * ```
+ *
+ * @param attrs - attributes to add to this {@link Scope}
+ * @returns an Oeration adding `attrs` to the current scope
+ * @since 4.1
+ */
+export function* useAttributes(attrs: Partial<Attributes>): Operation<void> {
+  let scope = yield* useScope();
+
+  let current = scope.hasOwn(AttributesContext)
+    ? scope.expect(AttributesContext)
+    : AttributesContext.defaultValue!;
+
+  scope.set(AttributesContext, { ...current, ...attrs });
+}
+
+/**
+ * Get the unique attributes of this {@link Scope}. Attributes are not
+ * inherited and only the attributes explicitly assigned to this scope
+ * will be returned.
+ */
+export function getAttributes(scope: Scope) {
+  if (scope.hasOwn(AttributesContext)) {
+    return scope.expect(AttributesContext);
+  }
+  return AttributesContext.defaultValue as Attributes;
+}

--- a/lib/attributes.ts
+++ b/lib/attributes.ts
@@ -1,0 +1,1 @@
+export { type Attributes, useAttributes } from "./attributes-internal.ts";

--- a/lib/callcc.ts
+++ b/lib/callcc.ts
@@ -11,7 +11,7 @@ export function* callcc<T>(
     reject: (error: Error) => Operation<void>,
   ) => Operation<void>,
 ): Operation<T> {
-  let result = withResolvers<Result<T>>();
+  let result = withResolvers<Result<T>>("await callcc");
 
   let resolve = lift((value: T) => result.resolve(Ok(value)));
 

--- a/lib/coroutine.ts
+++ b/lib/coroutine.ts
@@ -1,8 +1,10 @@
+import { api as effection } from "./api.ts";
 import { Priority } from "./contexts.ts";
 import { DelimiterContext } from "./delimiter.ts";
-import { ReducerContext } from "./reducer.ts";
 import { Ok } from "./result.ts";
 import type { Coroutine, Operation, Scope } from "./types.ts";
+
+const reducerApi = effection.Reducer;
 
 export interface CoroutineOptions<T> {
   scope: Scope;
@@ -12,8 +14,6 @@ export interface CoroutineOptions<T> {
 export function createCoroutine<T>(
   { operation, scope }: CoroutineOptions<T>,
 ): Coroutine<T> {
-  let reducer = scope.expect(ReducerContext);
-
   let iterator: Coroutine<T>["data"]["iterator"] | undefined = undefined;
 
   let routine = {
@@ -31,25 +31,25 @@ export function createCoroutine<T>(
     next(result) {
       routine.data.exit((exitResult) => {
         routine.data.exit = (didExit) => didExit(Ok());
-        reducer.reduce([
-          scope.expect(Priority),
+        reducerApi.invoke(routine.scope, "reduce", [[
+          routine.scope.expect(Priority),
           routine,
           exitResult.ok ? result : exitResult,
-          scope.expect(DelimiterContext).validator,
+          routine.scope.expect(DelimiterContext).validator,
           "next",
-        ]);
+        ]]);
       });
     },
     return(result) {
       routine.data.exit((exitResult) => {
         routine.data.exit = (didExit) => didExit(Ok());
-        reducer.reduce([
-          scope.expect(Priority),
+        reducerApi.invoke(routine.scope, "reduce", [[
+          routine.scope.expect(Priority),
           routine,
           exitResult.ok ? result : exitResult,
-          scope.expect(DelimiterContext).validator,
+          routine.scope.expect(DelimiterContext).validator,
           "return",
-        ]);
+        ]]);
       });
     },
   } as Coroutine<T>;

--- a/lib/delimiter.ts
+++ b/lib/delimiter.ts
@@ -10,7 +10,7 @@ export class Delimiter<T>
   implements Operation<Maybe<Result<T>>>, ErrorBoundary {
   level = 0;
   finalized = false;
-  future = withResolvers<Maybe<Result<T>>>();
+  future = withResolvers<Maybe<Result<T>>>("await delimiter");
   computed = false;
   routine?: Coroutine;
   outcome?: Maybe<Result<T>>;

--- a/lib/each.ts
+++ b/lib/each.ts
@@ -37,8 +37,8 @@ export function each<T>(stream: Stream<T, unknown>): Operation<Iterable<T>> {
         scope.set(EachStack, []);
       }
 
-      let done = withResolvers<void>();
-      let cxt = withResolvers<EachLoop<T>>();
+      let done = withResolvers<void>("await each done");
+      let cxt = withResolvers<EachLoop<T>>("await each context");
 
       yield* spawn(function* () {
         let subscription = yield* stream;

--- a/lib/future.ts
+++ b/lib/future.ts
@@ -9,7 +9,7 @@ export interface FutureWithResolvers<T> {
 }
 export function createFuture<T>(): FutureWithResolvers<T> {
   let promise = lazyPromiseWithResolvers<T>();
-  let operation = withResolvers<T>();
+  let operation = withResolvers<T>("await future");
 
   let resolve = (value: T) => {
     promise.resolve(value);

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -2,8 +2,9 @@ import { createContext } from "./context.ts";
 import type { Operation } from "./types.ts";
 import { callcc } from "./callcc.ts";
 import { run } from "./run.ts";
-import { useScope } from "./scope.ts";
+import { global, useScope } from "./scope.ts";
 import { call } from "./call.ts";
+import { api } from "./api.ts";
 
 /**
  * Halt process execution immediately and initiate shutdown. If a message is
@@ -60,103 +61,109 @@ export function* exit(status: number, message?: string): Operation<void> {
  * @since 3.0
  */
 
-export async function main(
+export function main(
   body: (args: string[]) => Operation<void>,
 ): Promise<void> {
-  let hardexit = (_status: number) => {};
-
-  let result = await run(() =>
-    callcc<Exit>(function* (resolve) {
-      // action will return shutdown immediately upon resolve, so stash
-      // this function in the exit context so it can be called anywhere.
-      yield* ExitContext.set(resolve);
-
-      // this will hold the event loop and prevent runtimes such as
-      // Node and Deno from exiting prematurely.
-      let interval = setInterval(() => {}, Math.pow(2, 30));
-
-      let scope = yield* useScope();
-
-      try {
-        let interrupt = {
-          SIGINT: () =>
-            scope.run(() => resolve({ status: 130, signal: "SIGINT" })),
-          SIGTERM: () =>
-            scope.run(() => resolve({ status: 143, signal: "SIGTERM" })),
-        };
-
-        yield* withHost({
-          *deno() {
-            hardexit = (status) => Deno.exit(status);
-            try {
-              Deno.addSignalListener("SIGINT", interrupt.SIGINT);
-              /**
-               * Windows only supports ctrl-c (SIGINT), ctrl-break (SIGBREAK), and ctrl-close (SIGUP)
-               */
-              if (Deno.build.os !== "windows") {
-                Deno.addSignalListener("SIGTERM", interrupt.SIGTERM);
-              }
-              yield* body(Deno.args.slice());
-            } finally {
-              Deno.removeSignalListener("SIGINT", interrupt.SIGINT);
-              if (Deno.build.os !== "windows") {
-                Deno.removeSignalListener("SIGTERM", interrupt.SIGTERM);
-              }
-            }
-          },
-          *node() {
-            // Annotate dynamic import so that webpack ignores it.
-            // See https://webpack.js.org/api/module-methods/#webpackignore
-            let { default: process } = yield* call(() =>
-              import(/* webpackIgnore: true */ "node:process")
-            );
-            hardexit = (status) => process.exit(status);
-            try {
-              process.on("SIGINT", interrupt.SIGINT);
-              if (process.platform !== "win32") {
-                process.on("SIGTERM", interrupt.SIGTERM);
-              }
-              yield* body(process.argv.slice(2));
-            } finally {
-              process.off("SIGINT", interrupt.SIGINT);
-              if (process.platform !== "win32") {
-                process.off("SIGTERM", interrupt.SIGINT);
-              }
-            }
-          },
-          *browser() {
-            try {
-              self.addEventListener("unload", interrupt.SIGINT);
-              yield* body([]);
-            } finally {
-              self.removeEventListener("unload", interrupt.SIGINT);
-            }
-          },
-        });
-
-        yield* exit(0);
-      } catch (error) {
-        yield* resolve({ status: 1, error: error as Error });
-      } finally {
-        clearInterval(interval);
-      }
-    })
-  );
-
-  if (result.message) {
-    if (result.status === 0) {
-      console.log(result.message);
-    } else {
-      console.error(result.message);
-    }
-  }
-
-  if (result.error) {
-    console.error(result.error);
-  }
-
-  hardexit(result.status);
+  return api.Main.invoke(global, "main", [body]);
 }
+
+global.around(api.Main, {
+  async main([body]) {
+    let hardexit = (_status: number) => {};
+
+    let result = await run(() =>
+      callcc<Exit>(function* (resolve) {
+        // action will return shutdown immediately upon resolve, so stash
+        // this function in the exit context so it can be called anywhere.
+        yield* ExitContext.set(resolve);
+
+        // this will hold the event loop and prevent runtimes such as
+        // Node and Deno from exiting prematurely.
+        let interval = setInterval(() => {}, Math.pow(2, 30));
+
+        let scope = yield* useScope();
+
+        try {
+          let interrupt = {
+            SIGINT: () =>
+              scope.run(() => resolve({ status: 130, signal: "SIGINT" })),
+            SIGTERM: () =>
+              scope.run(() => resolve({ status: 143, signal: "SIGTERM" })),
+          };
+
+          yield* withHost({
+            *deno() {
+              hardexit = (status) => Deno.exit(status);
+              try {
+                Deno.addSignalListener("SIGINT", interrupt.SIGINT);
+                /**
+                 * Windows only supports ctrl-c (SIGINT), ctrl-break (SIGBREAK), and ctrl-close (SIGUP)
+                 */
+                if (Deno.build.os !== "windows") {
+                  Deno.addSignalListener("SIGTERM", interrupt.SIGTERM);
+                }
+                yield* body(Deno.args.slice());
+              } finally {
+                Deno.removeSignalListener("SIGINT", interrupt.SIGINT);
+                if (Deno.build.os !== "windows") {
+                  Deno.removeSignalListener("SIGTERM", interrupt.SIGTERM);
+                }
+              }
+            },
+            *node() {
+              // Annotate dynamic import so that webpack ignores it.
+              // See https://webpack.js.org/api/module-methods/#webpackignore
+              let { default: process } = yield* call(() =>
+                import(/* webpackIgnore: true */ "node:process")
+              );
+              hardexit = (status) => process.exit(status);
+              try {
+                process.on("SIGINT", interrupt.SIGINT);
+                if (process.platform !== "win32") {
+                  process.on("SIGTERM", interrupt.SIGTERM);
+                }
+                yield* body(process.argv.slice(2));
+              } finally {
+                process.off("SIGINT", interrupt.SIGINT);
+                if (process.platform !== "win32") {
+                  process.off("SIGTERM", interrupt.SIGINT);
+                }
+              }
+            },
+            *browser() {
+              try {
+                self.addEventListener("unload", interrupt.SIGINT);
+                yield* body([]);
+              } finally {
+                self.removeEventListener("unload", interrupt.SIGINT);
+              }
+            },
+          });
+
+          yield* exit(0);
+        } catch (error) {
+          yield* resolve({ status: 1, error: error as Error });
+        } finally {
+          clearInterval(interval);
+        }
+      })
+    );
+
+    if (result.message) {
+      if (result.status === 0) {
+        console.log(result.message);
+      } else {
+        console.error(result.message);
+      }
+    }
+
+    if (result.error) {
+      console.error(result.error);
+    }
+
+    hardexit(result.status);
+  },
+}, { at: "min" });
 
 const ExitContext = createContext<(exit: Exit) => Operation<void>>("exit");
 

--- a/lib/mod.ts
+++ b/lib/mod.ts
@@ -2,6 +2,7 @@ export * from "./types.ts";
 export * from "./result.ts";
 export * from "./action.ts";
 export * from "./context.ts";
+export * from "./attributes.ts";
 export * from "./scope.ts";
 export * from "./suspend.ts";
 export * from "./sleep.ts";

--- a/lib/reducer.ts
+++ b/lib/reducer.ts
@@ -58,7 +58,7 @@ export class Reducer {
   };
 }
 
-type Instruction = [
+export type Instruction = [
   number,
   Coroutine<unknown>,
   Result<unknown>,
@@ -66,7 +66,7 @@ type Instruction = [
   "return" | "next",
 ];
 
-class InstructionQueue extends PriorityQueue<Instruction> {
+export class InstructionQueue extends PriorityQueue<Instruction> {
   enqueue(instruction: Instruction): void {
     let [priority] = instruction;
     this.push(priority, instruction);

--- a/lib/scope-internal.ts
+++ b/lib/scope-internal.ts
@@ -1,12 +1,14 @@
 import type { ApiInternal } from "./api-internal.ts";
 import { api as effection } from "./api.ts";
 import { Children, Priority } from "./contexts.ts";
+import { Reducer } from "./reducer.ts";
 import { Err, Ok, unbox } from "./result.ts";
 import { createTask } from "./task.ts";
 import type { Context, Operation, Scope, Task } from "./types.ts";
 import { type WithResolvers, withResolvers } from "./with-resolvers.ts";
 
 const api = effection.Scope;
+const reducerApi = effection.Reducer;
 
 export function createScopeInternal(
   parent?: Scope,
@@ -16,6 +18,12 @@ export function createScopeInternal(
     global.around(api, {
       create([parent]) {
         return buildScopeInternal(parent);
+      },
+    }, { at: "min" });
+    let defaultReducer = new Reducer();
+    global.around(reducerApi, {
+      reduce([instruction]) {
+        defaultReducer.reduce(instruction);
       },
     }, { at: "min" });
     return [global, destroy] as const;
@@ -133,7 +141,7 @@ export function buildScopeInternal(
       if (destruction) {
         return yield* destruction.operation;
       }
-      destruction = withResolvers<void>();
+      destruction = withResolvers<void>("await destruction");
       parent?.expect(Children).delete(scope);
       unbind();
       let outcome = Ok();

--- a/lib/scope-internal.ts
+++ b/lib/scope-internal.ts
@@ -1,10 +1,33 @@
+import type { ApiInternal } from "./api-internal.ts";
+import { api as effection } from "./api.ts";
 import { Children, Priority } from "./contexts.ts";
 import { Err, Ok, unbox } from "./result.ts";
 import { createTask } from "./task.ts";
 import type { Context, Operation, Scope, Task } from "./types.ts";
 import { type WithResolvers, withResolvers } from "./with-resolvers.ts";
 
+const api = effection.Scope;
+
 export function createScopeInternal(
+  parent?: Scope,
+): [ScopeInternal, () => Operation<void>] {
+  if (!parent) {
+    let [global, destroy] = buildScopeInternal();
+    global.around(api, {
+      create([parent]) {
+        return buildScopeInternal(parent);
+      },
+    }, { at: "min" });
+    return [global, destroy] as const;
+  } else {
+    return api.invoke(parent, "create", [parent]) as [
+      ScopeInternal,
+      () => Operation<void>,
+    ];
+  }
+}
+
+export function buildScopeInternal(
   parent?: Scope,
 ): [ScopeInternal, () => Operation<void>] {
   let destructors = new Set<() => Operation<void>>();
@@ -19,7 +42,7 @@ export function createScopeInternal(
       return (contexts[context.name] ?? context.defaultValue) as T | undefined;
     },
     set<T>(context: Context<T>, value: T): T {
-      return contexts[context.name] = value;
+      return api.invoke(scope, "set", [scope, context, value]) as T;
     },
     expect<T>(context: Context<T>): T {
       let value = scope.get(context);
@@ -31,7 +54,7 @@ export function createScopeInternal(
       return value;
     },
     delete<T>(context: Context<T>): boolean {
-      return delete contexts[context.name];
+      return api.invoke(scope, "delete", [scope, context]);
     },
     hasOwn<T>(context: Context<T>): boolean {
       return !!Reflect.getOwnPropertyDescriptor(contexts, context.name);
@@ -51,9 +74,47 @@ export function createScopeInternal(
       };
     },
 
+    around<A extends {}>(
+      api: ApiInternal<A>,
+      ...params: Parameters<ApiInternal<A>["around"]>
+    ) {
+      let [around, options] = params;
+      if (!scope.hasOwn(api.context)) {
+        scope.set(api.context, { min: [], max: [] });
+      }
+
+      let { min, max } = scope.expect(api.context);
+
+      if (options?.at === "min") {
+        min.push(around);
+      } else {
+        max.push(around);
+      }
+    },
+
     ensure(op: () => Operation<void>): () => void {
       destructors.add(op);
       return () => destructors.delete(op);
+    },
+
+    reduce<T, S>(
+      context: Context<T>,
+      fn: (sum: S, item: T) => S,
+      initial: S,
+    ): S {
+      let sum = initial;
+      let current = contexts;
+      while (current) {
+        if (Object.hasOwn(current, context.name)) {
+          let item = current[context.name] as T;
+          if (item) {
+            sum = fn(sum, item);
+          }
+        }
+
+        current = Object.getPrototypeOf(current);
+      }
+      return sum;
     },
   });
 
@@ -61,37 +122,41 @@ export function createScopeInternal(
   scope.set(Children, new Set());
   parent?.expect(Children).add(scope);
 
+  let destroy = () => api.invoke(scope, "destroy", [scope]);
+
   let unbind = parent ? (parent as ScopeInternal).ensure(destroy) : () => {};
 
   let destruction: WithResolvers<void> | undefined = undefined;
 
-  function* destroy(): Operation<void> {
-    if (destruction) {
-      return yield* destruction.operation;
-    }
-    destruction = withResolvers<void>();
-    parent?.expect(Children).delete(scope);
-    unbind();
-    let outcome = Ok();
-    try {
-      for (let destructor of destructors) {
-        try {
-          destructors.delete(destructor);
-          yield* destructor();
-        } catch (error) {
-          outcome = Err(error as Error);
+  scope.around(api, {
+    *destroy(): Operation<void> {
+      if (destruction) {
+        return yield* destruction.operation;
+      }
+      destruction = withResolvers<void>();
+      parent?.expect(Children).delete(scope);
+      unbind();
+      let outcome = Ok();
+      try {
+        for (let destructor of destructors) {
+          try {
+            destructors.delete(destructor);
+            yield* destructor();
+          } catch (error) {
+            outcome = Err(error as Error);
+          }
+        }
+      } finally {
+        if (outcome.ok) {
+          destruction.resolve();
+        } else {
+          destruction.reject(outcome.error);
         }
       }
-    } finally {
-      if (outcome.ok) {
-        destruction.resolve();
-      } else {
-        destruction.reject(outcome.error);
-      }
-    }
 
-    unbox(outcome);
-  }
+      unbox(outcome);
+    },
+  }, { at: "min" });
 
   return [scope, destroy];
 }
@@ -99,4 +164,9 @@ export function createScopeInternal(
 export interface ScopeInternal extends Scope, AsyncDisposable {
   contexts: Record<string, unknown>;
   ensure(op: () => Operation<void>): () => void;
+  reduce<T, TSum>(
+    context: Context<T>,
+    fn: (sum: TSum, item: T) => TSum,
+    initial: TSum,
+  ): TSum;
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,3 +1,4 @@
+// deno-lint-ignore-file no-explicit-any
 import type { Result } from "./result.ts";
 
 /**
@@ -335,7 +336,97 @@ export interface Scope {
    * @returns `true` if scope has its own context, `false` if context is not present, or inherited from its parent.
    */
   hasOwn<T>(context: Context<T>): boolean;
+
+  /**
+   * Enhance an {@link Api} within this scope by surrounding it with
+   * middleware.
+   *
+   * @param api - the api being enhanced
+   * @param middlewares - collection of {@link Middleware} to be added to this {@link Api}
+   * @param options - specifies which layer of dispatch `middlewares` will be applied
+   * @see {@link Api.around}
+   * @since 4.1
+   */
+  around<A>(api: Api<A>, ...options: Parameters<Api<A>["around"]>): void;
 }
+
+/**
+ * A set of methods and values that can be decorated on a per-scope
+ * basis. Apis are ideal for situations that require context
+ * sensitivity such as dependency injection, test mocking, and
+ * instrumentation.
+ *
+ * @template A - core shape of the Api
+ * @see {@link createApi}
+ * @since 4.1
+ */
+export interface Api<A> {
+  /**
+   * Every member of `A` "lifted" into an operation that invokes that
+   * member on the current {Scope}
+   */
+  operations: {
+    [K in keyof A]: A[K] extends Operation<unknown> ? A[K]
+      : A[K] extends (...args: infer TArgs) => infer TReturn
+        ? TReturn extends Operation<unknown> ? A[K]
+        : (...args: TArgs) => Operation<TReturn>
+      : Operation<A[K]>;
+  };
+  /**
+   * Enhance an {@link Api} within this scope by surrounding it with
+   * middleware.
+   *
+   * @param middlewares - a set of decorators that will surround the api core
+   * @param options - specify at which layer of dispatch, `middleware` will apply
+   * @returns an {Operation} that installs the middleware in the current {Scope}
+   */
+  around: (
+    middlewares: Partial<Around<A>>,
+    options?: {
+      at: "min" | "max";
+    },
+  ) => Operation<void>;
+
+  /**
+   * Call an API as it exists on `scope`.
+   */
+  invoke: <K extends keyof A>(
+    scope: Scope,
+    key: K,
+    args: A[K] extends (...args: any) => unknown ? Parameters<A[K]> : [],
+  ) => A[K] extends (...args: any) => unknown ? ReturnType<A[K]> : A[K];
+}
+
+/**
+ * An general function that can be used to surround any other function
+ * or value.
+ *
+ * @since 4.1
+ */
+export interface Middleware<TArgs extends unknown[], TReturn> {
+  /**
+   * Execute a single link in the middleware stack by doing whatever
+   * computation is necessary and then optionally delegating to the
+   * next link.
+   *
+   * @param args - the arguments to the value being surrounded.
+   * @param next - the next function in the change. It will accept the
+   * arguments contained in `args`
+   * @returns a value with the same shape as `next()`'s return value
+   */
+  (args: TArgs, next: (...args: TArgs) => TReturn): TReturn;
+}
+
+/**
+ * The shape of middlewares can surround a particular {Api}
+ *
+ * Members of an Api that are values are surrounded by no-arg functions.
+ */
+export type Around<Api> = {
+  [K in keyof Api]: Api[K] extends (...args: infer TArgs) => infer TReturn
+    ? Middleware<TArgs, TReturn>
+    : Middleware<[], Api[K]>;
+};
 
 /**
  * Unwrap the type of an `Operation`.

--- a/tasks/build-npm.ts
+++ b/tasks/build-npm.ts
@@ -1,4 +1,5 @@
-import { build, emptyDir } from "jsr:@deno/dnt@0.41.3";
+import { build, emptyDir } from "jsr:@deno/dnt@0.42.3";
+import denoJSON from "../deno.json" with { type: "json" };
 
 const outDir = "./build/npm";
 
@@ -10,7 +11,10 @@ if (!version) {
 }
 
 await build({
-  entryPoints: ["./mod.ts"],
+  entryPoints: Object.entries(denoJSON.exports).map(([key, value]) => ({
+    name: key,
+    path: value,
+  })),
   outDir,
   shims: {
     deno: false,

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -1,0 +1,210 @@
+import { run } from "../mod.ts";
+import { createApi } from "../experimental.ts";
+import { constant } from "../lib/constant.ts";
+import { type Operation, spawn } from "../lib/mod.ts";
+import { describe, expect, it } from "./suite.ts";
+
+describe("api", () => {
+  it("invokes operation functions as operations", async () => {
+    let api = createApi("test", {
+      *test() {
+        return 5;
+      },
+    });
+
+    await run(function* () {
+      expect(yield* api.operations.test()).toEqual(5);
+    });
+  });
+
+  it("invokes synchronous functions as operations", async () => {
+    let api = createApi("test", {
+      five: () => 5,
+    });
+
+    await run(function* () {
+      expect(yield* api.operations.five()).toEqual(5);
+    });
+  });
+
+  it("invokes operations as operations", async () => {
+    let api = createApi("test", {
+      five: {
+        *[Symbol.iterator]() {
+          return 5;
+        },
+      } as Operation<number>,
+    });
+
+    await run(function* () {
+      expect(yield* api.operations.five).toEqual(5);
+    });
+  });
+
+  it("invokes constants as operations", async () => {
+    let api = createApi("test", {
+      five: 5,
+    });
+
+    await run(function* () {
+      expect(yield* api.operations.five).toEqual(5);
+    });
+  });
+
+  it("can have middleware installed", async () => {
+    let api = createApi("test", {
+      constFive: 5,
+      *operationFnFive() {
+        return 5;
+      },
+      operationFive: constant(5),
+      syncFive: () => 5 as number,
+    });
+
+    await run(function* () {
+      yield* api.around({
+        constFive(args, next) {
+          return next(...args) * 2;
+        },
+        *operationFnFive(args, next) {
+          return (yield* next(...args)) * 2;
+        },
+        *operationFive(args, next) {
+          return (yield* next(...args)) * 2;
+        },
+        syncFive: (args, next) => next(...args) * 2,
+      });
+
+      expect(yield* api.operations.constFive).toEqual(10);
+      expect(yield* api.operations.operationFnFive()).toEqual(10);
+      expect(yield* api.operations.operationFive).toEqual(10);
+      expect(yield* api.operations.syncFive()).toEqual(10);
+    });
+  });
+
+  it("inherits middleware from scope", async () => {
+    let api = createApi("test", {
+      *num(value: number): Operation<number> {
+        return value;
+      },
+    });
+
+    await run(function* () {
+      yield* api.around({
+        *num(args, next) {
+          return (yield* next(...args)) * 2;
+        },
+      });
+      let task = yield* spawn(function* () {
+        return yield* api.operations.num(5);
+      });
+
+      expect(yield* task).toEqual(10);
+    });
+  });
+
+  it("applies maximal middleware before minimal middleware", async () => {
+    let api = createApi("test", {
+      *test(order: string[]): Operation<string[]> {
+        return order;
+      },
+    });
+
+    await run(function* () {
+      yield* api.around({
+        *test(args, next) {
+          let [input] = args;
+          let output = yield* next(input.concat("max1"));
+          return output.concat("/max1");
+        },
+      });
+      yield* api.around({
+        *test(args, next) {
+          let [input] = args;
+          let output = yield* next(input.concat("max2"));
+          return output.concat("/max2");
+        },
+      });
+      yield* api.around({
+        *test(args, next) {
+          let [input] = args;
+          let output = yield* next(input.concat("min1"));
+          return output.concat("/min1");
+        },
+      });
+      yield* api.around({
+        *test(args, next) {
+          let [input] = args;
+          let output = yield* next(input.concat("min2"));
+          return output.concat("/min2");
+        },
+      });
+
+      expect(yield* api.operations.test([])).toEqual([
+        "max1",
+        "max2",
+        "min1",
+        "min2",
+        "/min2",
+        "/min1",
+        "/max2",
+        "/max1",
+      ]);
+    });
+  });
+
+  it("applies outer scope maxima more maximally than inner scopes maxima", async () => {
+    let api = createApi("test", {
+      *test(order: string[]): Operation<string[]> {
+        return order;
+      },
+    });
+
+    await run(function* outer() {
+      yield* api.around({
+        *test(args, next) {
+          let [input] = args;
+          let output = yield* next(input.concat("outermax"));
+          return output.concat("/outermax");
+        },
+      });
+      yield* api.around({
+        *test(args, next) {
+          let [input] = args;
+          let output = yield* next(input.concat("outermin"));
+          return output.concat("/outermin");
+        },
+      }, { at: "min" });
+
+      let task = yield* spawn(function* inner() {
+        yield* api.around({
+          *test(args, next) {
+            let [input] = args;
+            let output = yield* next(input.concat("innermax"));
+            return output.concat("/innermax");
+          },
+        });
+        yield* api.around({
+          *test(args, next) {
+            let [input] = args;
+            let output = yield* next(input.concat("innermin"));
+            return output.concat("/innermin");
+          },
+        }, { at: "min" });
+
+        return yield* api.operations.test([]);
+      });
+
+      expect(yield* task).toEqual([
+        "outermax",
+        "innermax",
+        "innermin",
+        "outermin",
+        "/outermin",
+        "/innermin",
+        "/innermax",
+        "/outermax",
+      ]);
+    });
+  });
+});

--- a/test/attributes.test.ts
+++ b/test/attributes.test.ts
@@ -1,0 +1,45 @@
+import { run, spawn, useAttributes, useScope } from "../mod.ts";
+import { describe, expect, it } from "./suite.ts";
+import { getAttributes } from "../lib/attributes-internal.ts";
+
+describe("useAttributes", () => {
+  it("adds attributes to the current scope", async () => {
+    let scope = await run(function* main() {
+      yield* useAttributes({ name: "Main", awesome: true });
+
+      return yield* useScope();
+    });
+
+    let attrs = getAttributes(scope);
+
+    expect(attrs).toEqual({ name: "Main", awesome: true });
+  });
+
+  it("does not cause any attributes to be inherited from the parent", async () => {
+    let scope = await run(function* main() {
+      yield* useAttributes({ awesome: true });
+      let child = yield* spawn(function* () {
+        yield* useAttributes({ name: "Child" });
+        return yield* useScope();
+      });
+
+      return yield* child;
+    });
+
+    let attrs = getAttributes(scope);
+
+    expect(attrs).toEqual({ name: "Child" });
+  });
+
+  it("adds new attributes to existing ones", async () => {
+    let scope = await run(function* main() {
+      yield* useAttributes({ name: "Main" });
+      yield* useAttributes({ awesome: true });
+      return yield* useScope();
+    });
+
+    let attrs = getAttributes(scope);
+
+    expect(attrs).toEqual({ name: "Main", awesome: true });
+  });
+});


### PR DESCRIPTION
# Motivation

External packages (like `@effectionx/durable`) need to build custom reducers that intercept effect processing — for example, to record effect resolutions to a durable stream and replay them on resume. Currently, the types and contexts required to build a custom reducer (`ReducerContext`, `Instruction`, `InstructionQueue`, `DelimiterContext`) are internal to Effection and not accessible through any public entrypoint.

Additionally, custom reducers need to distinguish **infrastructure effects** (like `useCoroutine()`, `useScope()`, scope destruction) from **user-facing effects** (like `sleep()`, `call()`, `action()`). Infrastructure effects that use `withResolvers()` currently have no description label, making them indistinguishable from user code.

This PR makes durable execution (and other custom reducer patterns) **completely additive** to Effection — no fork required.

# Approach

**1. Export reducer internals via `experimental.ts`** (7 lines added)

Re-export `Reducer`, `ReducerContext`, `InstructionQueue`, and the `Instruction` type from `lib/reducer.ts`, plus `DelimiterContext` from `lib/delimiter.ts`, through the existing `experimental` entry point. This follows the established pattern — `experimental.ts` already exports `api` for the same reason (enabling external middleware).

**2. Add `export` to `Instruction` and `InstructionQueue`** (2 lines changed in `lib/reducer.ts`)

These were module-private. Making them `export` allows the re-export in `experimental.ts`.

**3. Label infrastructure `withResolvers()` calls** (5 files, 1 line each)

Add description strings to `withResolvers()` calls in core infrastructure:
- `lib/callcc.ts`: `"await callcc"`
- `lib/delimiter.ts`: `"await delimiter"`
- `lib/each.ts`: `"await each done"`, `"await each context"`
- `lib/future.ts`: `"await future"`
- `lib/scope-internal.ts`: `"await destruction"`

The `description` parameter already exists on `withResolvers()` and is already used elsewhere. These labels are purely additive — they make infrastructure effects identifiable by description, which is useful for debugging, inspection, and custom reducers.

**Zero behavior changes.** All 121 test steps across 15 core test suites pass unchanged.