### PR TITLE
💄 Fix dark mode hover contrast in API side menu

### DIFF
--- a/www/components/api/api-page.tsx
+++ b/www/components/api/api-page.tsx
@@ -227,7 +227,7 @@ function* Menu({
           )
           : (
             <a
-              class="rounded px-2 block w-full py-2 hover:bg-gray-100"
+              class="rounded px-2 block w-full py-2 hover:bg-gray-100 dark:hover:bg-gray-800"
               href={yield* linkResolver(page.name)}
             >
               <Icon kind={page.kind} />


### PR DESCRIPTION
# Motivation

In dark mode, the API side menu links have poor contrast on hover. The `hover:bg-gray-100` class creates a very light gray background that clashes with the dark theme.

# Approach

Add `dark:hover:bg-gray-800` to the menu link hover state, matching the pattern already used in the guides sidebar.

**Before:** `hover:bg-gray-100` (light gray hover in both modes - poor contrast in dark mode)
**After:** `hover:bg-gray-100 dark:hover:bg-gray-800` (appropriate contrast in both modes)

## Visual Change

| Mode | Before | After |
|------|--------|-------|
| Light | Light gray hover | Light gray hover (unchanged) |
| Dark | Light gray hover (poor contrast) | Dark gray hover (good contrast) |

The fix ensures hover states in the sidebar navigation are clearly visible in dark mode, improving accessibility and user experience.