### PR TITLE
✍️ Reframe strict structured concurrency around lifetime correctness

### DIFF
--- a/www/blog/2026-03-12-strict-structured-concurrency/index.md
+++ b/www/blog/2026-03-12-strict-structured-concurrency/index.md
@@ -1,90 +1,65 @@
 ---
 title: "What is Strict Structured Concurrency?"
-description: "Effection applies a refined version of structured concurrency where background tasks are automatically reclaimed when their scope exits. The result is code that focuses on the algorithm, not on cleanup."
+description: "In standard structured concurrency, background tasks can hold a scope open after the meaningful work is done. Strict structured concurrency corrects that lifetime model by reclaiming incidental work automatically."
 author: "Charles Lowell"
 image: strict-structured-concurrency.svg
 ---
 
-People who come to [Effection](https://frontside.com/effection) for the first
-time, even those who are already familiar with structured concurrency, are often
-surprised by how aggressively it tears down child tasks. They'll spawn a few
-concurrent operations, return from the parent, and discover that every single
-child has been _cancelled_. Not joined. Not awaited. Cancelled.
+When a scope completes its meaningful work, it should be done. That sounds
+obvious, but the standard model of structured concurrency still leaves a hole in
+the lifetime rules. If background tasks can hold a scope open after the
+foreground computation is complete, then the scope remains open for work it no
+longer structurally justifies.
 
-```jsx
-import { run, sleep, spawn } from "effection";
+That is not merely inconvenient. It is semantically wrong. Once background work
+has equal structural standing with foreground computation, correctness stops
+being a property of the model and becomes a burden on the programmer. Every
+spinner, timeout, heartbeat, polling loop, and listener now carries an
+incorrectness tax: forget to tear one down and an operation can hang, a request
+can fail to return, or a support process can outlive the very work it was meant
+to support.
 
-await run(function* () {
-  yield* spawn(function*(){
-	  yield* sleep(1000);
-	  console.log('one second');
-  );
+In performance-sensitive systems, that tax is not abstract. Work that no longer
+belongs to the computation can still retain resources, inflate latency, degrade
+throughput, and make shutdown behavior unstable under load. Incorrect lifetime
+semantics are operationally expensive.
 
-  yield* spawn(function*(){
-	  yield* sleep(2000);
-	  console.log('two seconds');
-  );
+Effection corrects that model with a stricter rule: **a child may not outlive
+its parent.** When a scope exits, incidental background work is reclaimed
+automatically. Cleanup still runs. `finally {}` blocks still run. Orderly
+shutdown is preserved. But the scope does not remain open for work that no
+longer contributes to its result. That refinement is what we call **strict
+structured concurrency**.
 
-  console.log("done");
-});
-```
+## Foreground and background
 
-This program prints `done` and exits right away. Both sleepers? Gone. If you're
-coming from a structured concurrency background like Python or Swift, this might
-feel wrong. In those systems, a parent scope waits for all of its children to
-complete before it exits. That's _the_ guarantee. That's what makes it
-structured. So what is Effection doing here?
+The key distinction is between work that defines the computation and work that
+merely supports it.
 
-The answer is that Effection is applying a refined version of structured
-concurrency; one that imposes more rigid constraints on the lifetime of each
-task. We arrived at this behavior after years of iteration, and we call it
-**strict structured concurrency.**
+A **foreground** task is one whose result is explicitly consumed by the parent.
+Its value is part of what the scope computes.
 
-## Structured concurrency as we know it
+A **background** task is one whose result is never consumed by the parent. It
+exists only to sustain some side-effect while the foreground runs.
 
-Nathaniel J. Smith changed the game back in 2018 when he
-published ["Notes on structured concurrency, or: Go statement considered harmful."](https://vorpus.org/blog/notes-on-structured-concurrency-or-go-statement-considered-harmful/)
-(If you haven’t read it, then you should right now. It’s so good!) Its core
-insight, which is now widely accepted, is that concurrent tasks, like local
-variables, should have their lifetimes aligned with the lexical scope in which
-they appear. In other words, every child task lives inside a parent, and the
-parent does not exit until every child is accounted for _without exception_.
+Foreground tasks and background tasks should not have equal structural standing.
+The lifetime of a foreground task is naturally aligned with the lifetime of its
+scope. If the parent needs the value, then the task must complete before the
+parent can complete. That is correctness by construction.
 
-_This_ is the guarantee that defines structured concurrency. But what does it
-mean in practice?
+Background tasks are different. A spinner can run forever. A heartbeat can run
+forever. A timeout can stay armed indefinitely. But once the foreground is done,
+they have no further reason to exist.
 
-In Smith’s original conception, it means that when an open scope has tasks
-spawned into it, it will wait until every task is finished before closing.
+A spinner whose download is complete? A heartbeat nobody is listening for? A
+collector with no more metrics to flush? These are not tasks that need equal
+standing with the computation. These are tasks that should simply go away.
 
-```
-// pseudocode
-with classic {
-  scope.start(taskA)  // runs for 1 second
-  scope.start(taskB)  // runs for 2 seconds
-  scope.start(taskC)  // runs for 3 seconds
-}
-// ← doesn't reach here until all three are done (3 seconds)
-```
+## Where the failure shows up
 
-Control flows in the top, stuff happens, control flows out the bottom, but in
-all cases the ledger of concurrent tasks is exactly the same as when it entered.
-This simple constraint is a straight up super-power because it allows us to
-build and compose abstractions that can nevertheless contain all kinds of
-side-effects and state. The safety is real.
+Take a simple operation that fetches user data while showing a spinner:
 
-## The cancellation tax
-
-But what happens when you want to leave a scope _before_ its children are done?
-
-Under the standard model, it’s roll your own. The scope implicitly holds the
-door open until everyone finishes, so if you want an early exit, you need to
-reach for a cancellation mechanism to wind down the children yourself. Each
-system is different (In Effection, you generally use `Task.halt()`)
-
-For example, this code shows a spinner while downloading and returning user
-information.
-
-```jsx
+```js
 function* getUserInfo(userId) {
   let spinner = yield* spawn(function* () {
     yield* showSpinner({ style: "circle" });
@@ -98,27 +73,16 @@ function* getUserInfo(userId) {
 }
 ```
 
-To recap, this code:
+Now add a timeout:
 
-1. shows the spinner
-2. grabs the user info
-3. halts the spinner
-4. return the user info
-
-This works, and it is safe, and it is correct. But in practice, we found that we
-were having to explicitly manage the lifetime of tasks like the spinner
-_constantly_.
-
-Imagine we extended our operation by adding a timeout.
-
-```jsx
+```js
 function* getUserInfo(userId, timeoutMs) {
   let spinner = yield* spawn(function* () {
     yield* showSpinner({ style: "circle" });
   });
 
   let timeout = yield* spawn(function* () {
-    yield* sleep(timeoutMS);
+    yield* sleep(timeoutMs);
     throw new Error("timed out");
   });
 
@@ -131,94 +95,91 @@ function* getUserInfo(userId, timeoutMs) {
 }
 ```
 
-This begins the countdown right after the spinner. Then, right before we’re
-ready to return, just as with the spinner, we tear it down.
+The spinner and the timeout are easy examples, but the issue is not that they
+require a few extra lines of teardown. The issue is that under weaker lifetime
+rules, support processes can continue to hold open a scope even after the
+meaningful computation has completed. In real systems, that is how operations
+hang, requests fail to return, and frameworks accumulate defensive cleanup logic
+everywhere.
 
-Additions like this kept happening over and over again. From maintaining a “keep
-alive” heartbeat on a web socket, to periodically flushing OTEL metrics, the
-pattern that began to emerge was that there were actually two types of tasks:
-one whose lifecycle always seemed to just work itself out, and another that
-always had to be managed.
+This is the cancellation tax. Not because cancellation is annoying, but because
+the runtime has preserved work that is no longer structurally justified. Every
+framework author inherits that burden and must manually defend against it at
+every layer of abstraction.
 
-## Foreground and background
+From maintaining a keep-alive heartbeat on a WebSocket, to flushing OTEL
+metrics, to polling for updates, the pattern is the same. The support process is
+not the result. It should not decide when the scope is done.
 
-The tasks whose lifecycles "just worked out" were the ones
-whose values represented the heart of the computation. In the example above, to
-return a combination of `fetchUsers()` and `fetchGroups()` is the _literal
-definition_ of what it means to `getUserInfo()`. They are the pure components
-used to express the scope’s algorithm which is why we call them **foreground**
-tasks.
+## Structured concurrency as we know it
 
-Then there are the other tasks: the spinner, the timeout, the heartbeat. These
-don’t participate in the algorithm, and they don't produce a value that the
-scope consumes. Instead they are there to produce a
-persistent _side-effect_ that supports the foreground while it runs. That’s what
-makes them **background** tasks.
+People who come to [Effection](https://frontside.com/effection) for the first
+time, even those already familiar with structured concurrency from Python or
+Swift, are often surprised by how aggressively it tears down child tasks.
+They'll spawn a few concurrent operations, return from the parent, and discover
+that every single child has been _cancelled_. Not joined. Not awaited.
+Cancelled.
 
-Stated more formally, a foreground task is one whose result is explicitly
-consumed by the foreground, whereas a background task is one whose result is
-_never_ consumed by the foreground.
+```js
+import { run, sleep, spawn } from "effection";
 
-To see this difference in action, let’s take our original example, but instead
-of consuming the user info directly, let’s start by spawning the fetch in a
-background task first.
-
-```jsx
-function* getUserInfo(userId) {
-  let spinner = yield* spawn(function* () {
-    yield* showSpinner({ style: "circle" });
+await run(function* () {
+  yield* spawn(function* () {
+    yield* sleep(1000);
+    console.log("one second");
   });
 
-  let info = yield* spawn(function* () {
-    return yield* all([fetchUser(userId), fetchGroups(userId)]);
+  yield* spawn(function* () {
+    yield* sleep(2000);
+    console.log("two seconds");
   });
 
-  // both `spinner` and `info` are now running in the background.
-
-  let [user, groups] = yield* info; // ← `info` is "pulled" into forgeground
-
-  // only `spinner` remains in the background... shut it down
-  yield* spinner.halt();
-
-  return { ...user, groups };
-}
+  console.log("done");
+});
 ```
 
-Notice how there is no need to manage the lifecycle of the `info` task. It just
-happened naturally because the foreground requires the values of `user` and
-`groups` in order compute its return value. In other words, the `info` task
-_must_ be completed by the time we get to the end of the function. If it
-weren’t, then we wouldn’t be at the end of the function, now would we? As a
-result, the lifetime of a foreground task is always naturally aligned with the
-lifetime of its scope.
+This program prints `done` and exits right away. Both sleepers? Gone. If you're
+coming from Python or Swift, this might feel wrong. In those systems, a parent
+scope waits for all of its children to complete before it exits. That's _the_
+guarantee. That's what makes it structured.
 
-On the other hand, the lifetime of a background task is _not_ naturally aligned
-with the lifetime of its scope. A background task’s natural lifetime can be
-long. It can be short. Quite often it is _infinite_. But whatever the case, what
-sets it apart from the foreground is that once its scope completes, it has no
-further reason to exist.
+Nathaniel J. Smith changed the game back in 2018 when he published
+["Notes on structured concurrency, or: Go statement considered harmful."](https://vorpus.org/blog/notes-on-structured-concurrency-or-go-statement-considered-harmful/)
+(If you haven't read it, you should right now. It's so good!) Its core insight,
+which is now widely accepted, is that concurrent tasks, like local variables,
+should have their lifetimes aligned with the lexical scope in which they appear.
+In other words, every child task lives inside a parent, and the parent does not
+exit until every child is accounted for _without exception_.
 
-A spinner whose downloads are complete? A heartbeat nobody is listening for? A
-collector with no more metrics to flush? These aren't tasks that need to be
-“managed.” These are tasks that just need to _go away_.
+In Smith's original conception, that means an open scope waits until every child
+finishes before closing.
 
-Under the standard model, background tasks hold the scope open just like
-foreground tasks do, which means that the _programmer_ is required to explicitly
-manage the lifecycle of each and every task in the background. That's the
-cancellation tax. It's a tax on your algorithm paid in the form of the stuff
-that isn’t in it.
+```
+// pseudocode
+with classic {
+  scope.start(taskA)  // runs for 1 second
+  scope.start(taskB)  // runs for 2 seconds
+  scope.start(taskC)  // runs for 3 seconds
+}
+// <- doesn't reach here until all three are done (3 seconds)
+```
 
-## The “strict” refinement
+That model is a super-power. It lets us build abstractions with real guarantees
+around state and side effects. But if background tasks are allowed to extend the
+lifetime of a scope after the foreground is complete, then the model is still
+too permissive. The scope stays open for work it no longer justifies, and
+correctness becomes a burden shifted upward onto the programmer.
 
-Strict structured concurrency, the kind built into Effection, adds a new
-constraint to the existing guarantee: **a child may not outlive its
-parent.** When a scope reaches its end, anything remaining in the background is
-instructed to immediately shut down.
+## The strict refinement
 
-What does this mean for our `getUserInfo` example? It means the teardown of the
-spinner and the timeout just disappear from the code:
+Strict structured concurrency adds one more rule to the existing guarantee:
+background work does not get to keep a parent alive after the parent's
+meaningful computation is done.
 
-```jsx
+What does that mean for `getUserInfo()`? It means the teardown of the spinner
+and the timeout disappears from the algorithm:
+
+```js
 function* getUserInfo(userId, timeoutMs) {
   yield* spawn(function* () {
     yield* showSpinner({ style: "circle" });
@@ -235,18 +196,15 @@ function* getUserInfo(userId, timeoutMs) {
 }
 ```
 
-The foreground expresses the algorithm, and the background is spun up to support
-it. When the foreground completes and its scope exits, the background, which is
-no longer needed, is automatically reclaimed. What's left is just the code that
-matters.
+The foreground expresses the computation. The background supports it. When the
+foreground completes and the scope exits, the background is reclaimed
+automatically.
 
-One way to think about it is like the memory resources that hold variable
-references in a function’s stack frame. When a function exits, those memory
-resources are automatically recycled. You don’t have to deallocate them
-explicitly, you don’t even have to think about them because the lifetime of the
-memory is tied to the function’s scope. Strict structured concurrency does the
-same thing for tasks. The background tasks are automatically reclaimed when the
-foreground moves on, so that it's one less thing you carry.
+One way to think about it is like the memory that holds local variables in a
+stack frame. When a function exits, that memory is reclaimed automatically. You
+do not keep it around just because there used to be something interesting in it.
+Strict structured concurrency applies the same principle to incidental work. If
+the scope is done computing, the support processes do not get to linger.
 
 ## The guarantees still hold
 
@@ -254,13 +212,12 @@ Strict structured concurrency is still structured concurrency.
 
 When a background task is shut down automatically, it is not terminated
 outright. The parent still waits, just as it would under the standard model, for
-every child to run _all_ of its cleanup paths. The result computed by the
-foreground will not be reported to the caller until they are complete.
+every child to run _all_ of its cleanup paths. The result computed by the
+foreground is not reported to the caller until that cleanup is complete.
 
-Consider this example that starts a task running in the background, and then
-promptly finishes.
+Consider this example that starts a background task and then promptly finishes:
 
-```jsx
+```js
 import { main, sleep, spawn } from "effection";
 
 await main(function* () {
@@ -272,26 +229,24 @@ await main(function* () {
       console.log("cleanup complete");
     }
   });
+
   console.log("done");
 });
 ```
 
-This will print `“done”` immediately, wait 500 milliseconds, and then print
-"cleanup complete" before exiting. This is because upon exit, the background
-task will be halted and its `finally {}` block must be run. The strict
-refinement doesn't weaken the guarantee. It just makes it more intuitive by
-making orderly shutdown the _default_ rather than something you have to arrange
-by hand.
+This prints `done` immediately, waits 500 milliseconds, and then prints
+`cleanup complete` before exiting. Upon scope exit, the background task is
+halted and its `finally {}` block still must run. Strictness does not weaken the
+guarantee. It tightens it around the correct lifetime boundary.
 
-## Focus on the algorithm
+## Focus on what computes
 
-However the deepest consequence of the strict variant of structured concurrency
-is where it focuses attention. The foreground is in the foreground. The
-background is just allowed to _be_ the background. And the structure of your
-program guarantees that the latter will gracefully disappear once the former is
-complete.
+The deepest consequence of strict structured concurrency is not that the code is
+cleaner, though it is. It is that the lifetime rules are more correct.
 
-Perhaps a more philosophical way to put it: if a concurrent operation computes,
-but there is no one there to consume its result, does it exist? Under strict
-structured concurrency, the answer is no. And the code you would have written to
-make it stop? That doesn't need to exist either.
+Foreground work remains in the foreground. Background work is allowed to be what
+it actually is: support work. Once the computation is complete, the support work
+no longer has structural standing to keep the scope alive.
+
+And if a concurrent operation computes, but there is no one left to consume its
+result, should it exist? Under strict structured concurrency, the answer is no.

--- a/www/blog/2026-03-12-strict-structured-concurrency/index.md
+++ b/www/blog/2026-03-12-strict-structured-concurrency/index.md
@@ -1,0 +1,297 @@
+---
+title: "What is Strict Structured Concurrency?"
+description: "Effection applies a refined version of structured concurrency where background tasks are automatically reclaimed when their scope exits. The result is code that focuses on the algorithm, not on cleanup."
+author: "Charles Lowell"
+image: strict-structured-concurrency.svg
+---
+
+People who come to [Effection](https://frontside.com/effection) for the first
+time, even those who are already familiar with structured concurrency, are often
+surprised by how aggressively it tears down child tasks. They'll spawn a few
+concurrent operations, return from the parent, and discover that every single
+child has been _cancelled_. Not joined. Not awaited. Cancelled.
+
+```jsx
+import { run, sleep, spawn } from "effection";
+
+await run(function* () {
+  yield* spawn(function*(){
+	  yield* sleep(1000);
+	  console.log('one second');
+  );
+
+  yield* spawn(function*(){
+	  yield* sleep(2000);
+	  console.log('two seconds');
+  );
+
+  console.log("done");
+});
+```
+
+This program prints `done` and exits right away. Both sleepers? Gone. If you're
+coming from a structured concurrency background like Python or Swift, this might
+feel wrong. In those systems, a parent scope waits for all of its children to
+complete before it exits. That's _the_ guarantee. That's what makes it
+structured. So what is Effection doing here?
+
+The answer is that Effection is applying a refined version of structured
+concurrency; one that imposes more rigid constraints on the lifetime of each
+task. We arrived at this behavior after years of iteration, and we call it
+**strict structured concurrency.**
+
+## Structured concurrency as we know it
+
+Nathaniel J. Smith changed the game back in 2018 when he
+published ["Notes on structured concurrency, or: Go statement considered harmful."](https://vorpus.org/blog/notes-on-structured-concurrency-or-go-statement-considered-harmful/)
+(If you haven’t read it, then you should right now. It’s so good!) Its core
+insight, which is now widely accepted, is that concurrent tasks, like local
+variables, should have their lifetimes aligned with the lexical scope in which
+they appear. In other words, every child task lives inside a parent, and the
+parent does not exit until every child is accounted for _without exception_.
+
+_This_ is the guarantee that defines structured concurrency. But what does it
+mean in practice?
+
+In Smith’s original conception, it means that when an open scope has tasks
+spawned into it, it will wait until every task is finished before closing.
+
+```
+// pseudocode
+with classic {
+  scope.start(taskA)  // runs for 1 second
+  scope.start(taskB)  // runs for 2 seconds
+  scope.start(taskC)  // runs for 3 seconds
+}
+// ← doesn't reach here until all three are done (3 seconds)
+```
+
+Control flows in the top, stuff happens, control flows out the bottom, but in
+all cases the ledger of concurrent tasks is exactly the same as when it entered.
+This simple constraint is a straight up super-power because it allows us to
+build and compose abstractions that can nevertheless contain all kinds of
+side-effects and state. The safety is real.
+
+## The cancellation tax
+
+But what happens when you want to leave a scope _before_ its children are done?
+
+Under the standard model, it’s roll your own. The scope implicitly holds the
+door open until everyone finishes, so if you want an early exit, you need to
+reach for a cancellation mechanism to wind down the children yourself. Each
+system is different (In Effection, you generally use `Task.halt()`)
+
+For example, this code shows a spinner while downloading and returning user
+information.
+
+```jsx
+function* getUserInfo(userId) {
+  let spinner = yield* spawn(function* () {
+    yield* showSpinner({ style: "circle" });
+  });
+
+  let [user, groups] = yield* all([fetchUser(userId), fetchGroups(userId)]);
+
+  yield* spinner.halt();
+
+  return { ...user, groups };
+}
+```
+
+To recap, this code:
+
+1. shows the spinner
+2. grabs the user info
+3. halts the spinner
+4. return the user info
+
+This works, and it is safe, and it is correct. But in practice, we found that we
+were having to explicitly manage the lifetime of tasks like the spinner
+_constantly_.
+
+Imagine we extended our operation by adding a timeout.
+
+```jsx
+function* getUserInfo(userId, timeoutMs) {
+  let spinner = yield* spawn(function* () {
+    yield* showSpinner({ style: "circle" });
+  });
+
+  let timeout = yield* spawn(function* () {
+    yield* sleep(timeoutMS);
+    throw new Error("timed out");
+  });
+
+  let [user, groups] = yield* all([fetchUser(userId), fetchGroups(userId)]);
+
+  yield* spinner.halt();
+  yield* timeout.halt();
+
+  return { ...user, groups };
+}
+```
+
+This begins the countdown right after the spinner. Then, right before we’re
+ready to return, just as with the spinner, we tear it down.
+
+Additions like this kept happening over and over again. From maintaining a “keep
+alive” heartbeat on a web socket, to periodically flushing OTEL metrics, the
+pattern that began to emerge was that there were actually two types of tasks:
+one whose lifecycle always seemed to just work itself out, and another that
+always had to be managed.
+
+## Foreground and background
+
+The tasks whose lifecycles "just worked out" were the ones
+whose values represented the heart of the computation. In the example above, to
+return a combination of `fetchUsers()` and `fetchGroups()` is the _literal
+definition_ of what it means to `getUserInfo()`. They are the pure components
+used to express the scope’s algorithm which is why we call them **foreground**
+tasks.
+
+Then there are the other tasks: the spinner, the timeout, the heartbeat. These
+don’t participate in the algorithm, and they don't produce a value that the
+scope consumes. Instead they are there to produce a
+persistent _side-effect_ that supports the foreground while it runs. That’s what
+makes them **background** tasks.
+
+Stated more formally, a foreground task is one whose result is explicitly
+consumed by the foreground, whereas a background task is one whose result is
+_never_ consumed by the foreground.
+
+To see this difference in action, let’s take our original example, but instead
+of consuming the user info directly, let’s start by spawning the fetch in a
+background task first.
+
+```jsx
+function* getUserInfo(userId) {
+  let spinner = yield* spawn(function* () {
+    yield* showSpinner({ style: "circle" });
+  });
+
+  let info = yield* spawn(function* () {
+    return yield* all([fetchUser(userId), fetchGroups(userId)]);
+  });
+
+  // both `spinner` and `info` are now running in the background.
+
+  let [user, groups] = yield* info; // ← `info` is "pulled" into forgeground
+
+  // only `spinner` remains in the background... shut it down
+  yield* spinner.halt();
+
+  return { ...user, groups };
+}
+```
+
+Notice how there is no need to manage the lifecycle of the `info` task. It just
+happened naturally because the foreground requires the values of `user` and
+`groups` in order compute its return value. In other words, the `info` task
+_must_ be completed by the time we get to the end of the function. If it
+weren’t, then we wouldn’t be at the end of the function, now would we? As a
+result, the lifetime of a foreground task is always naturally aligned with the
+lifetime of its scope.
+
+On the other hand, the lifetime of a background task is _not_ naturally aligned
+with the lifetime of its scope. A background task’s natural lifetime can be
+long. It can be short. Quite often it is _infinite_. But whatever the case, what
+sets it apart from the foreground is that once its scope completes, it has no
+further reason to exist.
+
+A spinner whose downloads are complete? A heartbeat nobody is listening for? A
+collector with no more metrics to flush? These aren't tasks that need to be
+“managed.” These are tasks that just need to _go away_.
+
+Under the standard model, background tasks hold the scope open just like
+foreground tasks do, which means that the _programmer_ is required to explicitly
+manage the lifecycle of each and every task in the background. That's the
+cancellation tax. It's a tax on your algorithm paid in the form of the stuff
+that isn’t in it.
+
+## The “strict” refinement
+
+Strict structured concurrency, the kind built into Effection, adds a new
+constraint to the existing guarantee: **a child may not outlive its
+parent.** When a scope reaches its end, anything remaining in the background is
+instructed to immediately shut down.
+
+What does this mean for our `getUserInfo` example? It means the teardown of the
+spinner and the timeout just disappear from the code:
+
+```jsx
+function* getUserInfo(userId, timeoutMs) {
+  yield* spawn(function* () {
+    yield* showSpinner({ style: "circle" });
+  });
+
+  yield* spawn(function* () {
+    yield* sleep(timeoutMs);
+    throw new Error("timed out");
+  });
+
+  let [user, groups] = yield* all([fetchUser(userId), fetchGroups(userId)]);
+
+  return { ...user, groups };
+}
+```
+
+The foreground expresses the algorithm, and the background is spun up to support
+it. When the foreground completes and its scope exits, the background, which is
+no longer needed, is automatically reclaimed. What's left is just the code that
+matters.
+
+One way to think about it is like the memory resources that hold variable
+references in a function’s stack frame. When a function exits, those memory
+resources are automatically recycled. You don’t have to deallocate them
+explicitly, you don’t even have to think about them because the lifetime of the
+memory is tied to the function’s scope. Strict structured concurrency does the
+same thing for tasks. The background tasks are automatically reclaimed when the
+foreground moves on, so that it's one less thing you carry.
+
+## The guarantees still hold
+
+Strict structured concurrency is still structured concurrency.
+
+When a background task is shut down automatically, it is not terminated
+outright. The parent still waits, just as it would under the standard model, for
+every child to run _all_ of its cleanup paths. The result computed by the
+foreground will not be reported to the caller until they are complete.
+
+Consider this example that starts a task running in the background, and then
+promptly finishes.
+
+```jsx
+import { main, sleep, spawn } from "effection";
+
+await main(function* () {
+  yield* spawn(function* () {
+    try {
+      yield* sleep(2000);
+    } finally {
+      yield* sleep(500);
+      console.log("cleanup complete");
+    }
+  });
+  console.log("done");
+});
+```
+
+This will print `“done”` immediately, wait 500 milliseconds, and then print
+"cleanup complete" before exiting. This is because upon exit, the background
+task will be halted and its `finally {}` block must be run. The strict
+refinement doesn't weaken the guarantee. It just makes it more intuitive by
+making orderly shutdown the _default_ rather than something you have to arrange
+by hand.
+
+## Focus on the algorithm
+
+However the deepest consequence of the strict variant of structured concurrency
+is where it focuses attention. The foreground is in the foreground. The
+background is just allowed to _be_ the background. And the structure of your
+program guarantees that the latter will gracefully disappear once the former is
+complete.
+
+Perhaps a more philosophical way to put it: if a concurrent operation computes,
+but there is no one there to consume its result, does it exist? Under strict
+structured concurrency, the answer is no. And the code you would have written to
+make it stop? That doesn't need to exist either.

--- a/www/blog/2026-03-12-strict-structured-concurrency/strict-structured-concurrency.svg
+++ b/www/blog/2026-03-12-strict-structured-concurrency/strict-structured-concurrency.svg
@@ -6,7 +6,7 @@
   fill="none"
   xmlns="http://www.w3.org/2000/svg"
   role="img"
-  aria-label="Strict Structured Concurrency — foreground tasks express the algorithm, background tasks are automatically reclaimed when the scope exits"
+  aria-label="Strict Structured Concurrency — a timeline showing foreground tasks completing naturally while background tasks are automatically reclaimed at the scope boundary"
 >
   <defs>
     <!-- Light-mode background gradient -->
@@ -133,13 +133,27 @@
       />
     </filter>
 
+    <!-- Clip paths for bar growth animation -->
+    <clipPath id="svg-clip-fg1">
+      <rect class="svg-clip-fg1-rect" x="200" y="0" width="430" height="630" />
+    </clipPath>
+    <clipPath id="svg-clip-fg2">
+      <rect class="svg-clip-fg2-rect" x="200" y="0" width="480" height="630" />
+    </clipPath>
+    <clipPath id="svg-clip-bg1">
+      <rect class="svg-clip-bg1-rect" x="200" y="0" width="560" height="630" />
+    </clipPath>
+    <clipPath id="svg-clip-bg2">
+      <rect class="svg-clip-bg2-rect" x="200" y="0" width="520" height="630" />
+    </clipPath>
+
     <style>
     /* ---- Font stacks ---- */
     .svg-title {
       font-family:
         ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica,
         Arial, "Apple Color Emoji", "Segoe UI Emoji";
-      font-size: 48px;
+      font-size: 44px;
       font-weight: 800;
       letter-spacing: -0.02em;
     }
@@ -147,23 +161,23 @@
       font-family:
         ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica,
         Arial, "Apple Color Emoji", "Segoe UI Emoji";
-      font-size: 18px;
+      font-size: 16px;
       font-weight: 600;
-      letter-spacing: 0.02em;
+      letter-spacing: 0.06em;
       text-transform: uppercase;
     }
     .svg-caption {
       font-family:
         ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica,
         Arial, "Apple Color Emoji", "Segoe UI Emoji";
-      font-size: 18px;
+      font-size: 17px;
       font-weight: 600;
     }
     .svg-mono {
       font-family:
         ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
         "Liberation Mono", "Courier New", monospace;
-      font-size: 14px;
+      font-size: 13px;
     }
     .svg-mono-sm {
       font-family:
@@ -175,9 +189,18 @@
       font-family:
         ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica,
         Arial, "Apple Color Emoji", "Segoe UI Emoji";
-      font-size: 15px;
+      font-size: 13px;
       font-weight: 700;
-      letter-spacing: 0.03em;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+    }
+    .svg-time-label {
+      font-family:
+        ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica,
+        Arial, "Apple Color Emoji", "Segoe UI Emoji";
+      font-size: 11px;
+      font-weight: 600;
+      letter-spacing: 0.08em;
       text-transform: uppercase;
     }
 
@@ -212,42 +235,6 @@
     .svg-card {
       fill: #ffffff;
     }
-    .svg-divider {
-      stroke: #d6e4ff;
-      stroke-dasharray: 4 4;
-      stroke-width: 1;
-    }
-
-    /* Foreground side */
-    .svg-fg-box {
-      fill: #ffffff;
-      stroke: #2b6ff7;
-      stroke-width: 2;
-    }
-    .svg-fg-dot {
-      fill: #2b6ff7;
-    }
-    .svg-fg-label {
-      fill: #2b6ff7;
-    }
-
-    /* Background side */
-    .svg-bg-box {
-      fill: #ffffff;
-      stroke: #9ca3af;
-      stroke-width: 1.5;
-      stroke-dasharray: 6 3;
-    }
-    .svg-bg-dot {
-      fill: #9ca3af;
-    }
-    .svg-bg-label {
-      fill: #6b7280;
-    }
-    .svg-bg-fade {
-      fill: #9ca3af;
-      opacity: 0.4;
-    }
 
     /* Scope */
     .svg-scope-parent {
@@ -255,25 +242,71 @@
       stroke: #97b7ff;
       stroke-width: 2;
     }
-    .svg-scope-label {
+    .svg-scope-label-bg {
       fill: #e6f0ff;
     }
-    .svg-dot-primary {
+
+    /* Foreground bars */
+    .svg-fg-bar {
       fill: #2b6ff7;
+      opacity: 0.85;
     }
-    .svg-check-text {
-      fill: #16a34a;
-      stroke: #16a34a;
-    }
-    .svg-cancel-text {
-      fill: #9ca3af;
-    }
-    .svg-arrow-line {
-      stroke: #97b7ff;
+    .svg-fg-bar-border {
       fill: none;
+      stroke: #2b6ff7;
+      stroke-width: 2;
     }
 
-    /* Shared text */
+    /* Background bars */
+    .svg-bg-bar {
+      fill: #9ca3af;
+      opacity: 0.35;
+    }
+    .svg-bg-bar-border {
+      fill: none;
+      stroke: #9ca3af;
+      stroke-width: 1.5;
+      stroke-dasharray: 6 3;
+    }
+
+    /* Background overshoot (past scope boundary) */
+    .svg-bg-overshoot {
+      fill: #9ca3af;
+      opacity: 0.35;
+    }
+    .svg-bg-overshoot-border {
+      fill: none;
+      stroke: #9ca3af;
+      stroke-width: 1.5;
+      stroke-dasharray: 6 3;
+    }
+
+    /* Scope exit boundary line */
+    .svg-boundary-line {
+      stroke: #2b6ff7;
+      stroke-width: 2;
+      stroke-dasharray: 8 5;
+    }
+
+    /* Time axis */
+    .svg-time-axis {
+      stroke: #97b7ff;
+      stroke-width: 1.5;
+    }
+    .svg-time-arrow {
+      fill: #97b7ff;
+    }
+    .svg-time-label {
+      fill: #97b7ff;
+    }
+
+    /* Tick marks */
+    .svg-tick {
+      stroke: #c9d9f2;
+      stroke-width: 1;
+    }
+
+    /* Text colors */
     .svg-title {
       fill: url(#ink);
     }
@@ -281,7 +314,7 @@
       fill: #33547b;
     }
     .svg-caption {
-      fill: #23435f;
+      fill: #33547b;
     }
     .svg-mono {
       fill: #1e3a8a;
@@ -294,6 +327,21 @@
     }
     .svg-label-heading {
       fill: #0b2a5b;
+    }
+    .svg-fg-label {
+      fill: #2b6ff7;
+    }
+    .svg-bg-label-text {
+      fill: #6b7280;
+    }
+    .svg-check-text {
+      fill: #16a34a;
+    }
+    .svg-cancel-text {
+      fill: #9ca3af;
+    }
+    .svg-boundary-label {
+      fill: #2b6ff7;
     }
 
     /* ---- Dark mode ---- */
@@ -327,55 +375,55 @@
       .svg-card {
         fill: #1f2937;
       }
-      .svg-divider {
-        stroke: #374151;
-      }
-
-      .svg-fg-box {
-        fill: #1f2937;
-        stroke: #60a5fa;
-      }
-      .svg-fg-dot {
-        fill: #60a5fa;
-      }
-      .svg-fg-label {
-        fill: #60a5fa;
-      }
-
-      .svg-bg-box {
-        fill: #1f2937;
-        stroke: #6b7280;
-      }
-      .svg-bg-dot {
-        fill: #6b7280;
-      }
-      .svg-bg-label {
-        fill: #9ca3af;
-      }
-      .svg-bg-fade {
-        fill: #6b7280;
-        opacity: 0.4;
-      }
 
       .svg-scope-parent {
         fill: #111827;
         stroke: #374151;
       }
-      .svg-scope-label {
+      .svg-scope-label-bg {
         fill: #1e3a8a;
       }
-      .svg-dot-primary {
+
+      .svg-fg-bar {
+        fill: #60a5fa;
+        opacity: 0.80;
+      }
+      .svg-fg-bar-border {
+        stroke: #60a5fa;
+      }
+
+      .svg-bg-bar {
+        fill: #6b7280;
+        opacity: 0.35;
+      }
+      .svg-bg-bar-border {
+        stroke: #6b7280;
+      }
+
+      .svg-bg-overshoot {
+        fill: #6b7280;
+        opacity: 0.35;
+      }
+      .svg-bg-overshoot-border {
+        stroke: #6b7280;
+      }
+
+      .svg-boundary-line {
+        stroke: #60a5fa;
+      }
+
+      .svg-time-axis {
+        stroke: #60a5fa;
+      }
+      .svg-time-arrow {
         fill: #60a5fa;
       }
-      .svg-check-text {
-        fill: #4ade80;
-        stroke: #4ade80;
+      .svg-time-label {
+        fill: #60a5fa;
       }
-      .svg-cancel-text {
-        fill: #6b7280;
-      }
-      .svg-arrow-line {
-        stroke: #60a5fa;
+
+      .svg-tick {
+        stroke: #374151;
       }
 
       .svg-title {
@@ -385,7 +433,7 @@
         fill: #9ca3af;
       }
       .svg-caption {
-        fill: #d1d5db;
+        fill: #9ca3af;
       }
       .svg-mono {
         fill: #e5e7eb;
@@ -398,6 +446,139 @@
       }
       .svg-label-heading {
         fill: #f3f4f6;
+      }
+      .svg-fg-label {
+        fill: #60a5fa;
+      }
+      .svg-bg-label-text {
+        fill: #9ca3af;
+      }
+      .svg-check-text {
+        fill: #4ade80;
+      }
+      .svg-cancel-text {
+        fill: #6b7280;
+      }
+      .svg-boundary-label {
+        fill: #60a5fa;
+      }
+    }
+
+    /* ======== ANIMATIONS ======== */
+
+    /* Phase 1: Bars grow (0s - 1.5s) */
+    /* Foreground bar 1: fetchUser — grows to 430px wide */
+    .svg-clip-fg1-rect {
+      animation: svg-grow-fg1 1.2s ease-out 0.2s both;
+    }
+    @keyframes svg-grow-fg1 {
+      from {
+        width: 0;
+      }
+      to {
+        width: 430px;
+      }
+    }
+
+    /* Foreground bar 2: fetchGroups — grows to 480px wide */
+    .svg-clip-fg2-rect {
+      animation: svg-grow-fg2 1.4s ease-out 0.2s both;
+    }
+    @keyframes svg-grow-fg2 {
+      from {
+        width: 0;
+      }
+      to {
+        width: 480px;
+      }
+    }
+
+    /* Background bar 1: spinner — grows to 560px wide (past boundary) */
+    .svg-clip-bg1-rect {
+      animation: svg-grow-bg1 1.8s linear 0.2s both;
+    }
+    @keyframes svg-grow-bg1 {
+      from {
+        width: 0;
+      }
+      to {
+        width: 560px;
+      }
+    }
+
+    /* Background bar 2: timeout — grows to 520px wide (past boundary) */
+    .svg-clip-bg2-rect {
+      animation: svg-grow-bg2 1.7s linear 0.2s both;
+    }
+    @keyframes svg-grow-bg2 {
+      from {
+        width: 0;
+      }
+      to {
+        width: 520px;
+      }
+    }
+
+    /* Phase 2: Scope boundary appears (1.8s) */
+    .svg-anim-boundary {
+      opacity: 0;
+      animation: svg-fade-in 0.5s ease-out 1.8s forwards;
+    }
+
+    /* Phase 3: Overshoot fades out (2.3s - 3.0s) */
+    .svg-anim-overshoot {
+      animation: svg-overshoot-fade 0.8s ease-in 2.3s forwards;
+    }
+    @keyframes svg-overshoot-fade {
+      from {
+        opacity: 1;
+      }
+      to {
+        opacity: 0;
+      }
+    }
+
+    /* Phase 4: Labels appear (2.8s) */
+    .svg-anim-label-fg {
+      opacity: 0;
+      animation: svg-fade-in 0.5s ease-out 2.6s forwards;
+    }
+    .svg-anim-label-bg {
+      opacity: 0;
+      animation: svg-fade-in 0.5s ease-out 2.9s forwards;
+    }
+    .svg-anim-caption {
+      opacity: 0;
+      animation: svg-fade-in 0.6s ease-out 3.2s forwards;
+    }
+
+    @keyframes svg-fade-in {
+      from {
+        opacity: 0;
+      }
+      to {
+        opacity: 1;
+      }
+    }
+
+    /* Reduced motion: show final state immediately */
+    @media (prefers-reduced-motion: reduce) {
+      .svg-clip-fg1-rect,
+      .svg-clip-fg2-rect,
+      .svg-clip-bg1-rect,
+      .svg-clip-bg2-rect {
+        animation: none;
+      }
+      .svg-anim-boundary,
+      .svg-anim-label-fg,
+      .svg-anim-label-bg,
+      .svg-anim-caption {
+        animation: none;
+        opacity: 1;
+      }
+      .svg-anim-overshoot {
+        animation: none;
+        opacity: 0;
       }
     }
     </style>
@@ -463,89 +644,218 @@
     <path class="svg-grid-line" d="M1080 80V580" />
   </g>
 
+  <!-- ======== TITLE AREA (top) ======== -->
+  <text x="110" y="72" class="svg-subtitle">Effection</text>
+  <text x="110" y="118" class="svg-title">Strict Structured</text>
+  <text x="110" y="166" class="svg-title">Concurrency</text>
+
   <!-- ======== DIAGRAM CARD ======== -->
   <g class="svg-shadow-light" filter="url(#softShadow-light)">
-    <rect class="svg-card" x="90" y="40" width="1020" height="550" rx="24" />
+    <rect class="svg-card" x="90" y="192" width="1020" height="398" rx="20" />
   </g>
   <g class="svg-shadow-dark" filter="url(#softShadow-dark)">
-    <rect class="svg-card" x="90" y="40" width="1020" height="550" rx="24" />
+    <rect class="svg-card" x="90" y="192" width="1020" height="398" rx="20" />
   </g>
 
   <!-- ======== SCOPE BOUNDARY ======== -->
   <g class="svg-shadow-light" filter="url(#tinyShadow-light)">
     <rect
       class="svg-scope-parent"
-      x="120"
-      y="70"
-      width="960"
-      height="420"
-      rx="16"
+      x="110"
+      y="208"
+      width="980"
+      height="324"
+      rx="14"
     />
   </g>
   <g class="svg-shadow-dark" filter="url(#tinyShadow-dark)">
     <rect
       class="svg-scope-parent"
-      x="120"
-      y="70"
-      width="960"
-      height="420"
-      rx="16"
+      x="110"
+      y="208"
+      width="980"
+      height="324"
+      rx="14"
     />
   </g>
-  <rect class="svg-scope-label" x="140" y="82" width="72" height="24" rx="8" />
-  <text x="152" y="99" class="svg-mono-sm">scope</text>
 
-  <!-- ======== DIVIDER ======== -->
-  <line class="svg-divider" x1="600" y1="120" x2="600" y2="470" />
+  <!-- Scope label pill -->
+  <rect
+    class="svg-scope-label-bg"
+    x="126"
+    y="218"
+    width="120"
+    height="22"
+    rx="7"
+  />
+  <text x="140" y="233" class="svg-mono-sm">getUserInfo()</text>
 
-  <!-- ======== LEFT: FOREGROUND ======== -->
-  <text x="370" y="140" class="svg-label svg-label-heading" text-anchor="middle"
-  >Foreground</text>
+  <!-- ======== TIME AXIS ======== -->
+  <line class="svg-time-axis" x1="200" y1="260" x2="1050" y2="260" />
+  <polygon class="svg-time-arrow" points="1050,256 1060,260 1050,264" />
+  <text x="1012" y="252" class="svg-time-label">time</text>
 
-  <rect class="svg-fg-box" x="200" y="168" width="340" height="48" rx="10" />
-  <circle class="svg-fg-dot" cx="224" cy="192" r="6" />
+  <!-- ======== ROW LABELS (left side) ======== -->
+  <!-- Foreground section label -->
+  <text x="136" y="310" class="svg-label svg-fg-label">FG</text>
+  <text x="136" y="358" class="svg-label svg-fg-label">FG</text>
 
-  <rect class="svg-fg-box" x="220" y="232" width="300" height="44" rx="10" />
-  <circle class="svg-fg-dot" cx="244" cy="254" r="6" />
+  <!-- Background section label -->
+  <text x="136" y="422" class="svg-label svg-bg-label-text">BG</text>
+  <text x="136" y="470" class="svg-label svg-bg-label-text">BG</text>
 
-  <rect class="svg-fg-box" x="220" y="290" width="300" height="44" rx="10" />
-  <circle class="svg-fg-dot" cx="244" cy="312" r="6" />
-
-  <!-- Check mark -->
-  <text x="220" y="416" class="svg-mono svg-check-text" stroke="none"
-  >&#x2713; values consumed</text>
-
-  <!-- ======== RIGHT: BACKGROUND ======== -->
-  <text x="830" y="140" class="svg-label svg-label-heading" text-anchor="middle"
-  >Background</text>
-
-  <rect class="svg-bg-box" x="680" y="168" width="300" height="48" rx="10" />
-  <circle class="svg-bg-dot" cx="704" cy="192" r="6" />
-
-  <rect class="svg-bg-box" x="680" y="232" width="300" height="48" rx="10" />
-  <circle class="svg-bg-dot" cx="704" cy="256" r="6" />
-
-  <rect class="svg-bg-box" x="680" y="296" width="300" height="48" rx="10" />
-  <circle class="svg-bg-dot" cx="704" cy="320" r="6" />
-
-  <!-- Fading out indication -->
-  <text x="720" y="386" class="svg-mono svg-cancel-text">scope exits</text>
-
-  <!-- Down arrow -->
+  <!-- Subtle divider between FG and BG rows -->
   <line
-    x1="790"
-    y1="396"
-    x2="790"
-    y2="428"
-    stroke-width="2"
-    class="svg-arrow-line"
-  />
-  <path
-    d="M784 422 L790 432 L796 422"
-    stroke-width="2"
-    class="svg-arrow-line"
+    x1="130"
+    y1="386"
+    x2="1070"
+    y2="386"
+    stroke-dasharray="4 4"
+    stroke-width="1"
+    class="svg-tick"
   />
 
-  <text x="720" y="460" class="svg-mono svg-cancel-text"
-  >&#x2717; automatically halted</text>
+  <!-- ======== FOREGROUND BARS ======== -->
+
+  <!-- Bar 1: fetchUser (shorter — ends at x=630) -->
+  <g clip-path="url(#svg-clip-fg1)">
+    <rect class="svg-fg-bar" x="200" y="294" width="430" height="32" rx="6" />
+    <rect
+      class="svg-fg-bar-border"
+      x="200"
+      y="294"
+      width="430"
+      height="32"
+      rx="6"
+    />
+    <text x="212" y="315" class="svg-mono" style="fill: #fff">fetchUser()</text>
+  </g>
+
+  <!-- Bar 2: fetchGroups (longer — ends at x=680, the boundary) -->
+  <g clip-path="url(#svg-clip-fg2)">
+    <rect class="svg-fg-bar" x="200" y="342" width="480" height="32" rx="6" />
+    <rect
+      class="svg-fg-bar-border"
+      x="200"
+      y="342"
+      width="480"
+      height="32"
+      rx="6"
+    />
+    <text x="212" y="363" class="svg-mono" style="fill: #fff"
+    >fetchGroups()</text>
+  </g>
+
+  <!-- ======== BACKGROUND BARS ======== -->
+
+  <!-- Bar 3: spinner — solid portion (up to boundary at x=680) -->
+  <g clip-path="url(#svg-clip-bg1)">
+    <rect class="svg-bg-bar" x="200" y="406" width="480" height="32" rx="6" />
+    <rect
+      class="svg-bg-bar-border"
+      x="200"
+      y="406"
+      width="480"
+      height="32"
+      rx="6"
+    />
+    <text x="212" y="427" class="svg-mono svg-bg-label-text">spinner</text>
+  </g>
+
+  <!-- Bar 3 overshoot: spinner past boundary (fades away) -->
+  <g class="svg-anim-overshoot" clip-path="url(#svg-clip-bg1)">
+    <rect
+      class="svg-bg-overshoot"
+      x="680"
+      y="406"
+      width="80"
+      height="32"
+      rx="0"
+    />
+    <rect
+      class="svg-bg-overshoot-border"
+      x="680"
+      y="406"
+      width="80"
+      height="32"
+      rx="0"
+    />
+  </g>
+
+  <!-- Bar 4: timeout — solid portion (up to boundary) -->
+  <g clip-path="url(#svg-clip-bg2)">
+    <rect class="svg-bg-bar" x="200" y="454" width="480" height="32" rx="6" />
+    <rect
+      class="svg-bg-bar-border"
+      x="200"
+      y="454"
+      width="480"
+      height="32"
+      rx="6"
+    />
+    <text x="212" y="475" class="svg-mono svg-bg-label-text">timeout</text>
+  </g>
+
+  <!-- Bar 4 overshoot: timeout past boundary (fades away) -->
+  <g class="svg-anim-overshoot" clip-path="url(#svg-clip-bg2)">
+    <rect
+      class="svg-bg-overshoot"
+      x="680"
+      y="454"
+      width="40"
+      height="32"
+      rx="0"
+    />
+    <rect
+      class="svg-bg-overshoot-border"
+      x="680"
+      y="454"
+      width="40"
+      height="32"
+      rx="0"
+    />
+  </g>
+
+  <!-- ======== SCOPE EXIT BOUNDARY LINE ======== -->
+  <!-- Vertical dashed line at x=680 (where foreground completes) -->
+  <g class="svg-anim-boundary">
+    <line
+      class="svg-boundary-line"
+      x1="680"
+      y1="268"
+      x2="680"
+      y2="522"
+    />
+    <!-- Boundary label -->
+    <text
+      x="680"
+      y="518"
+      text-anchor="middle"
+      class="svg-mono-sm svg-boundary-label"
+    >scope exits</text>
+  </g>
+
+  <!-- ======== RESULT LABELS ======== -->
+
+  <!-- Foreground complete label (left of boundary) -->
+  <g class="svg-anim-label-fg">
+    <text x="490" y="290" class="svg-mono-sm svg-check-text"
+    >&#x2713; values consumed</text>
+  </g>
+
+  <!-- Background reclaimed label (right of boundary) -->
+  <g class="svg-anim-label-bg">
+    <text x="700" y="443" class="svg-mono-sm svg-cancel-text"
+    >&#x2717; reclaimed</text>
+  </g>
+
+  <!-- ======== CAPTION ======== -->
+  <g class="svg-anim-caption">
+    <text
+      x="600"
+      y="570"
+      text-anchor="middle"
+      class="svg-caption"
+    >Scope lifetime aligned with what the scope computes</text>
+  </g>
 </svg>

--- a/www/blog/2026-03-12-strict-structured-concurrency/strict-structured-concurrency.svg
+++ b/www/blog/2026-03-12-strict-structured-concurrency/strict-structured-concurrency.svg
@@ -153,7 +153,7 @@
       font-family:
         ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica,
         Arial, "Apple Color Emoji", "Segoe UI Emoji";
-      font-size: 44px;
+      font-size: 52px;
       font-weight: 800;
       letter-spacing: -0.02em;
     }
@@ -645,16 +645,15 @@
   </g>
 
   <!-- ======== TITLE AREA (top) ======== -->
-  <text x="110" y="72" class="svg-subtitle">Effection</text>
-  <text x="110" y="118" class="svg-title">Strict Structured</text>
-  <text x="110" y="166" class="svg-title">Concurrency</text>
+  <text x="110" y="68" class="svg-subtitle">Effection</text>
+  <text x="110" y="122" class="svg-title">Strict Structured Concurrency</text>
 
   <!-- ======== DIAGRAM CARD ======== -->
   <g class="svg-shadow-light" filter="url(#softShadow-light)">
-    <rect class="svg-card" x="90" y="192" width="1020" height="398" rx="20" />
+    <rect class="svg-card" x="90" y="152" width="1020" height="438" rx="20" />
   </g>
   <g class="svg-shadow-dark" filter="url(#softShadow-dark)">
-    <rect class="svg-card" x="90" y="192" width="1020" height="398" rx="20" />
+    <rect class="svg-card" x="90" y="152" width="1020" height="438" rx="20" />
   </g>
 
   <!-- ======== SCOPE BOUNDARY ======== -->
@@ -662,9 +661,9 @@
     <rect
       class="svg-scope-parent"
       x="110"
-      y="208"
+      y="168"
       width="980"
-      height="324"
+      height="406"
       rx="14"
     />
   </g>
@@ -672,9 +671,9 @@
     <rect
       class="svg-scope-parent"
       x="110"
-      y="208"
+      y="168"
       width="980"
-      height="324"
+      height="406"
       rx="14"
     />
   </g>
@@ -683,66 +682,64 @@
   <rect
     class="svg-scope-label-bg"
     x="126"
-    y="218"
+    y="178"
     width="120"
     height="22"
     rx="7"
   />
-  <text x="140" y="233" class="svg-mono-sm">getUserInfo()</text>
+  <text x="140" y="193" class="svg-mono-sm">getUserInfo()</text>
 
   <!-- ======== TIME AXIS ======== -->
-  <line class="svg-time-axis" x1="200" y1="260" x2="1050" y2="260" />
-  <polygon class="svg-time-arrow" points="1050,256 1060,260 1050,264" />
-  <text x="1012" y="252" class="svg-time-label">time</text>
+  <line class="svg-time-axis" x1="200" y1="220" x2="1050" y2="220" />
+  <polygon class="svg-time-arrow" points="1050,216 1060,220 1050,224" />
+  <text x="1012" y="212" class="svg-time-label">time</text>
 
-  <!-- ======== ROW LABELS (left side) ======== -->
-  <!-- Foreground section label -->
-  <text x="136" y="310" class="svg-label svg-fg-label">FG</text>
-  <text x="136" y="358" class="svg-label svg-fg-label">FG</text>
+  <!-- ======== SECTION HEADINGS ======== -->
+  <!-- Foreground heading -->
+  <text x="200" y="252" class="svg-label svg-fg-label">FOREGROUND</text>
 
-  <!-- Background section label -->
-  <text x="136" y="422" class="svg-label svg-bg-label-text">BG</text>
-  <text x="136" y="470" class="svg-label svg-bg-label-text">BG</text>
-
-  <!-- Subtle divider between FG and BG rows -->
+  <!-- Subtle divider between FG and BG sections -->
   <line
     x1="130"
-    y1="386"
+    y1="370"
     x2="1070"
-    y2="386"
+    y2="370"
     stroke-dasharray="4 4"
     stroke-width="1"
     class="svg-tick"
   />
 
+  <!-- Background heading -->
+  <text x="200" y="398" class="svg-label svg-bg-label-text">BACKGROUND</text>
+
   <!-- ======== FOREGROUND BARS ======== -->
 
   <!-- Bar 1: fetchUser (shorter — ends at x=630) -->
   <g clip-path="url(#svg-clip-fg1)">
-    <rect class="svg-fg-bar" x="200" y="294" width="430" height="32" rx="6" />
+    <rect class="svg-fg-bar" x="200" y="268" width="430" height="34" rx="6" />
     <rect
       class="svg-fg-bar-border"
       x="200"
-      y="294"
+      y="268"
       width="430"
-      height="32"
+      height="34"
       rx="6"
     />
-    <text x="212" y="315" class="svg-mono" style="fill: #fff">fetchUser()</text>
+    <text x="212" y="290" class="svg-mono" style="fill: #fff">fetchUser()</text>
   </g>
 
   <!-- Bar 2: fetchGroups (longer — ends at x=680, the boundary) -->
   <g clip-path="url(#svg-clip-fg2)">
-    <rect class="svg-fg-bar" x="200" y="342" width="480" height="32" rx="6" />
+    <rect class="svg-fg-bar" x="200" y="318" width="480" height="34" rx="6" />
     <rect
       class="svg-fg-bar-border"
       x="200"
-      y="342"
+      y="318"
       width="480"
-      height="32"
+      height="34"
       rx="6"
     />
-    <text x="212" y="363" class="svg-mono" style="fill: #fff"
+    <text x="212" y="340" class="svg-mono" style="fill: #fff"
     >fetchGroups()</text>
   </g>
 
@@ -750,16 +747,16 @@
 
   <!-- Bar 3: spinner — solid portion (up to boundary at x=680) -->
   <g clip-path="url(#svg-clip-bg1)">
-    <rect class="svg-bg-bar" x="200" y="406" width="480" height="32" rx="6" />
+    <rect class="svg-bg-bar" x="200" y="414" width="480" height="34" rx="6" />
     <rect
       class="svg-bg-bar-border"
       x="200"
-      y="406"
+      y="414"
       width="480"
-      height="32"
+      height="34"
       rx="6"
     />
-    <text x="212" y="427" class="svg-mono svg-bg-label-text">spinner</text>
+    <text x="212" y="436" class="svg-mono svg-bg-label-text">spinner</text>
   </g>
 
   <!-- Bar 3 overshoot: spinner past boundary (fades away) -->
@@ -767,33 +764,33 @@
     <rect
       class="svg-bg-overshoot"
       x="680"
-      y="406"
+      y="414"
       width="80"
-      height="32"
+      height="34"
       rx="0"
     />
     <rect
       class="svg-bg-overshoot-border"
       x="680"
-      y="406"
+      y="414"
       width="80"
-      height="32"
+      height="34"
       rx="0"
     />
   </g>
 
   <!-- Bar 4: timeout — solid portion (up to boundary) -->
   <g clip-path="url(#svg-clip-bg2)">
-    <rect class="svg-bg-bar" x="200" y="454" width="480" height="32" rx="6" />
+    <rect class="svg-bg-bar" x="200" y="464" width="480" height="34" rx="6" />
     <rect
       class="svg-bg-bar-border"
       x="200"
-      y="454"
+      y="464"
       width="480"
-      height="32"
+      height="34"
       rx="6"
     />
-    <text x="212" y="475" class="svg-mono svg-bg-label-text">timeout</text>
+    <text x="212" y="486" class="svg-mono svg-bg-label-text">timeout</text>
   </g>
 
   <!-- Bar 4 overshoot: timeout past boundary (fades away) -->
@@ -801,17 +798,17 @@
     <rect
       class="svg-bg-overshoot"
       x="680"
-      y="454"
+      y="464"
       width="40"
-      height="32"
+      height="34"
       rx="0"
     />
     <rect
       class="svg-bg-overshoot-border"
       x="680"
-      y="454"
+      y="464"
       width="40"
-      height="32"
+      height="34"
       rx="0"
     />
   </g>
@@ -822,14 +819,14 @@
     <line
       class="svg-boundary-line"
       x1="680"
-      y1="268"
+      y1="228"
       x2="680"
-      y2="522"
+      y2="562"
     />
     <!-- Boundary label -->
     <text
       x="680"
-      y="518"
+      y="558"
       text-anchor="middle"
       class="svg-mono-sm svg-boundary-label"
     >scope exits</text>
@@ -837,15 +834,15 @@
 
   <!-- ======== RESULT LABELS ======== -->
 
-  <!-- Foreground complete label (left of boundary) -->
+  <!-- Foreground complete label (between bars and divider) -->
   <g class="svg-anim-label-fg">
-    <text x="490" y="290" class="svg-mono-sm svg-check-text"
+    <text x="490" y="364" class="svg-mono-sm svg-check-text"
     >&#x2713; values consumed</text>
   </g>
 
   <!-- Background reclaimed label (right of boundary) -->
   <g class="svg-anim-label-bg">
-    <text x="700" y="443" class="svg-mono-sm svg-cancel-text"
+    <text x="700" y="456" class="svg-mono-sm svg-cancel-text"
     >&#x2717; reclaimed</text>
   </g>
 
@@ -853,7 +850,7 @@
   <g class="svg-anim-caption">
     <text
       x="600"
-      y="570"
+      y="616"
       text-anchor="middle"
       class="svg-caption"
     >Scope lifetime aligned with what the scope computes</text>

--- a/www/blog/2026-03-12-strict-structured-concurrency/strict-structured-concurrency.svg
+++ b/www/blog/2026-03-12-strict-structured-concurrency/strict-structured-concurrency.svg
@@ -1,0 +1,551 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg
+  width="1200"
+  height="630"
+  viewBox="0 0 1200 630"
+  fill="none"
+  xmlns="http://www.w3.org/2000/svg"
+  role="img"
+  aria-label="Strict Structured Concurrency — foreground tasks express the algorithm, background tasks are automatically reclaimed when the scope exits"
+>
+  <defs>
+    <!-- Light-mode background gradient -->
+    <linearGradient
+      id="bg-light-grad"
+      x1="0"
+      y1="0"
+      x2="1200"
+      y2="630"
+      gradientUnits="userSpaceOnUse"
+    >
+      <stop offset="0" stop-color="#F8FAFF" />
+      <stop offset="0.55" stop-color="#F2F7FF" />
+      <stop offset="1" stop-color="#ECF3FF" />
+    </linearGradient>
+
+    <!-- Light-mode decorative glow -->
+    <radialGradient
+      id="glow-light-grad"
+      cx="0"
+      cy="0"
+      r="1"
+      gradientUnits="userSpaceOnUse"
+      gradientTransform="translate(900 120) rotate(120) scale(560 420)"
+    >
+      <stop offset="0" stop-color="#2B6FF7" stop-opacity="0.22" />
+      <stop offset="0.55" stop-color="#2B6FF7" stop-opacity="0.07" />
+      <stop offset="1" stop-color="#2B6FF7" stop-opacity="0" />
+    </radialGradient>
+
+    <!-- Dark-mode decorative glow -->
+    <radialGradient
+      id="glow-dark-grad"
+      cx="0"
+      cy="0"
+      r="1"
+      gradientUnits="userSpaceOnUse"
+      gradientTransform="translate(900 120) rotate(120) scale(560 420)"
+    >
+      <stop offset="0" stop-color="#60A5FA" stop-opacity="0.10" />
+      <stop offset="0.55" stop-color="#60A5FA" stop-opacity="0.03" />
+      <stop offset="1" stop-color="#60A5FA" stop-opacity="0" />
+    </radialGradient>
+
+    <!-- Light-mode title gradient -->
+    <linearGradient id="ink" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0B2A5B" />
+      <stop offset="1" stop-color="#0C3A7A" />
+    </linearGradient>
+
+    <!-- Light-mode shadow (card) -->
+    <filter
+      id="softShadow-light"
+      x="-40"
+      y="-40"
+      width="1280"
+      height="710"
+      filterUnits="userSpaceOnUse"
+      color-interpolation-filters="sRGB"
+    >
+      <feDropShadow
+        dx="0"
+        dy="10"
+        stdDeviation="18"
+        flood-color="#0B2A5B"
+        flood-opacity="0.12"
+      />
+    </filter>
+
+    <!-- Dark-mode shadow (card) -->
+    <filter
+      id="softShadow-dark"
+      x="-40"
+      y="-40"
+      width="1280"
+      height="710"
+      filterUnits="userSpaceOnUse"
+      color-interpolation-filters="sRGB"
+    >
+      <feDropShadow
+        dx="0"
+        dy="10"
+        stdDeviation="18"
+        flood-color="#000000"
+        flood-opacity="0.25"
+      />
+    </filter>
+
+    <!-- Light-mode shadow (inner) -->
+    <filter
+      id="tinyShadow-light"
+      x="-40"
+      y="-40"
+      width="1280"
+      height="710"
+      filterUnits="userSpaceOnUse"
+      color-interpolation-filters="sRGB"
+    >
+      <feDropShadow
+        dx="0"
+        dy="5"
+        stdDeviation="10"
+        flood-color="#0B2A5B"
+        flood-opacity="0.10"
+      />
+    </filter>
+
+    <!-- Dark-mode shadow (inner) -->
+    <filter
+      id="tinyShadow-dark"
+      x="-40"
+      y="-40"
+      width="1280"
+      height="710"
+      filterUnits="userSpaceOnUse"
+      color-interpolation-filters="sRGB"
+    >
+      <feDropShadow
+        dx="0"
+        dy="5"
+        stdDeviation="10"
+        flood-color="#000000"
+        flood-opacity="0.20"
+      />
+    </filter>
+
+    <style>
+    /* ---- Font stacks ---- */
+    .svg-title {
+      font-family:
+        ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica,
+        Arial, "Apple Color Emoji", "Segoe UI Emoji";
+      font-size: 48px;
+      font-weight: 800;
+      letter-spacing: -0.02em;
+    }
+    .svg-subtitle {
+      font-family:
+        ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica,
+        Arial, "Apple Color Emoji", "Segoe UI Emoji";
+      font-size: 18px;
+      font-weight: 600;
+      letter-spacing: 0.02em;
+      text-transform: uppercase;
+    }
+    .svg-caption {
+      font-family:
+        ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica,
+        Arial, "Apple Color Emoji", "Segoe UI Emoji";
+      font-size: 18px;
+      font-weight: 600;
+    }
+    .svg-mono {
+      font-family:
+        ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+        "Liberation Mono", "Courier New", monospace;
+      font-size: 14px;
+    }
+    .svg-mono-sm {
+      font-family:
+        ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+        "Liberation Mono", "Courier New", monospace;
+      font-size: 12px;
+    }
+    .svg-label {
+      font-family:
+        ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica,
+        Arial, "Apple Color Emoji", "Segoe UI Emoji";
+      font-size: 15px;
+      font-weight: 700;
+      letter-spacing: 0.03em;
+      text-transform: uppercase;
+    }
+
+    /* ---- Light mode (default) ---- */
+    .svg-bg-light {
+      display: block;
+    }
+    .svg-bg-dark {
+      display: none;
+    }
+    .svg-glow-light {
+      display: block;
+    }
+    .svg-glow-dark {
+      display: none;
+    }
+    .svg-shadow-light {
+      display: block;
+    }
+    .svg-shadow-dark {
+      display: none;
+    }
+
+    .svg-grid {
+      opacity: 0.25;
+    }
+    .svg-grid-line {
+      stroke: #c9d9f2;
+      stroke-width: 1;
+    }
+
+    .svg-card {
+      fill: #ffffff;
+    }
+    .svg-divider {
+      stroke: #d6e4ff;
+      stroke-dasharray: 4 4;
+      stroke-width: 1;
+    }
+
+    /* Foreground side */
+    .svg-fg-box {
+      fill: #ffffff;
+      stroke: #2b6ff7;
+      stroke-width: 2;
+    }
+    .svg-fg-dot {
+      fill: #2b6ff7;
+    }
+    .svg-fg-label {
+      fill: #2b6ff7;
+    }
+
+    /* Background side */
+    .svg-bg-box {
+      fill: #ffffff;
+      stroke: #9ca3af;
+      stroke-width: 1.5;
+      stroke-dasharray: 6 3;
+    }
+    .svg-bg-dot {
+      fill: #9ca3af;
+    }
+    .svg-bg-label {
+      fill: #6b7280;
+    }
+    .svg-bg-fade {
+      fill: #9ca3af;
+      opacity: 0.4;
+    }
+
+    /* Scope */
+    .svg-scope-parent {
+      fill: #f7fbff;
+      stroke: #97b7ff;
+      stroke-width: 2;
+    }
+    .svg-scope-label {
+      fill: #e6f0ff;
+    }
+    .svg-dot-primary {
+      fill: #2b6ff7;
+    }
+    .svg-check-text {
+      fill: #16a34a;
+      stroke: #16a34a;
+    }
+    .svg-cancel-text {
+      fill: #9ca3af;
+    }
+    .svg-arrow-line {
+      stroke: #97b7ff;
+      fill: none;
+    }
+
+    /* Shared text */
+    .svg-title {
+      fill: url(#ink);
+    }
+    .svg-subtitle {
+      fill: #33547b;
+    }
+    .svg-caption {
+      fill: #23435f;
+    }
+    .svg-mono {
+      fill: #1e3a8a;
+    }
+    .svg-mono-sm {
+      fill: #1e3a8a;
+    }
+    .svg-label {
+      fill: #33547b;
+    }
+    .svg-label-heading {
+      fill: #0b2a5b;
+    }
+
+    /* ---- Dark mode ---- */
+    @media (prefers-color-scheme: dark) {
+      .svg-bg-light {
+        display: none;
+      }
+      .svg-bg-dark {
+        display: block;
+      }
+      .svg-glow-light {
+        display: none;
+      }
+      .svg-glow-dark {
+        display: block;
+      }
+      .svg-shadow-light {
+        display: none;
+      }
+      .svg-shadow-dark {
+        display: block;
+      }
+
+      .svg-grid {
+        opacity: 0.20;
+      }
+      .svg-grid-line {
+        stroke: #374151;
+      }
+
+      .svg-card {
+        fill: #1f2937;
+      }
+      .svg-divider {
+        stroke: #374151;
+      }
+
+      .svg-fg-box {
+        fill: #1f2937;
+        stroke: #60a5fa;
+      }
+      .svg-fg-dot {
+        fill: #60a5fa;
+      }
+      .svg-fg-label {
+        fill: #60a5fa;
+      }
+
+      .svg-bg-box {
+        fill: #1f2937;
+        stroke: #6b7280;
+      }
+      .svg-bg-dot {
+        fill: #6b7280;
+      }
+      .svg-bg-label {
+        fill: #9ca3af;
+      }
+      .svg-bg-fade {
+        fill: #6b7280;
+        opacity: 0.4;
+      }
+
+      .svg-scope-parent {
+        fill: #111827;
+        stroke: #374151;
+      }
+      .svg-scope-label {
+        fill: #1e3a8a;
+      }
+      .svg-dot-primary {
+        fill: #60a5fa;
+      }
+      .svg-check-text {
+        fill: #4ade80;
+        stroke: #4ade80;
+      }
+      .svg-cancel-text {
+        fill: #6b7280;
+      }
+      .svg-arrow-line {
+        stroke: #60a5fa;
+      }
+
+      .svg-title {
+        fill: #f3f4f6;
+      }
+      .svg-subtitle {
+        fill: #9ca3af;
+      }
+      .svg-caption {
+        fill: #d1d5db;
+      }
+      .svg-mono {
+        fill: #e5e7eb;
+      }
+      .svg-mono-sm {
+        fill: #e5e7eb;
+      }
+      .svg-label {
+        fill: #9ca3af;
+      }
+      .svg-label-heading {
+        fill: #f3f4f6;
+      }
+    }
+    </style>
+  </defs>
+
+  <!-- ======== BACKGROUND ======== -->
+  <rect
+    class="svg-bg-light"
+    x="0"
+    y="0"
+    width="1200"
+    height="630"
+    fill="url(#bg-light-grad)"
+  />
+  <rect
+    class="svg-bg-dark"
+    x="0"
+    y="0"
+    width="1200"
+    height="630"
+    fill="#111827"
+  />
+  <rect
+    class="svg-glow-light"
+    x="0"
+    y="0"
+    width="1200"
+    height="630"
+    fill="url(#glow-light-grad)"
+  />
+  <rect
+    class="svg-glow-dark"
+    x="0"
+    y="0"
+    width="1200"
+    height="630"
+    fill="url(#glow-dark-grad)"
+  />
+
+  <!-- ======== SUBTLE GRID ======== -->
+  <g class="svg-grid">
+    <path class="svg-grid-line" d="M90 90H1110" />
+    <path class="svg-grid-line" d="M90 150H1110" />
+    <path class="svg-grid-line" d="M90 210H1110" />
+    <path class="svg-grid-line" d="M90 270H1110" />
+    <path class="svg-grid-line" d="M90 330H1110" />
+    <path class="svg-grid-line" d="M90 390H1110" />
+    <path class="svg-grid-line" d="M90 450H1110" />
+    <path class="svg-grid-line" d="M90 510H1110" />
+    <path class="svg-grid-line" d="M90 570H1110" />
+    <path class="svg-grid-line" d="M120 80V580" />
+    <path class="svg-grid-line" d="M200 80V580" />
+    <path class="svg-grid-line" d="M280 80V580" />
+    <path class="svg-grid-line" d="M360 80V580" />
+    <path class="svg-grid-line" d="M440 80V580" />
+    <path class="svg-grid-line" d="M520 80V580" />
+    <path class="svg-grid-line" d="M600 80V580" />
+    <path class="svg-grid-line" d="M680 80V580" />
+    <path class="svg-grid-line" d="M760 80V580" />
+    <path class="svg-grid-line" d="M840 80V580" />
+    <path class="svg-grid-line" d="M920 80V580" />
+    <path class="svg-grid-line" d="M1000 80V580" />
+    <path class="svg-grid-line" d="M1080 80V580" />
+  </g>
+
+  <!-- ======== DIAGRAM CARD ======== -->
+  <g class="svg-shadow-light" filter="url(#softShadow-light)">
+    <rect class="svg-card" x="90" y="40" width="1020" height="550" rx="24" />
+  </g>
+  <g class="svg-shadow-dark" filter="url(#softShadow-dark)">
+    <rect class="svg-card" x="90" y="40" width="1020" height="550" rx="24" />
+  </g>
+
+  <!-- ======== SCOPE BOUNDARY ======== -->
+  <g class="svg-shadow-light" filter="url(#tinyShadow-light)">
+    <rect
+      class="svg-scope-parent"
+      x="120"
+      y="70"
+      width="960"
+      height="420"
+      rx="16"
+    />
+  </g>
+  <g class="svg-shadow-dark" filter="url(#tinyShadow-dark)">
+    <rect
+      class="svg-scope-parent"
+      x="120"
+      y="70"
+      width="960"
+      height="420"
+      rx="16"
+    />
+  </g>
+  <rect class="svg-scope-label" x="140" y="82" width="72" height="24" rx="8" />
+  <text x="152" y="99" class="svg-mono-sm">scope</text>
+
+  <!-- ======== DIVIDER ======== -->
+  <line class="svg-divider" x1="600" y1="120" x2="600" y2="470" />
+
+  <!-- ======== LEFT: FOREGROUND ======== -->
+  <text x="370" y="140" class="svg-label svg-label-heading" text-anchor="middle"
+  >Foreground</text>
+
+  <rect class="svg-fg-box" x="200" y="168" width="340" height="48" rx="10" />
+  <circle class="svg-fg-dot" cx="224" cy="192" r="6" />
+
+  <rect class="svg-fg-box" x="220" y="232" width="300" height="44" rx="10" />
+  <circle class="svg-fg-dot" cx="244" cy="254" r="6" />
+
+  <rect class="svg-fg-box" x="220" y="290" width="300" height="44" rx="10" />
+  <circle class="svg-fg-dot" cx="244" cy="312" r="6" />
+
+  <!-- Check mark -->
+  <text x="220" y="416" class="svg-mono svg-check-text" stroke="none"
+  >&#x2713; values consumed</text>
+
+  <!-- ======== RIGHT: BACKGROUND ======== -->
+  <text x="830" y="140" class="svg-label svg-label-heading" text-anchor="middle"
+  >Background</text>
+
+  <rect class="svg-bg-box" x="680" y="168" width="300" height="48" rx="10" />
+  <circle class="svg-bg-dot" cx="704" cy="192" r="6" />
+
+  <rect class="svg-bg-box" x="680" y="232" width="300" height="48" rx="10" />
+  <circle class="svg-bg-dot" cx="704" cy="256" r="6" />
+
+  <rect class="svg-bg-box" x="680" y="296" width="300" height="48" rx="10" />
+  <circle class="svg-bg-dot" cx="704" cy="320" r="6" />
+
+  <!-- Fading out indication -->
+  <text x="720" y="386" class="svg-mono svg-cancel-text">scope exits</text>
+
+  <!-- Down arrow -->
+  <line
+    x1="790"
+    y1="396"
+    x2="790"
+    y2="428"
+    stroke-width="2"
+    class="svg-arrow-line"
+  />
+  <path
+    d="M784 422 L790 432 L796 422"
+    stroke-width="2"
+    class="svg-arrow-line"
+  />
+
+  <text x="720" y="460" class="svg-mono svg-cancel-text"
+  >&#x2717; automatically halted</text>
+</svg>


### PR DESCRIPTION
# Motivation

The strict structured concurrency post already introduced foreground and background work, but it still read primarily as a convenience refinement. This follow-up makes the stronger claim explicit: when incidental background work can keep a scope alive after the meaningful computation is complete, the lifetime model is semantically wrong and every framework built on top of it inherits an incorrectness tax.

# Approach

Rewrite the article to lead with the correctness argument, introduce foreground vs background earlier, and recast the spinner/timeout example as a semantic and operational failure mode rather than cleanup boilerplate. Preserve the existing points about aggressive teardown, classic structured concurrency, and orderly cleanup while tightening the argument around lifetime correctness, hung scopes, and the operational cost of letting support work outlive the computation it was supposed to support.