### PR TITLE
🤖 Require braces on if statements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -372,6 +372,10 @@ for (const item of yield * each(stream(asyncIterable))) {
 - After resolve/reject, yielding the `operation` always produces the same
   outcome; calling resolve/reject again has no effect.
 
+## Code style
+
+- Always use braces for `if` statements. No bare/braceless `if` blocks.
+
 ## Commit and PR conventions
 
 Use [gitmoji](https://gitmoji.dev) for commit and pull request subjects. For


### PR DESCRIPTION
## Motivation

Bare/braceless `if` statements reduce readability and are prone to bugs when
additional statements are added later. The [Heartbleed vulnerability](https://dwheeler.com/essays/heartbleed.html#goto-fail) in Apple's SSL implementation (goto fail) is a famous example of how a missing brace led to a critical security flaw.

## Approach

Added a "Code style" section to `AGENTS.md` with the rule.