### PR TITLE
⏱️ Increase interval test timeout for CI reliability

### DIFF
--- a/test/interval.test.ts
+++ b/test/interval.test.ts
@@ -17,7 +17,7 @@ describe("interval", () => {
       let result = yield* race([
         task,
         call(function* () {
-          yield* sleep(50);
+          yield* sleep(500);
           return "interval not producing!";
         }),
       ]);


### PR DESCRIPTION
# Motivation

In CI environments (especially Windows), 50ms is not enough time to reliably produce 10 intervals. The test flakes because the timeout fires before the intervals are observed.

# Approach

Increase the interval test timeout from 50ms to 500ms. This has no impact on test duration since the `race` resolves as soon as 10 intervals are observed — the timeout only fires if something is actually broken.