### PR TITLE
🐛 Fix Windows test flakes and format blog SVGs

### DIFF
--- a/test/interval.test.ts
+++ b/test/interval.test.ts
@@ -17,7 +17,7 @@ describe("interval", () => {
       let result = yield* race([
         task,
         call(function* () {
-          yield* sleep(50);
+          yield* sleep(500);
           return "interval not producing!";
         }),
       ]);

--- a/test/suite.ts
+++ b/test/suite.ts
@@ -117,11 +117,12 @@ export function x(
       },
       lines: stream(tinyexec),
       *kill(signal) {
-        tinyexec.kill(signal);
         if (
           Deno.build.os === "windows" && signal === "SIGINT" && tinyexec.pid
         ) {
           ctrlc(tinyexec.pid);
+        } else {
+          tinyexec.kill(signal);
         }
         let result = yield* output;
 

--- a/www/blog/2026-02-06-structured-concurrency-for-javascript/structured-concurrency-js.svg
+++ b/www/blog/2026-02-06-structured-concurrency-for-javascript/structured-concurrency-js.svg
@@ -133,8 +133,7 @@
       />
     </filter>
 
-    <style>
-    /* ---- Font stacks ---- */
+    <style>/* ---- Font stacks ---- */
     .svg-title {
       font-family:
         ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica,
@@ -411,8 +410,7 @@
       .svg-label-heading {
         fill: #f3f4f6;
       }
-    }
-    </style>
+    }</style>
   </defs>
 
   <!-- ======== BACKGROUND ======== -->
@@ -498,7 +496,11 @@
   <!-- ======== LEFT SIDE: PROMISES ======== -->
 
   <!-- Section heading -->
-  <text x="680" y="128" class="svg-label svg-label-heading" text-anchor="middle"
+  <text
+    x="680"
+    y="128"
+    class="svg-label svg-label-heading"
+    text-anchor="middle"
   >Promises</text>
 
   <!-- Dashed function boundary — intentionally small so boxes overflow -->
@@ -573,17 +575,27 @@
   <!-- Status text below (warning color) -->
   <text x="592" y="430" class="svg-mono-sm svg-leak-text">● still pending</text>
   <text x="592" y="450" class="svg-mono-sm svg-leak-text">● still ticking</text>
-  <text x="592" y="470" class="svg-mono-sm svg-leak-text"
+  <text
+    x="592"
+    y="470"
+    class="svg-mono-sm svg-leak-text"
   >● port still bound</text>
 
   <!-- Punchline -->
-  <text x="592" y="508" class="svg-mono-sm svg-uncertain-text"
+  <text
+    x="592"
+    y="508"
+    class="svg-mono-sm svg-uncertain-text"
   >finally {} ?</text>
 
   <!-- ======== RIGHT SIDE: EFFECTION ======== -->
 
   <!-- Section heading -->
-  <text x="975" y="128" class="svg-label svg-label-heading" text-anchor="middle"
+  <text
+    x="975"
+    y="128"
+    class="svg-label svg-label-heading"
+    text-anchor="middle"
   >Effection</text>
 
   <!-- Parent scope (solid boundary) — wide enough for the boxes -->
@@ -698,10 +710,17 @@
   />
 
   <!-- Checkmark -->
-  <text x="880" y="498" class="svg-mono-sm svg-check-text" stroke="none"
+  <text
+    x="880"
+    y="498"
+    class="svg-mono-sm svg-check-text"
+    stroke="none"
   >✓ halted + cleaned up</text>
 
   <!-- ======== BOTTOM TAGLINE ======== -->
-  <text x="90" y="560" class="svg-mono svg-caption"
+  <text
+    x="90"
+    y="560"
+    class="svg-mono svg-caption"
   >Async should just feel normal.</text>
 </svg>

--- a/www/blog/2026-02-13-abortcontroller-abort-doesnt-mean-it-stopped/abortcontroller-abort.svg
+++ b/www/blog/2026-02-13-abortcontroller-abort-doesnt-mean-it-stopped/abortcontroller-abort.svg
@@ -94,8 +94,7 @@
       />
     </filter>
 
-    <style>
-    /* ---- Font stacks ---- */
+    <style>/* ---- Font stacks ---- */
     .svg-title {
       font-family:
         ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica,
@@ -636,8 +635,7 @@
         opacity: 0;
         animation: none;
       }
-    }
-    </style>
+    }</style>
   </defs>
 
   <!-- ======== BACKGROUND ======== -->
@@ -678,7 +676,7 @@
   <text x="60" y="52" class="svg-subtitle">Effection Blog</text>
   <text y="100" class="svg-title">
     <tspan x="60" class="svg-title-mono">AbortController.abort()</tspan>
-    <tspan class="svg-title"> Doesn't Mean It Stopped</tspan>
+    <tspan class="svg-title">Doesn't Mean It Stopped</tspan>
   </text>
 
   <!-- ======== LEFT TERMINAL: AbortController ======== -->
@@ -745,31 +743,70 @@
   <!-- Left terminal content -->
   <g class="svg-mono">
     <text x="80" y="210" class="svg-terminal-text svg-cursor">█</text>
-    <text x="80" y="210" class="svg-terminal-text svg-anim-line svg-anim-L1"
+    <text
+      x="80"
+      y="210"
+      class="svg-terminal-text svg-anim-line svg-anim-L1"
     >tick: STILL RUNNING</text>
-    <text x="80" y="230" class="svg-terminal-text svg-anim-line svg-anim-L2"
+    <text
+      x="80"
+      y="230"
+      class="svg-terminal-text svg-anim-line svg-anim-L2"
     >tick: STILL RUNNING</text>
-    <text x="80" y="250" class="svg-terminal-text svg-anim-line svg-anim-L3"
+    <text
+      x="80"
+      y="250"
+      class="svg-terminal-text svg-anim-line svg-anim-L3"
     >tick: STILL RUNNING</text>
-    <text x="80" y="280" class="svg-terminal-dim svg-anim-line svg-anim-L4"
+    <text
+      x="80"
+      y="280"
+      class="svg-terminal-dim svg-anim-line svg-anim-L4"
     >>>> calling abort()</text>
-    <text x="80" y="300" class="svg-terminal-dim svg-anim-line svg-anim-L5"
+    <text
+      x="80"
+      y="300"
+      class="svg-terminal-dim svg-anim-line svg-anim-L5"
     >>>> abort() returned</text>
-    <text x="80" y="330" class="svg-terminal-info svg-anim-line svg-anim-L6"
+    <text
+      x="80"
+      y="330"
+      class="svg-terminal-info svg-anim-line svg-anim-L6"
     >task ended with: aborted</text>
-    <text x="80" y="360" class="svg-terminal-dim svg-anim-line svg-anim-L7"
+    <text
+      x="80"
+      y="360"
+      class="svg-terminal-dim svg-anim-line svg-anim-L7"
     >>>> caller thinks it's done</text>
-    <text x="80" y="400" class="svg-terminal-warn svg-anim-line svg-anim-L8"
+    <text
+      x="80"
+      y="400"
+      class="svg-terminal-warn svg-anim-line svg-anim-L8"
     >tick: STILL RUNNING</text>
-    <text x="80" y="420" class="svg-terminal-warn svg-anim-line svg-anim-L9"
+    <text
+      x="80"
+      y="420"
+      class="svg-terminal-warn svg-anim-line svg-anim-L9"
     >tick: STILL RUNNING</text>
-    <text x="80" y="440" class="svg-terminal-warn svg-anim-line svg-anim-L10"
+    <text
+      x="80"
+      y="440"
+      class="svg-terminal-warn svg-anim-line svg-anim-L10"
     >tick: STILL RUNNING</text>
-    <text x="80" y="460" class="svg-terminal-warn svg-anim-line svg-anim-L11"
+    <text
+      x="80"
+      y="460"
+      class="svg-terminal-warn svg-anim-line svg-anim-L11"
     >tick: STILL RUNNING</text>
-    <text x="80" y="480" class="svg-terminal-warn svg-anim-line svg-anim-L12"
+    <text
+      x="80"
+      y="480"
+      class="svg-terminal-warn svg-anim-line svg-anim-L12"
     >tick: STILL RUNNING</text>
-    <text x="80" y="500" class="svg-terminal-dim svg-anim-line svg-anim-L13"
+    <text
+      x="80"
+      y="500"
+      class="svg-terminal-dim svg-anim-line svg-anim-L13"
     >...</text>
   </g>
 
@@ -858,17 +895,35 @@
   <!-- Right terminal content -->
   <g class="svg-mono">
     <text x="640" y="210" class="svg-terminal-text svg-cursor">█</text>
-    <text x="640" y="210" class="svg-terminal-text svg-anim-line svg-anim-R1"
+    <text
+      x="640"
+      y="210"
+      class="svg-terminal-text svg-anim-line svg-anim-R1"
     >tick: RUNNING</text>
-    <text x="640" y="230" class="svg-terminal-text svg-anim-line svg-anim-R2"
+    <text
+      x="640"
+      y="230"
+      class="svg-terminal-text svg-anim-line svg-anim-R2"
     >tick: RUNNING</text>
-    <text x="640" y="250" class="svg-terminal-text svg-anim-line svg-anim-R3"
+    <text
+      x="640"
+      y="250"
+      class="svg-terminal-text svg-anim-line svg-anim-R3"
     >tick: RUNNING</text>
-    <text x="640" y="280" class="svg-terminal-dim svg-anim-line svg-anim-R4"
+    <text
+      x="640"
+      y="280"
+      class="svg-terminal-dim svg-anim-line svg-anim-R4"
     >>>> leaving scope</text>
-    <text x="640" y="300" class="svg-terminal-dim svg-anim-line svg-anim-R5"
+    <text
+      x="640"
+      y="300"
+      class="svg-terminal-dim svg-anim-line svg-anim-R5"
     >>>> scope exited</text>
-    <text x="640" y="350" class="svg-terminal-success svg-anim-line svg-anim-R6"
+    <text
+      x="640"
+      y="350"
+      class="svg-terminal-success svg-anim-line svg-anim-R6"
     >all children stopped</text>
   </g>
 

--- a/www/blog/blog-image-template.svg
+++ b/www/blog/blog-image-template.svg
@@ -148,8 +148,7 @@
       />
     </filter>
 
-    <style>
-    /* ---- Font stacks ---- */
+    <style>/* ---- Font stacks ---- */
     .svg-title {
       font-family:
         ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica,
@@ -426,8 +425,7 @@
       .svg-label-heading {
         fill: #f3f4f6;
       }
-    }
-    </style>
+    }</style>
   </defs>
 
   <!-- ======== BACKGROUND ======== -->


### PR DESCRIPTION
# Motivation

Three Windows CI issues that must land together — each fix alone still fails CI due to the other two:

1. **Windows main test flake**: The `main` tests (`gracefully shuts down on SIGINT`, `works even if suspend is the only operation`) fail on Windows because `tinyexec.kill('SIGINT')` forcefully terminates the process before `ctrlc()` can send a graceful `CTRL_C_EVENT`. The subprocess dies before its `finally` block runs, so stdout is empty.

2. **Unformatted blog SVGs**: SVGs added in #1103 and #1111 were hand-authored and merged without running `deno fmt`. This causes `deno fmt --check` to fail on Ubuntu CI.

3. **Windows interval test flake**: The interval test uses a 50ms timeout, which isn't enough time to produce 10 intervals on Windows CI. The timeout fires before the intervals are observed.

# Approach

- **Windows kill fix** (`test/suite.ts`): On Windows with SIGINT, skip `tinyexec.kill()` and only call `ctrlc(pid)`. This lets the daemon receive the ctrl-c, run its `finally` block, and exit cleanly.
- **SVG formatting** (`www/blog/**/*.svg`): Run `deno fmt` on the three affected files. Changes are purely whitespace.
- **Interval timeout** (`test/interval.test.ts`): Increase timeout from 50ms to 500ms. No impact on test duration since the race resolves as soon as 10 intervals are observed.