### PR TITLE
✨ throw CircularTaskError when a task depends on itself or an ancestor

### DIFF
--- a/lib/future.ts
+++ b/lib/future.ts
@@ -1,9 +1,10 @@
 import { lazyPromiseWithResolvers } from "./lazy-promise.ts";
-import type { Future } from "./types.ts";
+import type { Future, Operation } from "./types.ts";
 import { withResolvers } from "./with-resolvers.ts";
 
 export interface FutureWithResolvers<T> {
   future: Future<T>;
+  operation: Operation<T>;
   resolve(value: T): void;
   reject(error: Error): void;
 }
@@ -24,6 +25,7 @@ export function createFuture<T>(): FutureWithResolvers<T> {
   let future = Object.defineProperties(promise.promise, {
     [Symbol.iterator]: {
       enumerable: false,
+      configurable: true,
       value: operation.operation[Symbol.iterator],
     },
     [Symbol.toStringTag]: {
@@ -33,5 +35,5 @@ export function createFuture<T>(): FutureWithResolvers<T> {
     },
   }) as Future<T>;
 
-  return { future, resolve, reject };
+  return { future, operation: operation.operation, resolve, reject };
 }

--- a/lib/task.ts
+++ b/lib/task.ts
@@ -33,7 +33,10 @@ export function createTask<T>(options: TaskOptions<T>): NewTask<T> {
         return Object.defineProperties(Object.create(Promise.prototype), {
           [Symbol.iterator]: {
             enumerable: false,
-            value: destroy,
+            *value() {
+              yield* assertNonCircular(scope);
+              yield* destroy();
+            },
           },
           then: {
             enumerable: false,
@@ -58,7 +61,10 @@ export function createTask<T>(options: TaskOptions<T>): NewTask<T> {
     },
     [Symbol.iterator]: {
       enumerable: false,
-      value: future.future[Symbol.iterator],
+      *value() {
+        yield* assertNonCircular(scope);
+        return yield* future.operation;
+      },
     },
     [Symbol.toStringTag]: {
       enumerable: false,
@@ -145,5 +151,33 @@ export function* trap<T>(operation: () => Operation<T>): Operation<T> {
         return (didExit) => didExit(Ok());
       },
     }) as T;
+  }
+}
+
+function* assertNonCircular(scope: Scope) {
+  let caller = (yield* useScope()) as ScopeInternal;
+
+  if (isSelfOrAncestor(scope as ScopeInternal, caller)) {
+    throw new CircularTaskError();
+  }
+}
+
+function isSelfOrAncestor(scope: ScopeInternal, child: ScopeInternal) {
+  for (
+    let contexts = child.contexts;
+    contexts;
+    contexts = Object.getPrototypeOf(contexts)
+  ) {
+    if (scope.contexts === contexts) {
+      return true;
+    }
+  }
+  return false;
+}
+
+class CircularTaskError extends Error {
+  constructor() {
+    super("a task may not depend on itself");
+    this.name = "CircularTaskError";
   }
 }

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -202,29 +202,6 @@ describe("run()", () => {
     await expect(task).rejects.toMatchObject({ message: "boom" });
   });
 
-  it("can halt itself", async () => {
-    let task: Task<void> = run(function* () {
-      yield* sleep(0);
-      yield* task.halt();
-    });
-
-    await expect(task).rejects.toMatchObject({ message: "halted" });
-  });
-
-  it("can halt itself between yield points", async () => {
-    let task: Task<void> = run(function* root() {
-      yield* sleep(0);
-
-      yield* spawn(function* child() {
-        yield* task.halt();
-      });
-
-      yield* suspend();
-    });
-
-    await expect(task).rejects.toMatchObject({ message: "halted" });
-  });
-
   it("can delay halt if child fails", async () => {
     let didRun = false;
     let task = run(function* Main() {
@@ -385,5 +362,145 @@ describe("run()", () => {
     expect(error).toBeDefined();
     expect(error?.message).toEqual("halted");
     expect(halted).toEqual(true);
+  });
+
+  describe("task dependencies", () => {
+    it("throws an error if a task depends on itself", async () => {
+      await expect(run(function* () {
+        let task: Task<string> = yield* spawn(function* () {
+          yield* sleep(1);
+          yield* task;
+          return "hello world";
+        });
+        return yield* task;
+      })).rejects.toMatchObject({ name: "CircularTaskError" });
+    });
+
+    it("throws an error if a task depends on its own halt()", async () => {
+      await expect(run(function* () {
+        let task: Task<string> = yield* spawn(function* () {
+          yield* sleep(1);
+          yield* task.halt();
+          return "hello world";
+        });
+        return yield* task;
+      })).rejects.toMatchObject({ name: "CircularTaskError" });
+    });
+
+    it("throws an error if a task depends on its parent's halt()", async () => {
+      let parent: Task<void>;
+      parent = run(function* () {
+        yield* spawn(function* () {
+          yield* sleep(1);
+          yield* parent.halt();
+        });
+        yield* suspend();
+      });
+      await expect(parent).rejects.toMatchObject({ name: "CircularTaskError" });
+    });
+
+    it("throws an error if a task depends on its parent", async () => {
+      let parent: Task<void>;
+      parent = run(function* () {
+        yield* spawn(function* () {
+          yield* sleep(1);
+          yield* parent;
+        });
+        yield* suspend();
+      });
+      await expect(parent).rejects.toMatchObject({ name: "CircularTaskError" });
+    });
+
+    it("throws an error if a task depends on an ancestor's halt()", async () => {
+      let root: Task<void>;
+      root = run(function* () {
+        yield* spawn(function* () {
+          yield* spawn(function* () {
+            yield* sleep(1);
+            yield* root.halt();
+          });
+          yield* suspend();
+        });
+        yield* suspend();
+      });
+      await expect(root).rejects.toMatchObject({ name: "CircularTaskError" });
+    });
+
+    it("throws an error if a task depends on an ancestor", async () => {
+      let root: Task<void>;
+      root = run(function* () {
+        yield* spawn(function* () {
+          yield* spawn(function* () {
+            yield* sleep(1);
+            yield* root;
+          });
+          yield* suspend();
+        });
+        yield* suspend();
+      });
+      await expect(root).rejects.toMatchObject({ name: "CircularTaskError" });
+    });
+
+    it("allows a task to depend on a sibling", async () => {
+      let observed = await run(function* () {
+        let scope = yield* useScope();
+        let producer = scope.run(function* () {
+          yield* sleep(1);
+          return "produced";
+        });
+        let consumer = scope.run(function* () {
+          return yield* producer;
+        });
+        return yield* consumer;
+      });
+      expect(observed).toEqual("produced");
+    });
+
+    it("allows a task to depend on a sibling's halt()", async () => {
+      let halted = false;
+      await run(function* () {
+        let scope = yield* useScope();
+        let target = scope.run(function* () {
+          try {
+            yield* suspend();
+          } finally {
+            halted = true;
+          }
+        });
+        yield* sleep(1);
+        let halter = scope.run(function* () {
+          yield* target.halt();
+        });
+        yield* halter;
+      });
+      expect(halted).toEqual(true);
+    });
+
+    it("allows a task to depend on its child", async () => {
+      let observed = await run(function* () {
+        let child = yield* spawn(function* () {
+          yield* sleep(1);
+          return "child-result";
+        });
+        return yield* child;
+      });
+      expect(observed).toEqual("child-result");
+    });
+
+    it("allows a task to depend on its child's halt()", async () => {
+      let halted = false;
+      await run(function* () {
+        let child = yield* spawn(function* () {
+          try {
+            yield* suspend();
+          } finally {
+            halted = true;
+          }
+        });
+        yield* sleep(1);
+        yield* child.halt();
+      });
+      expect(halted).toEqual(true);
+    });
   });
 });


### PR DESCRIPTION
# Motivation

A task that awaits its own result or the result of an ancestor is a circular dependency that should deadlock. The parent cannot complete until every child does, so any descendant waiting on itself or an ancestor should hang forever. This applies equally to the main task computation as well as its `halt()`

We currently try to fudge this situation when we encounter it and try to allow it to muddle through for historical reasons, but that ends up making things works by introducing complexity in order to paper over a pathological use-case. It's better to be up-front about it and when we detect a circular dependency between task, explicitly call that out 

The options are:

1. Silently deadlock
2. try to do some fake workarounds (what is happening today)
3. Fail fast when an impossible situation is detected. 

## Approach

Compare the scopes of the operation yielding to a task and the task itself. If the caller is, or is descended from the task being halted, then raise a `CircularTaskError`.

## Potential Drawbacks

⚠️ this can break some code that could conceivably rely on this behavior, so it should not be merged without discussion. Personally, I think this can be released as a 4.1 concern since it does away with a totally invalid use-case which I have never personally encountered. However, it is worth considering.