### PR TITLE
Bug: error in finally during halt propagates despite being caught

### DIFF
--- a/test/spawn.test.ts
+++ b/test/spawn.test.ts
@@ -255,4 +255,31 @@ describe("spawn", () => {
 
     expect(sequence).toEqual(["parent", "second", "first"]);
   });
+
+  it("does not fail parent scope when error from child halt is caught", async () => {
+    let result = run(function* () {
+      let task = yield* spawn(function* () {
+        try {
+          yield* suspend();
+        } finally {
+          throw new Error("finally-boom");
+        }
+      });
+
+      yield* sleep(0);
+
+      try {
+        yield* task.halt();
+      } catch (error) {
+        // Error is explicitly caught — parent scope should remain healthy
+        expect((error as Error).message).toEqual("finally-boom");
+      }
+
+      return "success";
+    });
+
+    // The parent caught the error, so it should resolve with "success",
+    // not reject with "finally-boom"
+    await expect(result).resolves.toEqual("success");
+  });
 });


### PR DESCRIPTION
# Motivation

When a child task throws in a `finally` block during halt, the error propagates through **two independent paths**:

1. **Through `halt()` return** — the caller's `try/catch` catches it ✓
2. **Through the scope tree** — fails the parent scope unconditionally ✗

This means even when the caller explicitly handles the error from `yield* task.halt()`, the parent scope is still considered failed and the error escapes.

```ts
let result = run(function* () {
  let task = yield* spawn(function* () {
    try {
      yield* suspend();
    } finally {
      throw new Error("finally-boom");
    }
  });

  yield* sleep(0);

  try {
    yield* task.halt();
  } catch (error) {
    // Error IS caught here ✓
  }

  return "success"; // This executes ✓
});

// But the run() rejects with "finally-boom" instead of resolving with "success" ✗
await expect(result).resolves.toEqual("success");
```

All three variants reproduce: synchronous `throw`, synchronous `action` reject, and async `until(Promise.reject(...))`.

# Approach

This PR adds a single failing test to `test/spawn.test.ts` that demonstrates the bug. No fix is included — this is intended to document the issue and serve as a regression test for a future fix.