### PR TITLE
🐛 Fix API reference showing alpha instead of stable release

### DIFF
--- a/www/components/api/api-page.tsx
+++ b/www/components/api/api-page.tsx
@@ -63,14 +63,16 @@ export function* ApiPage({
         ),
         linkResolver: createSibling,
         versionToggle: yield* (function* () {
-          const { series: SERIES } = yield* useConfig();
+          const { series } = yield* useConfig();
+          // Only show stable series in version toggle (no prereleases)
+          const stableSeries = series.filter((s) => !s.includePrerelease);
           const currentSeries = `v${major(pkg.version)}`;
 
           const links = yield* all(
-            SERIES.map(function* (s) {
+            stableSeries.map(function* (s) {
               const seriesPkg = yield* usePackage({
                 type: "worktree",
-                series: s,
+                series: s.name,
               });
               const seriesDocs = yield* seriesPkg.docs();
               const hasSymbol = seriesDocs["."].some((node) =>
@@ -81,9 +83,9 @@ export function* ApiPage({
 
               return (
                 <a
-                  href={yield* createRootUrl(`api/${s}`)(current)}
+                  href={yield* createRootUrl(`api/${s.name}`)(current)}
                   class={`text-base ${
-                    s === currentSeries
+                    s.name === currentSeries
                       ? "font-bold text-sky-500"
                       : "text-gray-600 dark:text-gray-400 hover:text-sky-500"
                   }`}

--- a/www/context/config.ts
+++ b/www/context/config.ts
@@ -1,21 +1,56 @@
 import { createContext, type Operation } from "effection";
 
-export interface SiteConfig<T extends string = string> {
-  series: T[];
-  current: NoInfer<T>;
+export interface SeriesConfig {
+  /** Series identifier used in URLs, e.g., "v4", "v4-next" */
+  name: string;
+  /** Major version number for semver matching */
+  major: number;
+  /** Include prerelease versions when finding latest tag */
+  includePrerelease?: boolean;
+  /** Parent series name for grouping (e.g., "v4-next" -> "v4") */
+  parent?: string;
+}
+
+export interface SiteConfig {
+  series: SeriesConfig[];
+  current: string;
 }
 
 const ConfigContext = createContext<SiteConfig>("site-config", {
-  series: ["v3", "v4"],
+  series: [
+    { name: "v3", major: 3 },
+    { name: "v4", major: 4 },
+    { name: "v4-next", major: 4, includePrerelease: true, parent: "v4" },
+  ],
   current: "v4",
 });
 
-export function* initConfig<T extends string>(
-  config: SiteConfig<T>,
+export function* initConfig(
+  config: SiteConfig,
 ): Operation<void> {
   yield* ConfigContext.set(config);
 }
 
 export function* useConfig(): Operation<SiteConfig> {
   return yield* ConfigContext.expect();
+}
+
+/**
+ * Find a series configuration by name
+ */
+export function findSeries(
+  config: SiteConfig,
+  name: string,
+): SeriesConfig | undefined {
+  return config.series.find((s) => s.name === name);
+}
+
+/**
+ * Get series that are children of a parent series
+ */
+export function getChildSeries(
+  config: SiteConfig,
+  parentName: string,
+): SeriesConfig[] {
+  return config.series.filter((s) => s.parent === parentName);
 }

--- a/www/lib/package.ts
+++ b/www/lib/package.ts
@@ -3,7 +3,7 @@ import { relative } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import z from "zod";
-import { SiteConfig } from "../context/config.ts";
+import { findSeries, type SeriesConfig, useConfig } from "../context/config.ts";
 import { useJSRClient } from "../context/jsr.ts";
 import { LocalDocsPages, useDocPages } from "../hooks/use-deno-doc.tsx";
 import { useDescription, useTitle } from "../hooks/use-description-parse.tsx";
@@ -19,7 +19,10 @@ import { useWorktree } from "./worktrees.ts";
 
 export type WorkTreePackageOptions = {
   type: "worktree";
-  series: SiteConfig["series"][number];
+  /** Series name, e.g., "v4", "v4-next" */
+  series: string;
+  /** Override series config (optional, will look up from SiteConfig if not provided) */
+  seriesConfig?: SeriesConfig;
 };
 
 export type ClonePackageOptions = {
@@ -72,9 +75,26 @@ export function* usePackage(options: PackageOptions): Operation<Package> {
   if (options.type === "worktree") {
     let repo = createRepo({ name: "effection", owner: "thefrontside" });
 
-    let tags = yield* repo.tags(new RegExp(`effection-${options.series}.*`));
+    // Get series config from options or look it up
+    let seriesConfig = options.seriesConfig;
+    if (!seriesConfig) {
+      let config = yield* useConfig();
+      seriesConfig = findSeries(config, options.series);
+      if (!seriesConfig) {
+        throw new Error(`unknown series: ${options.series}`);
+      }
+    }
 
-    let ref = findLatestSemverTag(tags);
+    // Fetch all tags for this major version
+    let tags = yield* repo.tags(
+      new RegExp(`effection-v${seriesConfig.major}.*`),
+    );
+
+    // Use semver range to find latest (excludes prereleases unless configured)
+    let range = `${seriesConfig.major}.x`;
+    let ref = findLatestSemverTag(tags, range, {
+      includePrerelease: seriesConfig.includePrerelease,
+    });
 
     if (!ref) {
       throw new Error(`unable to find package ref for ${options.series}`);

--- a/www/lib/semver.ts
+++ b/www/lib/semver.ts
@@ -1,6 +1,6 @@
-export { compare, major, minor, rsort } from "semver";
+export { compare, gt, major, maxSatisfying, minor, rsort } from "semver";
 
-import { rsort } from "semver";
+import { maxSatisfying, rsort } from "semver";
 
 export function extractVersion(input: string) {
   let parts = input.match(
@@ -14,14 +14,33 @@ export function extractVersion(input: string) {
   }
 }
 
+export interface FindLatestSemverTagOptions {
+  includePrerelease?: boolean;
+}
+
 /**
  * Find the latest Semver tag from an array of tags
  * @param tags - Array of tag objects with name property
+ * @param range - Optional semver range to filter tags (e.g., "4.x", ">=3.0.0")
+ * @param options - Optional settings like includePrerelease
  * @returns Latest semver tag if found, undefined otherwise
  */
 export function findLatestSemverTag<T extends { name: string }>(
   tags: T[],
+  range?: string,
+  options?: FindLatestSemverTagOptions,
 ): T | undefined {
-  let [latest] = rsort(tags.map((tag) => tag.name).map(extractVersion));
+  let versions = tags.map((tag) => tag.name).map(extractVersion);
+
+  let latest: string | undefined;
+  if (range) {
+    // Use semver range matching (excludes prereleases by default)
+    latest = maxSatisfying(versions, range, options) ?? undefined;
+  } else {
+    // Fallback to current behavior: sort all and take first
+    [latest] = rsort(versions);
+  }
+
+  if (!latest) return undefined;
   return tags.find((tag) => tag.name.endsWith(latest));
 }

--- a/www/main.tsx
+++ b/www/main.tsx
@@ -37,11 +37,16 @@ if (import.meta.main) {
   await main(function* () {
     let { current, series } = yield* useConfig();
 
+    // Get stable series (no prereleases) for guides
+    let stableSeries = series.filter((s) => !s.includePrerelease);
+
     yield* initClones("build/clones");
     yield* initWorktrees("build/worktrees");
     yield* initGuides({
       current,
-      worktrees: series.filter((s) => s !== current),
+      worktrees: stableSeries
+        .filter((s) => s.name !== current)
+        .map((s) => s.name),
     });
 
     yield* initBlog();
@@ -58,8 +63,9 @@ if (import.meta.main) {
         route("/search", searchRoute()),
         route("/docs", redirectIndexRoute(firstPage(current))),
         route("/docs/:id", redirectDocsRoute(current)),
-        ...series.map((s) =>
-          route(`/guides/${s}`, redirectIndexRoute(firstPage(s)))
+        // Guides only for stable series (no prereleases)
+        ...stableSeries.map((s) =>
+          route(`/guides/${s.name}`, redirectIndexRoute(firstPage(s.name)))
         ),
         route("/guides/:series/:id", guidesRoute({ search: true })),
         route("/contrib", xIndexRedirect()),
@@ -67,8 +73,12 @@ if (import.meta.main) {
         route("/x", xIndexRoute({ search: true })),
         route("/x/:workspacePath", xPackageRoute({ search: true })),
         route("/api", apiIndexRoute({ search: true })),
+        // API docs for all series including prereleases
         ...series.map((s) =>
-          route(`/api/${s}/:symbol`, apiReferenceRoute(s, { search: true }))
+          route(
+            `/api/${s.name}/:symbol`,
+            apiReferenceRoute(s.name, { search: true }),
+          )
         ),
         route("/blog", blogIndexRoute({ search: true })),
         route("/blog/feed.xml", blogFeedRoute()),

--- a/www/routes/api-index-route.tsx
+++ b/www/routes/api-index-route.tsx
@@ -3,7 +3,7 @@ import { type JSXElement } from "revolution";
 import { Icon } from "../components/type/icon.tsx";
 import { DocPage } from "../hooks/use-deno-doc.tsx";
 import { ResolveLinkFunction } from "../hooks/use-markdown.tsx";
-import { Package, usePackage } from "../lib/package.ts";
+import { usePackage } from "../lib/package.ts";
 import { gt } from "../lib/semver.ts";
 import { SitemapRoute } from "../plugins/sitemap.ts";
 import { useAppHtml } from "./app.html.tsx";
@@ -35,6 +35,10 @@ export function apiIndexRoute(
       // Only show prerelease link if it's newer than stable
       let showV4Prerelease = gt(v4Next.version, v4.version);
 
+      // Get first symbol for prerelease link
+      let v4NextDocs = showV4Prerelease ? yield* v4Next.docs() : null;
+      let v4NextFirstSymbol = v4NextDocs?.["."]?.[0]?.name ?? "run";
+
       let docs = {
         v3: yield* v3.docs(),
         v4: yield* v4.docs(),
@@ -52,6 +56,18 @@ export function apiIndexRoute(
             <section>
               <h3 id={v4.version} class="group scroll-mt-[200px]">
                 {v4.version}
+                {showV4Prerelease && (
+                  <span class="text-sm font-normal text-gray-500 dark:text-gray-400 ml-2">
+                    ·{" "}
+                    <a
+                      href={`/api/v4-next/${v4NextFirstSymbol}`}
+                      class="text-blue-600 dark:text-blue-400 hover:underline"
+                    >
+                      {v4Next.version}
+                    </a>{" "}
+                    also available
+                  </span>
+                )}
                 <a
                   href={`#${v4.version}`}
                   class="opacity-0 group-hover:opacity-100 after:content-['#'] after:ml-1.5 no-underline"
@@ -59,11 +75,6 @@ export function apiIndexRoute(
                   <span class="icon icon-link" />
                 </a>
               </h3>
-              {yield* PrereleaseNote({
-                show: showV4Prerelease,
-                pkg: v4Next,
-                seriesPath: "v4-next",
-              })}
               <ul class="columns-3 pl-0">
                 {yield* listPages({
                   pages: docs.v4["."],
@@ -94,36 +105,6 @@ export function apiIndexRoute(
       );
     },
   };
-}
-
-function* PrereleaseNote({
-  show,
-  pkg,
-  seriesPath,
-}: {
-  show: boolean;
-  pkg: Package;
-  seriesPath: string;
-}) {
-  if (!show) {
-    return <></>;
-  }
-
-  // Get the first symbol to link to
-  let docs = yield* pkg.docs();
-  let firstSymbol = docs["."]?.[0]?.name ?? "run";
-
-  return (
-    <p class="text-sm text-gray-500 dark:text-gray-400 mt-1 mb-3">
-      Also available:{" "}
-      <a
-        href={`/api/${seriesPath}/${firstSymbol}`}
-        class="text-blue-600 dark:text-blue-400 hover:underline"
-      >
-        {pkg.version}
-      </a>
-    </p>
-  );
 }
 
 function* listPages({

--- a/www/routes/api-index-route.tsx
+++ b/www/routes/api-index-route.tsx
@@ -3,7 +3,8 @@ import { type JSXElement } from "revolution";
 import { Icon } from "../components/type/icon.tsx";
 import { DocPage } from "../hooks/use-deno-doc.tsx";
 import { ResolveLinkFunction } from "../hooks/use-markdown.tsx";
-import { usePackage } from "../lib/package.ts";
+import { Package, usePackage } from "../lib/package.ts";
+import { gt } from "../lib/semver.ts";
 import { SitemapRoute } from "../plugins/sitemap.ts";
 import { useAppHtml } from "./app.html.tsx";
 import { createChildURL } from "../lib/links-resolvers.ts";
@@ -25,6 +26,14 @@ export function apiIndexRoute(
         type: "worktree",
         series: "v4",
       });
+
+      let v4Next = yield* usePackage({
+        type: "worktree",
+        series: "v4-next",
+      });
+
+      // Only show prerelease link if it's newer than stable
+      let showV4Prerelease = gt(v4Next.version, v4.version);
 
       let docs = {
         v3: yield* v3.docs(),
@@ -50,6 +59,11 @@ export function apiIndexRoute(
                   <span class="icon icon-link" />
                 </a>
               </h3>
+              {yield* PrereleaseNote({
+                show: showV4Prerelease,
+                pkg: v4Next,
+                seriesPath: "v4-next",
+              })}
               <ul class="columns-3 pl-0">
                 {yield* listPages({
                   pages: docs.v4["."],
@@ -80,6 +94,36 @@ export function apiIndexRoute(
       );
     },
   };
+}
+
+function* PrereleaseNote({
+  show,
+  pkg,
+  seriesPath,
+}: {
+  show: boolean;
+  pkg: Package;
+  seriesPath: string;
+}) {
+  if (!show) {
+    return <></>;
+  }
+
+  // Get the first symbol to link to
+  let docs = yield* pkg.docs();
+  let firstSymbol = docs["."]?.[0]?.name ?? "run";
+
+  return (
+    <p class="text-sm text-gray-500 dark:text-gray-400 mt-1 mb-3">
+      Also available:{" "}
+      <a
+        href={`/api/${seriesPath}/${firstSymbol}`}
+        class="text-blue-600 dark:text-blue-400 hover:underline"
+      >
+        {pkg.version}
+      </a>
+    </p>
+  );
 }
 
 function* listPages({

--- a/www/routes/api-reference-route.tsx
+++ b/www/routes/api-reference-route.tsx
@@ -6,9 +6,8 @@ import { useAppHtml } from "./app.html.tsx";
 import { ApiPage } from "../components/api/api-page.tsx";
 import { usePackage } from "../lib/package.ts";
 import { createSibling } from "../lib/links-resolvers.ts";
-import { SiteConfig } from "../context/config.ts";
 
-export function apiReferenceRoute(series: SiteConfig["series"][number], {
+export function apiReferenceRoute(series: string, {
   search,
 }: {
   search: boolean;

--- a/www/routes/guides-route.tsx
+++ b/www/routes/guides-route.tsx
@@ -30,15 +30,17 @@ export function guidesRoute({
 }): SitemapRoute<JSXElement> {
   return {
     *routemap(pathname) {
-      let { series: SERIES } = yield* useConfig();
-      let paths = SERIES.map(function* (series) {
+      let { series } = yield* useConfig();
+      // Only stable series have guides (no prereleases)
+      let stableSeries = series.filter((s) => !s.includePrerelease);
+      let paths = stableSeries.map(function* (s) {
         let paths: RoutePath[] = [];
 
-        let pages = yield* useGuides(series);
+        let pages = yield* useGuides(s.name);
 
         for (let page of yield* pages.all()) {
           paths.push({
-            pathname: pathname({ id: page.id, series }),
+            pathname: pathname({ id: page.id, series: s.name }),
           });
         }
         return paths;
@@ -46,7 +48,9 @@ export function guidesRoute({
       return (yield* all(paths)).flat();
     },
     *handler(req) {
-      let { series: SERIES, current } = yield* useConfig();
+      let { series: allSeries, current } = yield* useConfig();
+      // Only stable series have guides (no prereleases)
+      let stableSeries = allSeries.filter((s) => !s.includePrerelease);
 
       let { id, series = current } = yield* useParams<{
         id: string | undefined;
@@ -114,21 +118,21 @@ export function guidesRoute({
       }
 
       let versionToggle = yield* all(
-        SERIES.map(function* (s) {
-          let target = yield* useGuides(s);
+        stableSeries.map(function* (s) {
+          let target = yield* useGuides(s.name);
           let targetPage = yield* target.get(page.id);
-          let base = current === s ? "docs" : `guides/${s}`;
+          let base = current === s.name ? "docs" : `guides/${s.name}`;
           let url = yield* createRootUrl(base)(targetPage ? page.id : "/");
           return (
             <a
               href={url}
               class={`text-base ${
-                s === series
+                s.name === series
                   ? "font-bold text-sky-500"
                   : "text-gray-600 dark:text-gray-400 hover:text-sky-500"
               }`}
             >
-              {s}
+              {s.name}
             </a>
           );
         }),


### PR DESCRIPTION
# Motivation

When switching from v3 to v4 as the current stable series, the semver matching query was not updated. The regex pattern `effection-v4.*` matches all v4 tags including alpha releases (e.g., `4.1.0-alpha.5`), causing the API reference to show the alpha version instead of the stable release (`4.0.2`).

Additionally, users on the bleeding edge had no way to access API documentation for prerelease versions.

# Approach

## Semantic Version Matching

Replace regex-based tag matching with proper semver range matching using the `semver` library's `maxSatisfying()` function:

- **Before**: `new RegExp(/`effection-v4.*/`)` → matches all including prereleases
- **After**: `maxSatisfying(versions, "4.x")` → excludes prereleases by default (per semver spec)

## Series Configuration

Introduce `SeriesConfig` to distinguish stable from prerelease series:

```typescript
interface SeriesConfig {
  name: string;           // "v4", "v4-next"
  major: number;          // 4
  includePrerelease?: boolean;
  parent?: string;        // For grouping
}
```

Default config now includes:
- `v3` (stable)
- `v4` (stable)
- `v4-next` (prerelease, parent: v4)

## Prerelease Documentation

For bleeding edge users, the API index now shows an "Also available" link when a prerelease version exists that is newer than stable:

- Full API docs generated at `/api/v4-next/:symbol`
- Link only appears when `gt(v4Next.version, v4.version)` is true
- Disappears automatically when stable catches up

## Files Changed

| File | Change |
|------|--------|
| `lib/semver.ts` | Add `maxSatisfying`, `gt` exports; add `range` and `options` params to `findLatestSemverTag` |
| `context/config.ts` | Add `SeriesConfig` interface; add `findSeries` and `getChildSeries` helpers |
| `lib/package.ts` | Use series config for semver range; pass `includePrerelease` option |
| `main.tsx` | Filter to stable series for guides; use series names for routes |
| `routes/api-index-route.tsx` | Fetch prerelease; conditionally show "Also available" link |
| `routes/api-reference-route.tsx` | Simplify series parameter to string |
| `routes/guides-route.tsx` | Filter to stable series for guides |
| `components/api/api-page.tsx` | Filter to stable series for version toggle |