### PR TITLE
Fix /x/worker/ page broken by generic type params in MDX

### DIFF
--- a/www/hooks/use-markdown.tsx
+++ b/www/hooks/use-markdown.tsx
@@ -49,6 +49,14 @@ export function* useMarkdown(
   );
   let sanitized = yield* sanitize(markdown);
 
+  // Escape generic type parameters like <T>, <TSend, TRecv> that MDX
+  // would interpret as JSX tags. Only matches uppercase-starting identifiers
+  // inside angle brackets to avoid escaping actual HTML tags.
+  sanitized = sanitized.replace(
+    /<([A-Z]\w*(?:\s*,\s*[A-Z]\w*)*)>/g,
+    "&lt;$1&gt;",
+  );
+
   let mod = yield* useMDX(sanitized, {
     remarkPlugins: [remarkGfm, ...(options?.remarkPlugins ?? [])],
     rehypePlugins: [


### PR DESCRIPTION
## Summary
- The `/x/worker/` page was failing with "Failed to load worker due to error" because MDX interpreted generic type references like `Result<T>` in JSDoc comments as JSX tags
- Added a regex in `useMarkdown` to escape uppercase-starting angle bracket patterns (e.g. `<T>`, `<TSend, TRecv>`) to HTML entities before MDX processing
- Only affects TypeScript-style generics (uppercase start), not actual HTML tags (lowercase)

## Test plan
- [x] Verified `/x/worker/` renders correctly with README + API reference (155KB vs 13KB error page)
- [x] Verified `/x/fetch/`, `/x/websocket/`, `/x/process/` still render correctly
- [x] No server errors in console