### PR TITLE
Remove bundlephobia badge and references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![npm](https://img.shields.io/npm/v/effection.svg)](https://www.npmjs.com/package/effection)
-[![bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/effection)](https://bundlephobia.com/result?p=effection)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Created by Frontside](https://img.shields.io/badge/created%20by-frontside-26abe8.svg)](https://frontside.com)
 [![Chat on Discord](https://img.shields.io/discord/700803887132704931?Label=Discord)](https://discord.gg/Ug5nWH8)

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -27,4 +27,3 @@ import { main } from "jsr:@effection/effection@4.0.0";
 [unpkg]: https://unpkg.com/effection
 [yarn]: https://yarnpkg.com/package?q=effection&name=effection
 [npm]: https://www.npmjs.com/package/effection
-[bundlephobia]: https://bundlephobia.com/package/effection


### PR DESCRIPTION
Bundlephobia appears to be abandonware and has been bit-rotting for awhile.