### PR TITLE
🐛 Ensure Task.halt() does not resolve before resource cleanup finishes

### DIFF
--- a/lib/delimiter.ts
+++ b/lib/delimiter.ts
@@ -12,6 +12,7 @@ export class Delimiter<T>
   finalized = false;
   future = withResolvers<Maybe<Result<T>>>();
   computed = false;
+  settling = false;
   routine?: Coroutine;
   outcome?: Maybe<Result<T>>;
 
@@ -33,6 +34,10 @@ export class Delimiter<T>
     this.exit(Nothing());
   }
 
+  settle(): void {
+    this.settling = true;
+  }
+
   *close(): Operation<void> {
     let done = this.future.operation;
     let interrupted = !this.computed;
@@ -45,6 +50,8 @@ export class Delimiter<T>
     };
     if (!this.outcome) {
       this.interrupt();
+      yield* this.close();
+    } else if (!this.finalized) {
       yield* this.close();
     } else {
       if (interrupted && this.outcome.exists && !this.outcome.value.ok) {
@@ -65,7 +72,7 @@ export class Delimiter<T>
     if (!this.routine) {
       this.finalized = true;
       this.future.resolve(this.outcome);
-    } else {
+    } else if (!this.settling) {
       this.routine.return(Ok(this.outcome));
     }
   }

--- a/lib/task-group.ts
+++ b/lib/task-group.ts
@@ -1,6 +1,8 @@
 import { createContext } from "./context.ts";
 import { box } from "./box.ts";
+import { DelimiterContext } from "./delimiter.ts";
 import { Ok, unbox } from "./result.ts";
+import { useScope } from "./scope.ts";
 import type { Operation, Task } from "./types.ts";
 
 export class TaskGroup {
@@ -40,7 +42,14 @@ export function encapsulate<T>(operation: () => Operation<T>): Operation<T> {
     try {
       return yield* operation();
     } finally {
-      yield* group.halt();
+      let scope = yield* useScope();
+      let delimiter = scope.expect(DelimiterContext);
+      delimiter.settle();
+      try {
+        yield* group.halt();
+      } finally {
+        delimiter.settling = false;
+      }
     }
   });
 }

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -4,6 +4,7 @@ import { Children } from "../lib/contexts.ts";
 import {
   action,
   createScope,
+  resource,
   run,
   type Scope,
   sleep,
@@ -164,6 +165,33 @@ describe("run()", () => {
     await expect(task).rejects.toMatchObject({ message: "halted" });
 
     expect(completed).toEqual(true);
+  });
+
+  it("halts only after resource cleanup finishes", async () => {
+    let events: string[] = [];
+    let entered = Promise.withResolvers<void>();
+
+    let task = run(function* () {
+      yield* resource(function* (provide) {
+        try {
+          yield* provide("resource");
+        } finally {
+          events.push("cleanup:entered");
+          entered.resolve();
+          yield* sleep(50);
+          events.push("cleanup:finished");
+        }
+      });
+    });
+
+    await entered.promise;
+
+    await task.halt();
+    events.push("halt:resolved");
+
+    expect(events.indexOf("halt:resolved")).toBeGreaterThan(
+      events.indexOf("cleanup:finished"),
+    );
   });
 
   it("can suspend in yielded finally block", async () => {


### PR DESCRIPTION
## Motivation

`Task.halt()` can resolve while async resource cleanup is still running. Code that uses `await task.halt()` as a join point can proceed while resource finalizers are still suspended, producing leaked work and use-after-close races.

Fixes #1153

## Approach

Add a `settling` flag to `Delimiter` that `encapsulate` sets when entering its finally block (before `group.halt()`). While settling, `exit()` skips the `.return()` call since the operation is already winding down naturally. `close()` now also waits for the delimiter future when the outcome is set but not yet finalized.

The flag is reset after `group.halt()` completes so that inner `encapsulate` calls (e.g. `callcc`) don't permanently poison the parent delimiter.

### Possible Drawbacks or Risks

This is a spike — the `settling` flag adds a new state bit to `Delimiter` and a coupling between `encapsulate` and `Delimiter` via `DelimiterContext`. A future refactor could internalize this into the Delimiter itself.

### TODOs and Open Questions

- [ ] Evaluate whether `settling` should live inside the Delimiter's own `[Symbol.iterator]` rather than being set externally by `encapsulate`