### PR TITLE
🔥 Remove unused runLevel field from createCoroutine

### DIFF
--- a/lib/coroutine.ts
+++ b/lib/coroutine.ts
@@ -17,7 +17,6 @@ export function createCoroutine<T>(
   let iterator: Coroutine<T>["data"]["iterator"] | undefined = undefined;
 
   let routine = {
-    runLevel: 0,
     scope,
     data: {
       get iterator() {


### PR DESCRIPTION
# Motivation

The `runLevel` field on the routine object created by `createCoroutine` is not used anywhere in the codebase, nor is it part of the `Coroutine` type defined in `lib/types.ts`.

# Approach

Drop the `runLevel: 0` initializer from `createCoroutine`.