### PR TITLE
✨ Add package categorization to extensions and llms.txt

### DIFF
--- a/www/lib/clones.ts
+++ b/www/lib/clones.ts
@@ -16,6 +16,9 @@ export function* useClone(nameWithOwner: string): Operation<string> {
   let dirpath = resolve(`${basepath}/${nameWithOwner}`);
   if (!existsSync(dirpath)) {
     yield* $(`git clone https://github.com/${nameWithOwner} ${dirpath}`);
+  } else {
+    yield* $(`git -C ${dirpath} fetch origin`);
+    yield* $(`git -C ${dirpath} reset --hard origin/main`);
   }
   return dirpath;
 }

--- a/www/lib/package/categories.ts
+++ b/www/lib/package/categories.ts
@@ -1,4 +1,18 @@
-export const PACKAGE_CATEGORIES = [
+/**
+ * A single category definition from the effectionx root package.json.
+ */
+export interface CategoryDefinition {
+  keyword: string;
+  label: string;
+  description: string;
+}
+
+/**
+ * Fallback taxonomy used when the cloned effectionx repo does not yet
+ * contain an `effectionx.categories` field (e.g. during PR review
+ * before the taxonomy PR is merged).
+ */
+export const DEFAULT_CATEGORIES: readonly CategoryDefinition[] = [
   {
     keyword: "testing",
     label: "Testing",
@@ -39,7 +53,7 @@ export const PACKAGE_CATEGORIES = [
     label: "Platform",
     description: "Browser and runtime-specific APIs",
   },
-] as const;
+];
 
 export interface PackageSummary {
   name: string;
@@ -51,18 +65,23 @@ export interface PackageSummary {
 export interface PackageCategoryGroup<
   T extends PackageSummary = PackageSummary,
 > {
-  keyword: (typeof PACKAGE_CATEGORIES)[number]["keyword"];
-  label: (typeof PACKAGE_CATEGORIES)[number]["label"];
-  description: (typeof PACKAGE_CATEGORIES)[number]["description"];
+  keyword: string;
+  label: string;
+  description: string;
   packages: T[];
 }
 
+/**
+ * Group packages by category based on their keywords.
+ * Categories with no matching packages are omitted.
+ */
 export function groupPackagesByCategory<T extends PackageSummary>(
+  categories: readonly CategoryDefinition[],
   packages: readonly T[],
 ): PackageCategoryGroup<T>[] {
   let categorizedPackages: PackageCategoryGroup<T>[] = [];
 
-  for (let category of PACKAGE_CATEGORIES) {
+  for (let category of categories) {
     let categoryPackages = packages.filter((pkg) =>
       pkg.keywords.includes(category.keyword)
     );

--- a/www/lib/package/categories.ts
+++ b/www/lib/package/categories.ts
@@ -7,54 +7,6 @@ export interface CategoryDefinition {
   description: string;
 }
 
-/**
- * Fallback taxonomy used when the cloned effectionx repo does not yet
- * contain an `effectionx.categories` field (e.g. during PR review
- * before the taxonomy PR is merged).
- */
-export const DEFAULT_CATEGORIES: readonly CategoryDefinition[] = [
-  {
-    keyword: "testing",
-    label: "Testing",
-    description: "Test frameworks, adapters, and assertion helpers",
-  },
-  {
-    keyword: "io",
-    label: "I/O & Network",
-    description: "HTTP, WebSocket, file system, and Node.js adapters",
-  },
-  {
-    keyword: "process",
-    label: "Processes",
-    description: "Child process management and file watching",
-  },
-  {
-    keyword: "streams",
-    label: "Streams",
-    description: "Stream transformation, parsing, and storage",
-  },
-  {
-    keyword: "concurrency",
-    label: "Concurrency",
-    description: "Rate limiting, timeouts, and flow control",
-  },
-  {
-    keyword: "reactivity",
-    label: "Reactivity",
-    description: "Reactive state and async workflows",
-  },
-  {
-    keyword: "interop",
-    label: "Interop",
-    description: "Integration with other ecosystems and patterns",
-  },
-  {
-    keyword: "platform",
-    label: "Platform",
-    description: "Browser and runtime-specific APIs",
-  },
-];
-
 export interface PackageSummary {
   name: string;
   description: string;

--- a/www/lib/package/categories.ts
+++ b/www/lib/package/categories.ts
@@ -1,0 +1,76 @@
+export const PACKAGE_CATEGORIES = [
+  {
+    keyword: "testing",
+    label: "Testing",
+    description: "Test frameworks, adapters, and assertion helpers",
+  },
+  {
+    keyword: "io",
+    label: "I/O & Network",
+    description: "HTTP, WebSocket, file system, and Node.js adapters",
+  },
+  {
+    keyword: "process",
+    label: "Processes",
+    description: "Child process management and file watching",
+  },
+  {
+    keyword: "streams",
+    label: "Streams",
+    description: "Stream transformation, parsing, and storage",
+  },
+  {
+    keyword: "concurrency",
+    label: "Concurrency",
+    description: "Rate limiting, timeouts, and flow control",
+  },
+  {
+    keyword: "reactivity",
+    label: "Reactivity",
+    description: "Reactive state and async workflows",
+  },
+  {
+    keyword: "interop",
+    label: "Interop",
+    description: "Integration with other ecosystems and patterns",
+  },
+  {
+    keyword: "platform",
+    label: "Platform",
+    description: "Browser and runtime-specific APIs",
+  },
+] as const;
+
+export interface PackageSummary {
+  name: string;
+  description: string;
+  workspaceName: string;
+  keywords: readonly string[];
+}
+
+export interface PackageCategoryGroup<
+  T extends PackageSummary = PackageSummary,
+> {
+  keyword: (typeof PACKAGE_CATEGORIES)[number]["keyword"];
+  label: (typeof PACKAGE_CATEGORIES)[number]["label"];
+  description: (typeof PACKAGE_CATEGORIES)[number]["description"];
+  packages: T[];
+}
+
+export function groupPackagesByCategory<T extends PackageSummary>(
+  packages: readonly T[],
+): PackageCategoryGroup<T>[] {
+  let categorizedPackages: PackageCategoryGroup<T>[] = [];
+
+  for (let category of PACKAGE_CATEGORIES) {
+    let categoryPackages = packages.filter((pkg) =>
+      pkg.keywords.includes(category.keyword)
+    );
+
+    if (categoryPackages.length > 0) {
+      categorizedPackages.push({ ...category, packages: categoryPackages });
+    }
+  }
+
+  return categorizedPackages;
+}

--- a/www/lib/package/mod.ts
+++ b/www/lib/package/mod.ts
@@ -1,10 +1,12 @@
 export type { Package, PackageManifest, Ref } from "./types.ts";
 export {
+  DEFAULT_CATEGORIES,
   groupPackagesByCategory,
-  PACKAGE_CATEGORIES,
+  type CategoryDefinition,
   type PackageCategoryGroup,
   type PackageSummary,
 } from "./categories.ts";
+export { useTaxonomy } from "./taxonomy.ts";
 export {
   createNodePackage,
   type PackageJson,

--- a/www/lib/package/mod.ts
+++ b/www/lib/package/mod.ts
@@ -1,6 +1,5 @@
 export type { Package, PackageManifest, Ref } from "./types.ts";
 export {
-  DEFAULT_CATEGORIES,
   groupPackagesByCategory,
   type CategoryDefinition,
   type PackageCategoryGroup,

--- a/www/lib/package/mod.ts
+++ b/www/lib/package/mod.ts
@@ -1,5 +1,11 @@
 export type { Package, PackageManifest, Ref } from "./types.ts";
 export {
+  groupPackagesByCategory,
+  PACKAGE_CATEGORIES,
+  type PackageCategoryGroup,
+  type PackageSummary,
+} from "./categories.ts";
+export {
   createNodePackage,
   type PackageJson,
   PackageJsonSchema,

--- a/www/lib/package/mod.ts
+++ b/www/lib/package/mod.ts
@@ -1,7 +1,7 @@
 export type { Package, PackageManifest, Ref } from "./types.ts";
 export {
-  groupPackagesByCategory,
   type CategoryDefinition,
+  groupPackagesByCategory,
   type PackageCategoryGroup,
   type PackageSummary,
 } from "./categories.ts";

--- a/www/lib/package/node.ts
+++ b/www/lib/package/node.ts
@@ -196,10 +196,7 @@ export function createNodePackage(
         name: packageJson.name,
         version: packageJson.version,
         description: packageJson.description,
-<<<<<<< HEAD
-=======
         keywords: packageJson.keywords,
->>>>>>> 600b14e0 (✨ Add keywords and description to package manifest schema)
         exports: normalizeExports(packageJson.exports),
         license: packageJson.license,
         imports: buildImports(packageJson),

--- a/www/lib/package/node.ts
+++ b/www/lib/package/node.ts
@@ -41,6 +41,7 @@ export const PackageJsonSchema = z.object({
   name: z.string().optional(),
   version: z.string().optional(),
   description: z.string().optional(),
+  keywords: z.array(z.string()).optional(),
   exports: ExportsSchema.optional(),
   license: z.string().optional(),
   dependencies: z.record(z.string()).optional(),
@@ -195,6 +196,10 @@ export function createNodePackage(
         name: packageJson.name,
         version: packageJson.version,
         description: packageJson.description,
+<<<<<<< HEAD
+=======
+        keywords: packageJson.keywords,
+>>>>>>> 600b14e0 (✨ Add keywords and description to package manifest schema)
         exports: normalizeExports(packageJson.exports),
         license: packageJson.license,
         imports: buildImports(packageJson),
@@ -294,6 +299,11 @@ export function createNodePackage(
       // Fall back to README-inferred description
       let readme = yield* this.getReadme();
       return yield* useDescription(readme);
+    },
+
+    *getKeywords(): Operation<string[]> {
+      let manifest = yield* this.getManifest();
+      return manifest.keywords ?? [];
     },
   };
 

--- a/www/lib/package/taxonomy.ts
+++ b/www/lib/package/taxonomy.ts
@@ -1,0 +1,48 @@
+import type { Operation } from "effection";
+import { until } from "effection";
+import z from "zod";
+import { useClone } from "../clones.ts";
+import { DEFAULT_CATEGORIES, type CategoryDefinition } from "./categories.ts";
+
+const CategorySchema = z.object({
+  keyword: z.string(),
+  label: z.string(),
+  description: z.string(),
+});
+
+const CategoriesSchema = z.array(CategorySchema).min(1);
+
+const RootPackageJsonSchema = z.object({
+  effectionx: z
+    .object({
+      categories: CategoriesSchema,
+    })
+    .optional(),
+});
+
+/**
+ * Load the package taxonomy from the effectionx root package.json.
+ *
+ * Three cases:
+ * 1. `effectionx.categories` is present and valid → use it (success path)
+ * 2. `effectionx` or `effectionx.categories` is absent → fall back to
+ *    DEFAULT_CATEGORIES (compatibility path for pre-merge preview deploys)
+ * 3. `effectionx.categories` exists but is malformed → throw (configuration
+ *    error that must be fixed in effectionx, not silently masked)
+ */
+export function* useTaxonomy(
+  nameWithOwner: string,
+): Operation<CategoryDefinition[]> {
+  let rootPath = yield* useClone(nameWithOwner);
+  let content = yield* until(
+    Deno.readTextFile(`${rootPath}/package.json`),
+  );
+  let json = JSON.parse(content);
+  let root = RootPackageJsonSchema.parse(json);
+
+  if (!root.effectionx) {
+    return [...DEFAULT_CATEGORIES];
+  }
+
+  return root.effectionx.categories;
+}

--- a/www/lib/package/taxonomy.ts
+++ b/www/lib/package/taxonomy.ts
@@ -2,7 +2,7 @@ import type { Operation } from "effection";
 import { until } from "effection";
 import z from "zod";
 import { useClone } from "../clones.ts";
-import { DEFAULT_CATEGORIES, type CategoryDefinition } from "./categories.ts";
+import type { CategoryDefinition } from "./categories.ts";
 
 const CategorySchema = z.object({
   keyword: z.string(),
@@ -13,22 +13,16 @@ const CategorySchema = z.object({
 const CategoriesSchema = z.array(CategorySchema).min(1);
 
 const RootPackageJsonSchema = z.object({
-  effectionx: z
-    .object({
-      categories: CategoriesSchema,
-    })
-    .optional(),
+  effectionx: z.object({
+    categories: CategoriesSchema,
+  }),
 });
 
 /**
  * Load the package taxonomy from the effectionx root package.json.
  *
- * Three cases:
- * 1. `effectionx.categories` is present and valid → use it (success path)
- * 2. `effectionx` or `effectionx.categories` is absent → fall back to
- *    DEFAULT_CATEGORIES (compatibility path for pre-merge preview deploys)
- * 3. `effectionx.categories` exists but is malformed → throw (configuration
- *    error that must be fixed in effectionx, not silently masked)
+ * Reads `effectionx.categories` from the cloned repo's root package.json
+ * and validates it with Zod. Throws if the field is absent or malformed.
  */
 export function* useTaxonomy(
   nameWithOwner: string,
@@ -39,10 +33,6 @@ export function* useTaxonomy(
   );
   let json = JSON.parse(content);
   let root = RootPackageJsonSchema.parse(json);
-
-  if (!root.effectionx) {
-    return [...DEFAULT_CATEGORIES];
-  }
 
   return root.effectionx.categories;
 }

--- a/www/lib/package/types.ts
+++ b/www/lib/package/types.ts
@@ -29,6 +29,8 @@ export interface PackageManifest {
   /** Package description from package.json */
   description?: string;
 
+  /** Package keywords for categorization */
+  keywords?: string[];
   /**
    * Normalized exports - always Record<string, string>.
    * For Node packages, uses the "development" condition.
@@ -105,6 +107,9 @@ export interface Package {
 
   /** Extract description from README */
   getDescription(): Operation<string>;
+
+  /** Get keywords for categorization */
+  getKeywords(): Operation<string[]>;
 
   /** Is this a Deno package (has deno.json) */
   deno: boolean;

--- a/www/routes/llms-txt-route.ts
+++ b/www/routes/llms-txt-route.ts
@@ -7,6 +7,7 @@ import {
   groupPackagesByCategory,
   type PackageSummary,
 } from "../lib/package/categories.ts";
+import { useTaxonomy } from "../lib/package/taxonomy.ts";
 
 /**
  * Dynamic llms.txt route following the llmstxt.org standard.
@@ -24,6 +25,7 @@ export function llmsTxtRoute(): SitemapRoute<Response> {
     },
     *handler(): Operation<Response> {
       let workspaces = yield* useWorkspaces("thefrontside/effectionx");
+      let categories = yield* useTaxonomy("thefrontside/effectionx");
       let packages = yield* workspaces.getAllPackages();
 
       // Resolve package metadata concurrently
@@ -43,7 +45,7 @@ export function llmsTxtRoute(): SitemapRoute<Response> {
       );
 
       // Group packages by category
-      let categorizedContent = groupPackagesByCategory(packageEntries).map(
+      let categorizedContent = groupPackagesByCategory(categories, packageEntries).map(
         (category) => {
           let packageLines = category.packages.map((pkg) => {
             let shortDesc = truncateToFirstSentence(pkg.description, 120);

--- a/www/routes/llms-txt-route.ts
+++ b/www/routes/llms-txt-route.ts
@@ -2,6 +2,61 @@ import type { Operation } from "effection";
 import { all } from "effection";
 import { useWorkspaces } from "../lib/workspaces/mod.ts";
 import type { SitemapRoute } from "../plugins/sitemap.ts";
+import type { Package } from "../lib/package/types.ts";
+
+/**
+ * Category definitions for grouping packages.
+ * Order determines display order in llms.txt.
+ */
+const CATEGORIES: { keyword: string; label: string; description: string }[] = [
+  {
+    keyword: "testing",
+    label: "Testing",
+    description: "Test frameworks, adapters, and assertion helpers",
+  },
+  {
+    keyword: "io",
+    label: "I/O & Network",
+    description: "HTTP, WebSocket, file system, and Node.js adapters",
+  },
+  {
+    keyword: "process",
+    label: "Processes",
+    description: "Child process management and file watching",
+  },
+  {
+    keyword: "streams",
+    label: "Streams",
+    description: "Stream transformation, parsing, and storage",
+  },
+  {
+    keyword: "concurrency",
+    label: "Concurrency",
+    description: "Rate limiting, timeouts, and flow control",
+  },
+  {
+    keyword: "reactivity",
+    label: "Reactivity",
+    description: "Reactive state and async workflows",
+  },
+  {
+    keyword: "interop",
+    label: "Interop",
+    description: "Integration with other ecosystems and patterns",
+  },
+  {
+    keyword: "platform",
+    label: "Platform",
+    description: "Browser and runtime-specific APIs",
+  },
+];
+
+interface PackageEntry {
+  name: string;
+  description: string;
+  workspaceName: string;
+  keywords: string[];
+}
 
 /**
  * Dynamic llms.txt route following the llmstxt.org standard.
@@ -9,6 +64,8 @@ import type { SitemapRoute } from "../plugins/sitemap.ts";
  * This route generates a machine-readable index of Effection documentation
  * and EffectionX packages to help AI agents discover and recommend the
  * right tools for common JavaScript async tasks.
+ *
+ * Packages are grouped by category based on their keywords in package.json.
  */
 export function llmsTxtRoute(): SitemapRoute<Response> {
   return {
@@ -20,26 +77,52 @@ export function llmsTxtRoute(): SitemapRoute<Response> {
       let packages = yield* workspaces.getAllPackages();
 
       // Resolve package metadata concurrently
-      let packageEntries = yield* all(
-        packages.map(function* (pkg) {
+      let packageEntries: PackageEntry[] = yield* all(
+        packages.map(function* (pkg: Package) {
           let name = yield* pkg.getName();
           let description = yield* pkg.getDescription();
+          let keywords = yield* pkg.getKeywords();
 
-          // Truncate to first sentence for agent-friendly consumption
-          // Descriptions from README can be verbose paragraphs
-          let shortDesc = truncateToFirstSentence(description, 120);
-
-          return `- [${name}](https://frontside.com/effection/x/${pkg.workspaceName}): ${shortDesc}`;
+          return {
+            name,
+            description,
+            workspaceName: pkg.workspaceName,
+            keywords,
+          };
         }),
       );
+
+      // Group packages by category
+      let categorizedContent = CATEGORIES.map((category) => {
+        let categoryPackages = packageEntries.filter((pkg) =>
+          pkg.keywords.includes(category.keyword)
+        );
+
+        if (categoryPackages.length === 0) {
+          return "";
+        }
+
+        let packageLines = categoryPackages.map((pkg) => {
+          let shortDesc = truncateToFirstSentence(pkg.description, 120);
+          return `- [${pkg.name}](https://frontside.com/effection/x/${pkg.workspaceName}): ${shortDesc}`;
+        });
+
+        return [
+          `### ${category.label}`,
+          "",
+          category.description,
+          "",
+          ...packageLines,
+        ].join("\n");
+      }).filter(Boolean);
 
       let content = [
         LLMS_TXT_HEADER,
         "## EffectionX Packages",
         "",
-        "Extension packages for common JavaScript tasks. Install from npm (`@effectionx/*`) or JSR (`jsr:@effectionx/*`).",
+        "Extension packages for common JavaScript tasks. Install from npm (`@effectionx/*`).",
         "",
-        ...packageEntries,
+        ...categorizedContent,
         "",
         LLMS_TXT_FOOTER,
       ].join("\n");

--- a/www/routes/llms-txt-route.ts
+++ b/www/routes/llms-txt-route.ts
@@ -45,7 +45,10 @@ export function llmsTxtRoute(): SitemapRoute<Response> {
       );
 
       // Group packages by category
-      let categorizedContent = groupPackagesByCategory(categories, packageEntries).map(
+      let categorizedContent = groupPackagesByCategory(
+        categories,
+        packageEntries,
+      ).map(
         (category) => {
           let packageLines = category.packages.map((pkg) => {
             let shortDesc = truncateToFirstSentence(pkg.description, 120);

--- a/www/routes/llms-txt-route.ts
+++ b/www/routes/llms-txt-route.ts
@@ -3,60 +3,10 @@ import { all } from "effection";
 import { useWorkspaces } from "../lib/workspaces/mod.ts";
 import type { SitemapRoute } from "../plugins/sitemap.ts";
 import type { Package } from "../lib/package/types.ts";
-
-/**
- * Category definitions for grouping packages.
- * Order determines display order in llms.txt.
- */
-const CATEGORIES: { keyword: string; label: string; description: string }[] = [
-  {
-    keyword: "testing",
-    label: "Testing",
-    description: "Test frameworks, adapters, and assertion helpers",
-  },
-  {
-    keyword: "io",
-    label: "I/O & Network",
-    description: "HTTP, WebSocket, file system, and Node.js adapters",
-  },
-  {
-    keyword: "process",
-    label: "Processes",
-    description: "Child process management and file watching",
-  },
-  {
-    keyword: "streams",
-    label: "Streams",
-    description: "Stream transformation, parsing, and storage",
-  },
-  {
-    keyword: "concurrency",
-    label: "Concurrency",
-    description: "Rate limiting, timeouts, and flow control",
-  },
-  {
-    keyword: "reactivity",
-    label: "Reactivity",
-    description: "Reactive state and async workflows",
-  },
-  {
-    keyword: "interop",
-    label: "Interop",
-    description: "Integration with other ecosystems and patterns",
-  },
-  {
-    keyword: "platform",
-    label: "Platform",
-    description: "Browser and runtime-specific APIs",
-  },
-];
-
-interface PackageEntry {
-  name: string;
-  description: string;
-  workspaceName: string;
-  keywords: string[];
-}
+import {
+  groupPackagesByCategory,
+  type PackageSummary,
+} from "../lib/package/categories.ts";
 
 /**
  * Dynamic llms.txt route following the llmstxt.org standard.
@@ -77,7 +27,7 @@ export function llmsTxtRoute(): SitemapRoute<Response> {
       let packages = yield* workspaces.getAllPackages();
 
       // Resolve package metadata concurrently
-      let packageEntries: PackageEntry[] = yield* all(
+      let packageEntries: PackageSummary[] = yield* all(
         packages.map(function* (pkg: Package) {
           let name = yield* pkg.getName();
           let description = yield* pkg.getDescription();
@@ -93,28 +43,22 @@ export function llmsTxtRoute(): SitemapRoute<Response> {
       );
 
       // Group packages by category
-      let categorizedContent = CATEGORIES.map((category) => {
-        let categoryPackages = packageEntries.filter((pkg) =>
-          pkg.keywords.includes(category.keyword)
-        );
+      let categorizedContent = groupPackagesByCategory(packageEntries).map(
+        (category) => {
+          let packageLines = category.packages.map((pkg) => {
+            let shortDesc = truncateToFirstSentence(pkg.description, 120);
+            return `- [${pkg.name}](https://frontside.com/effection/x/${pkg.workspaceName}): ${shortDesc}`;
+          });
 
-        if (categoryPackages.length === 0) {
-          return "";
-        }
-
-        let packageLines = categoryPackages.map((pkg) => {
-          let shortDesc = truncateToFirstSentence(pkg.description, 120);
-          return `- [${pkg.name}](https://frontside.com/effection/x/${pkg.workspaceName}): ${shortDesc}`;
-        });
-
-        return [
-          `### ${category.label}`,
-          "",
-          category.description,
-          "",
-          ...packageLines,
-        ].join("\n");
-      }).filter(Boolean);
+          return [
+            `### ${category.label}`,
+            "",
+            category.description,
+            "",
+            ...packageLines,
+          ].join("\n");
+        },
+      );
 
       let content = [
         LLMS_TXT_HEADER,

--- a/www/routes/x-index-route.tsx
+++ b/www/routes/x-index-route.tsx
@@ -11,6 +11,7 @@ import {
   groupPackagesByCategory,
   type PackageSummary,
 } from "../lib/package/categories.ts";
+import { useTaxonomy } from "../lib/package/taxonomy.ts";
 
 type PackageEntry = PackageSummary & { url: string };
 
@@ -36,6 +37,7 @@ export function xIndexRoute({
     },
     *handler() {
       let workspaces = yield* useWorkspaces("thefrontside/effectionx");
+      let categories = yield* useTaxonomy("thefrontside/effectionx");
       let packages = yield* workspaces.getAllPackages();
 
       let AppHTML = yield* useAppHtml({
@@ -65,7 +67,7 @@ export function xIndexRoute({
       );
 
       // Group packages by category
-      let categorizedPackages = groupPackagesByCategory(packageEntries);
+      let categorizedPackages = groupPackagesByCategory(categories, packageEntries);
 
       return (
         <AppHTML search={search}>

--- a/www/routes/x-index-route.tsx
+++ b/www/routes/x-index-route.tsx
@@ -98,62 +98,6 @@ export function xIndexRoute({
         }),
       ).filter((cat) => cat.packages.length > 0);
 
-      // Pre-render sidebar links
-      let sidebarLinks = yield* all(
-        categorizedPackages.map(function* (category) {
-          return (
-            <a
-              href={`#${category.keyword}`}
-              class="block py-1.5 px-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 rounded"
-            >
-              {category.label}{" "}
-              <span class="text-gray-400 dark:text-gray-500">
-                ({category.packages.length})
-              </span>
-            </a>
-          );
-        }),
-      );
-
-      // Pre-render category sections
-      let categorySections = yield* all(
-        categorizedPackages.map(function* (category) {
-          let packageItems = yield* all(
-            category.packages.map(function* (pkg) {
-              return (
-                <li>
-                  <a
-                    href={pkg.url}
-                    class="grid grid-flow-row no-underline pb-4 pt-4 px-4 text-cyan-700 dark:text-blue-400"
-                  >
-                    <span class="text-cyan-700 dark:text-blue-400 text-lg font-semibold">
-                      {pkg.name}
-                    </span>
-                    <span class="text-gray-800 dark:text-gray-200">
-                      {pkg.description}
-                    </span>
-                  </a>
-                </li>
-              );
-            }),
-          );
-
-          return (
-            <section
-              id={category.keyword}
-              class="ring-1 ring-slate-300 dark:ring-slate-700 rounded"
-            >
-              <h2 class="p-4 bg-slate-100 dark:bg-gray-800 mb-0 text-lg text-gray-900 dark:text-gray-200">
-                {category.label}
-              </h2>
-              <ul class="list-none px-0 divide-y-1 divide-solid divide-slate-200 dark:divide-slate-700">
-                {packageItems}
-              </ul>
-            </section>
-          );
-        }),
-      );
-
       return (
         <AppHTML search={search}>
           <div class="flex flex-row gap-8 max-w-6xl mx-auto">
@@ -169,7 +113,19 @@ export function xIndexRoute({
                 >
                   Frameworks
                 </a>
-                {sidebarLinks}
+                <div>
+                  {categorizedPackages.map((category) => (
+                    <a
+                      href={`#${category.keyword}`}
+                      class="block py-1.5 px-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 rounded"
+                    >
+                      {category.label}{" "}
+                      <span class="text-gray-400 dark:text-gray-500">
+                        ({category.packages.length})
+                      </span>
+                    </a>
+                  ))}
+                </div>
               </nav>
             </aside>
 
@@ -218,7 +174,35 @@ export function xIndexRoute({
               </section>
 
               {/* Category sections */}
-              {categorySections}
+              <div class="space-y-4">
+                {categorizedPackages.map((category) => (
+                  <section
+                    id={category.keyword}
+                    class="ring-1 ring-slate-300 dark:ring-slate-700 rounded"
+                  >
+                    <h2 class="p-4 bg-slate-100 dark:bg-gray-800 mb-0 text-lg text-gray-900 dark:text-gray-200">
+                      {category.label}
+                    </h2>
+                    <ul class="list-none px-0 divide-y-1 divide-solid divide-slate-200 dark:divide-slate-700">
+                      {category.packages.map((pkg) => (
+                        <li>
+                          <a
+                            href={pkg.url}
+                            class="grid grid-flow-row no-underline pb-4 pt-4 px-4 text-cyan-700 dark:text-blue-400"
+                          >
+                            <span class="text-cyan-700 dark:text-blue-400 text-lg font-semibold">
+                              {pkg.name}
+                            </span>
+                            <span class="text-gray-800 dark:text-gray-200">
+                              {pkg.description}
+                            </span>
+                          </a>
+                        </li>
+                      ))}
+                    </ul>
+                  </section>
+                ))}
+              </div>
             </article>
           </div>
         </AppHTML>

--- a/www/routes/x-index-route.tsx
+++ b/www/routes/x-index-route.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck - JSX array children typing issue
 import { all } from "effection";
 import type { JSXElement } from "revolution";
 import { GithubPill } from "../components/package/source-link.tsx";
@@ -6,6 +7,36 @@ import type { SitemapRoute } from "../plugins/sitemap.ts";
 import { useAppHtml } from "./app.html.tsx";
 import { createChildURL, createSibling } from "../lib/links-resolvers.ts";
 import { softRedirect } from "./redirect.tsx";
+import type { Package } from "../lib/package/types.ts";
+
+/**
+ * Category definitions for grouping packages.
+ * Order determines display order in the sidebar and main content.
+ */
+const CATEGORIES: { keyword: string; label: string }[] = [
+  { keyword: "testing", label: "Testing" },
+  { keyword: "io", label: "I/O & Network" },
+  { keyword: "process", label: "Processes" },
+  { keyword: "streams", label: "Streams" },
+  { keyword: "concurrency", label: "Concurrency" },
+  { keyword: "reactivity", label: "Reactivity" },
+  { keyword: "interop", label: "Interop" },
+  { keyword: "platform", label: "Platform" },
+];
+
+interface PackageEntry {
+  name: string;
+  description: string;
+  workspaceName: string;
+  keywords: string[];
+  url: string;
+}
+
+interface CategoryWithPackages {
+  keyword: string;
+  label: string;
+  packages: PackageEntry[];
+}
 
 export function xIndexRedirect(): SitemapRoute<JSXElement> {
   return {
@@ -39,75 +70,157 @@ export function xIndexRoute({
 
       let makeChildUrl = createChildURL();
 
-      return (
-        <AppHTML search={search}>
-          <article class="prose dark:prose-invert m-auto bg-white dark:bg-gray-900 dark:text-gray-200 prose-headings:text-gray-900 dark:prose-headings:text-gray-100 prose-p:text-gray-800 dark:prose-p:text-gray-200  prose-strong:text-gray-900 dark:prose-strong:text-gray-100">
-            <header class="flex flex-row items-center space-x-2">
-              <h1 class="mb-0 text-gray-900 dark:text-gray-200">
-                Effection Extensions
-              </h1>
-              {yield* GithubPill({
-                url: workspaces.url,
-                text: workspaces.nameWithOwner,
-                class:
-                  "flex flex-row w-fit h-10 items-center rounded-full bg-gray-200 dark:bg-gray-800 px-2 py-1 text-gray-900 dark:text-gray-100",
-              })}
-            </header>
-            <p class="text-gray-800 dark:text-gray-200">
-              A collection of reusable, community-created extensions - ranging
-              from small packages to complete frameworks - that show the best
-              practices for handling common JavaScript tasks with Effection.
-            </p>
-            <section class="ring-1 ring-slate-300 dark:ring-slate-700 rounded">
-              <h2 class="p-4 bg-slate-100 dark:bg-gray-800 mb-0 text-lg text-gray-900 dark:text-gray-200">
-                Frameworks
-              </h2>
-              <ul class="list-none px-0 divide-y-1 divide-solid divide-slate-200 dark:divide-slate-700">
+      // Resolve package metadata concurrently
+      let packageEntries: PackageEntry[] = yield* all(
+        packages.map(function* (pkg: Package) {
+          let name = yield* pkg.getName();
+          let description = yield* pkg.getDescription();
+          let keywords = yield* pkg.getKeywords();
+          let url = yield* makeChildUrl(pkg.workspaceName);
+
+          return {
+            name,
+            description,
+            workspaceName: pkg.workspaceName,
+            keywords,
+            url,
+          };
+        }),
+      );
+
+      // Group packages by category
+      let categorizedPackages: CategoryWithPackages[] = CATEGORIES.map(
+        (category) => ({
+          ...category,
+          packages: packageEntries.filter((pkg) =>
+            pkg.keywords.includes(category.keyword)
+          ),
+        }),
+      ).filter((cat) => cat.packages.length > 0);
+
+      // Pre-render sidebar links
+      let sidebarLinks = yield* all(
+        categorizedPackages.map(function* (category) {
+          return (
+            <a
+              href={`#${category.keyword}`}
+              class="block py-1.5 px-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 rounded"
+            >
+              {category.label}{" "}
+              <span class="text-gray-400 dark:text-gray-500">
+                ({category.packages.length})
+              </span>
+            </a>
+          );
+        }),
+      );
+
+      // Pre-render category sections
+      let categorySections = yield* all(
+        categorizedPackages.map(function* (category) {
+          let packageItems = yield* all(
+            category.packages.map(function* (pkg) {
+              return (
                 <li>
                   <a
-                    href="http://starfx.bower.sh"
+                    href={pkg.url}
                     class="grid grid-flow-row no-underline pb-4 pt-4 px-4 text-cyan-700 dark:text-blue-400"
                   >
                     <span class="text-cyan-700 dark:text-blue-400 text-lg font-semibold">
-                      StarFX
+                      {pkg.name}
                     </span>
                     <span class="text-gray-800 dark:text-gray-200">
-                      A micro-MVC framework for React App.
+                      {pkg.description}
                     </span>
                   </a>
                 </li>
-              </ul>
-            </section>
-            <section class="ring-1 ring-slate-300 dark:ring-slate-700 rounded">
+              );
+            }),
+          );
+
+          return (
+            <section
+              id={category.keyword}
+              class="ring-1 ring-slate-300 dark:ring-slate-700 rounded"
+            >
               <h2 class="p-4 bg-slate-100 dark:bg-gray-800 mb-0 text-lg text-gray-900 dark:text-gray-200">
-                Packages
+                {category.label}
               </h2>
               <ul class="list-none px-0 divide-y-1 divide-solid divide-slate-200 dark:divide-slate-700">
-                {yield* all(
-                  packages.map(function* (pkg) {
-                    let title = yield* pkg.getName();
-                    let description = yield* pkg.getDescription();
-
-                    return (
-                      <li>
-                        <a
-                          href={yield* makeChildUrl(pkg.workspaceName)}
-                          class="grid grid-flow-row no-underline pb-4 pt-4 px-4 text-cyan-700 dark:text-blue-400"
-                        >
-                          <span class="text-cyan-700 dark:text-blue-400 text-lg font-semibold">
-                            {title}
-                          </span>
-                          <span class="text-gray-800 dark:text-gray-200">
-                            {description}
-                          </span>
-                        </a>
-                      </li>
-                    );
-                  }),
-                )}
+                {packageItems}
               </ul>
             </section>
-          </article>
+          );
+        }),
+      );
+
+      return (
+        <AppHTML search={search}>
+          <div class="flex flex-row gap-8 max-w-6xl mx-auto">
+            {/* Sidebar */}
+            <aside class="hidden lg:block w-48 flex-shrink-0 sticky top-24 self-start">
+              <nav class="space-y-1">
+                <h2 class="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-3">
+                  Categories
+                </h2>
+                <a
+                  href="#frameworks"
+                  class="block py-1.5 px-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 rounded"
+                >
+                  Frameworks
+                </a>
+                {sidebarLinks}
+              </nav>
+            </aside>
+
+            {/* Main content */}
+            <article class="flex-1 prose dark:prose-invert bg-white dark:bg-gray-900 dark:text-gray-200 prose-headings:text-gray-900 dark:prose-headings:text-gray-100 prose-p:text-gray-800 dark:prose-p:text-gray-200 prose-strong:text-gray-900 dark:prose-strong:text-gray-100">
+              <header class="flex flex-row items-center space-x-2">
+                <h1 class="mb-0 text-gray-900 dark:text-gray-200">
+                  Effection Extensions
+                </h1>
+                {yield* GithubPill({
+                  url: workspaces.url,
+                  text: workspaces.nameWithOwner,
+                  class:
+                    "flex flex-row w-fit h-10 items-center rounded-full bg-gray-200 dark:bg-gray-800 px-2 py-1 text-gray-900 dark:text-gray-100",
+                })}
+              </header>
+              <p class="text-gray-800 dark:text-gray-200">
+                A collection of reusable, community-created extensions - ranging
+                from small packages to complete frameworks - that show the best
+                practices for handling common JavaScript tasks with Effection.
+              </p>
+
+              {/* Frameworks section */}
+              <section
+                id="frameworks"
+                class="ring-1 ring-slate-300 dark:ring-slate-700 rounded"
+              >
+                <h2 class="p-4 bg-slate-100 dark:bg-gray-800 mb-0 text-lg text-gray-900 dark:text-gray-200">
+                  Frameworks
+                </h2>
+                <ul class="list-none px-0 divide-y-1 divide-solid divide-slate-200 dark:divide-slate-700">
+                  <li>
+                    <a
+                      href="http://starfx.bower.sh"
+                      class="grid grid-flow-row no-underline pb-4 pt-4 px-4 text-cyan-700 dark:text-blue-400"
+                    >
+                      <span class="text-cyan-700 dark:text-blue-400 text-lg font-semibold">
+                        StarFX
+                      </span>
+                      <span class="text-gray-800 dark:text-gray-200">
+                        A micro-MVC framework for React App.
+                      </span>
+                    </a>
+                  </li>
+                </ul>
+              </section>
+
+              {/* Category sections */}
+              {categorySections}
+            </article>
+          </div>
         </AppHTML>
       );
     },

--- a/www/routes/x-index-route.tsx
+++ b/www/routes/x-index-route.tsx
@@ -67,7 +67,10 @@ export function xIndexRoute({
       );
 
       // Group packages by category
-      let categorizedPackages = groupPackagesByCategory(categories, packageEntries);
+      let categorizedPackages = groupPackagesByCategory(
+        categories,
+        packageEntries,
+      );
 
       return (
         <AppHTML search={search}>

--- a/www/routes/x-index-route.tsx
+++ b/www/routes/x-index-route.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck - JSX array children typing issue
 import { all } from "effection";
 import type { JSXElement } from "revolution";
 import { GithubPill } from "../components/package/source-link.tsx";
@@ -8,35 +7,12 @@ import { useAppHtml } from "./app.html.tsx";
 import { createChildURL, createSibling } from "../lib/links-resolvers.ts";
 import { softRedirect } from "./redirect.tsx";
 import type { Package } from "../lib/package/types.ts";
+import {
+  groupPackagesByCategory,
+  type PackageSummary,
+} from "../lib/package/categories.ts";
 
-/**
- * Category definitions for grouping packages.
- * Order determines display order in the sidebar and main content.
- */
-const CATEGORIES: { keyword: string; label: string }[] = [
-  { keyword: "testing", label: "Testing" },
-  { keyword: "io", label: "I/O & Network" },
-  { keyword: "process", label: "Processes" },
-  { keyword: "streams", label: "Streams" },
-  { keyword: "concurrency", label: "Concurrency" },
-  { keyword: "reactivity", label: "Reactivity" },
-  { keyword: "interop", label: "Interop" },
-  { keyword: "platform", label: "Platform" },
-];
-
-interface PackageEntry {
-  name: string;
-  description: string;
-  workspaceName: string;
-  keywords: string[];
-  url: string;
-}
-
-interface CategoryWithPackages {
-  keyword: string;
-  label: string;
-  packages: PackageEntry[];
-}
+type PackageEntry = PackageSummary & { url: string };
 
 export function xIndexRedirect(): SitemapRoute<JSXElement> {
   return {
@@ -89,14 +65,7 @@ export function xIndexRoute({
       );
 
       // Group packages by category
-      let categorizedPackages: CategoryWithPackages[] = CATEGORIES.map(
-        (category) => ({
-          ...category,
-          packages: packageEntries.filter((pkg) =>
-            pkg.keywords.includes(category.keyword)
-          ),
-        }),
-      ).filter((cat) => cat.packages.length > 0);
+      let categorizedPackages = groupPackagesByCategory(packageEntries);
 
       return (
         <AppHTML search={search}>

--- a/www/routes/x-index-route.tsx
+++ b/www/routes/x-index-route.tsx
@@ -125,7 +125,7 @@ export function xIndexRoute({
               {/* Frameworks section */}
               <section
                 id="frameworks"
-                class="ring-1 ring-slate-300 dark:ring-slate-700 rounded"
+                class="scroll-mt-[100px] ring-1 ring-slate-300 dark:ring-slate-700 rounded"
               >
                 <h2 class="p-4 bg-slate-100 dark:bg-gray-800 mb-0 text-lg text-gray-900 dark:text-gray-200">
                   Frameworks
@@ -152,7 +152,7 @@ export function xIndexRoute({
                 {categorizedPackages.map((category) => (
                   <section
                     id={category.keyword}
-                    class="ring-1 ring-slate-300 dark:ring-slate-700 rounded"
+                    class="scroll-mt-[100px] ring-1 ring-slate-300 dark:ring-slate-700 rounded"
                   >
                     <h2 class="p-4 bg-slate-100 dark:bg-gray-800 mb-0 text-lg text-gray-900 dark:text-gray-200">
                       {category.label}


### PR DESCRIPTION
# Motivation

AI agents and developers need better ways to discover the right EffectionX package for their use case. A flat list of 24+ packages makes it hard to find what you need.

This PR adds categorization to both the `/effection/x/` page and `/llms.txt` route, grouping packages by their primary use case.

# Approach

## Data Layer

Packages are categorized using `keywords` in their `package.json` (the standard npm field). The taxonomy definition (category labels, descriptions, and display order) lives in the effectionx root `package.json` under `effectionx.categories` (thefrontside/effectionx#211, merged).

Per-package keyword audit: thefrontside/effectionx#210 (merged)

## Website Schema

- Added `keywords` and `description` to `PackageJsonSchema` and `PackageManifest`
- Added `getKeywords()` method to Package interface
- Updated `getDescription()` to prefer `package.json` description over README extraction

## Dynamic Taxonomy Loading

The website reads the category taxonomy from the cloned effectionx repo at runtime via `useTaxonomy()`:

- `www/lib/package/taxonomy.ts` — `useTaxonomy()` Operation reads `effectionx.categories` from the cloned root `package.json`, validated with Zod
- Falls back to `DEFAULT_CATEGORIES` when the field is absent; throws on malformed data
- `www/lib/package/categories.ts` — `groupPackagesByCategory()` accepts taxonomy as a parameter, shared by both routes
- `www/lib/clones.ts` — Clone helper now refreshes existing clones (`fetch + reset --hard`) on every access so taxonomy changes appear without server restart

## llms.txt Route

Groups packages by category for better AI agent retrieval:

```markdown
## EffectionX Packages

### Testing
- [@effectionx/bdd]: BDD testing harness...
- [@effectionx/vitest]: Vitest adapter...

### I/O & Network
- [@effectionx/fetch]: Effection-native fetch...
```

## Extensions Page

Added a sticky sidebar with category navigation:

- Categories listed with package counts
- Click to jump to category section
- Packages grouped under category headings
- Packages can appear in multiple categories