### PR TITLE
🤖 Add no-marketing-material directive to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -382,6 +382,9 @@ Use [gitmoji](https://gitmoji.dev) for commit and pull request subjects. For
 changes to files that direct the behavior of AI such as AGENTS.md or llms.txt
 use a robot emoji instead of the standard gitmoji for documentation
 
+Do not include any agent marketing material (e.g. "Generated with...",
+"Co-Authored-By: \<agent>") in commits, pull requests, issues, or comments.
+
 ## Pre-commit workflow
 
 Before committing any changes to this repository:


### PR DESCRIPTION
# Motivation

Agent tools often append marketing footers (e.g. "Generated with...",
"Co-Authored-By: <agent>") to commits, PRs, issues, and comments. We are not being paid for this free advertising, so it should not appear in our project history.

# Approach

Add a directive to the "Commit and PR conventions" section of AGENTS.md instructing agents not to include any marketing material in commits, pull requests, issues, or comments.