### PR TITLE
🐛 Skip non-documentable .wasm exports in doc generation

### DIFF
--- a/www/lib/package/node.ts
+++ b/www/lib/package/node.ts
@@ -91,12 +91,20 @@ function normalizeExports(
   let result: Record<string, string> = {};
   for (let [key, value] of Object.entries(exports)) {
     let resolved = resolveExportValue(value);
-    if (resolved) {
+    if (resolved && isDocumentable(resolved)) {
       result[key] = resolved;
     }
   }
 
   return Object.keys(result).length > 0 ? result : { ".": "./src/index.ts" };
+}
+
+/**
+ * Check if an export path points to a documentable source file.
+ * Filters out binary artifacts like .wasm files that can't be parsed as TypeScript/JavaScript.
+ */
+function isDocumentable(path: string): boolean {
+  return !path.endsWith(".wasm");
 }
 
 /**


### PR DESCRIPTION
## Motivation

The website build crashes when generating docs for `@effectionx/inline` because its `package.json` exports include a `./swc` entry pointing to a WASM binary (`swc/target/wasm32-wasip1/release/swc_plugin_inline.wasm`). This file is a Rust build artifact that:

1. Doesn't exist in the git clone (it's in `.gitignore`)
2. Isn't parseable as TypeScript/JavaScript even if it did exist

The doc loader's `Deno.readTextFile()` call hits an ENOENT, breaking the entire site build.

## Approach

Add an `isDocumentable()` filter in `normalizeExports()` that skips `.wasm` file exports before they reach the doc generation pipeline.

### Possible Drawbacks or Risks

If a future package legitimately needs documentation generated from a `.wasm` export, it would be silently skipped. This seems unlikely since WASM binaries aren't source-documentable.