### PR TITLE
👷 don't run @effectionx/watch in CI website build

### DIFF
--- a/.github/workflows/www.yaml
+++ b/.github/workflows/www.yaml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Serve Website
         run: |
-          deno task dev &
+          deno run -A main.tsx &
           until curl --output /dev/null --silent --head --fail http://127.0.0.1:8000; do
             printf '.'
             sleep 1


### PR DESCRIPTION
# Motivation

The scheduled `www` workflow has been failing intermittently — a different URL returns 500 each time (`/guides/v3/events`, `/docs/collections`, `/x/signals`, `/docs/tutorial`), and the failed runs all bail in ~40s while successful ones take 2m+.

Theory: `deno task dev` wraps the server in `@effectionx/watch`. While Staticalize crawls pages, it writes output into `www/built/`. The watcher (running from `www/`) sees those writes, restarts the server, and in-flight requests get 500. Staticalize aborts on the first non-2xx.

(Locally the watcher should pick up `.gitignore` excludes including `built/`, so this could be a bug in @effectionx/watch, but either way, there's no reason to watch in CI.)

# Approach

Replace `deno task dev` with `deno run -A main.tsx` in `.github/workflows/www.yaml`. No watcher in CI = no mid-crawl restarts.