### PR TITLE
♻️ Invert reducer ↔ delimiter control

### DIFF
--- a/lib/coroutine.ts
+++ b/lib/coroutine.ts
@@ -4,6 +4,8 @@ import { ReducerContext } from "./reducer.ts";
 import { Ok } from "./result.ts";
 import type { Coroutine, Operation, Scope } from "./types.ts";
 
+export type StepType = "next" | "return" | "throw" | "drop";
+
 export interface CoroutineOptions<T> {
   scope: Scope;
   operation(): Operation<T>;
@@ -30,24 +32,13 @@ export function createCoroutine<T>(
     next(result) {
       routine.data.exit((exitResult) => {
         routine.data.exit = (didExit) => didExit(Ok());
+        let delim = scope.expect(DelimiterContext);
         reducer.reduce([
           scope.expect(Priority),
           routine,
           exitResult.ok ? result : exitResult,
-          scope.expect(DelimiterContext).validator,
-          "next",
-        ]);
-      });
-    },
-    return(result) {
-      routine.data.exit((exitResult) => {
-        routine.data.exit = (didExit) => didExit(Ok());
-        reducer.reduce([
-          scope.expect(Priority),
-          routine,
-          exitResult.ok ? result : exitResult,
-          scope.expect(DelimiterContext).validator,
-          "return",
+          delim,
+          delim.epoch,
         ]);
       });
     },

--- a/lib/delimiter.ts
+++ b/lib/delimiter.ts
@@ -1,6 +1,6 @@
 // deno-lint-ignore-file no-unsafe-finally
 import { createContext } from "./context.ts";
-import { useCoroutine } from "./coroutine.ts";
+import { type StepType, useCoroutine } from "./coroutine.ts";
 import { Just, type Maybe, Nothing } from "./maybe.ts";
 import { Err, Ok, type Result } from "./result.ts";
 import type { Coroutine, Operation } from "./types.ts";
@@ -8,10 +8,10 @@ import { withResolvers } from "./with-resolvers.ts";
 
 export class Delimiter<T>
   implements Operation<Maybe<Result<T>>>, ErrorBoundary {
-  level = 0;
-  finalized = false;
-  future = withResolvers<Maybe<Result<T>>>();
+  state: "running" | "cancelling" | "finalized" = "running";
+  epoch = 0;
   computed = false;
+  future = withResolvers<Maybe<Result<T>>>();
   routine?: Coroutine;
   outcome?: Maybe<Result<T>>;
 
@@ -20,26 +20,38 @@ export class Delimiter<T>
     public readonly parent?: Delimiter<unknown>,
   ) {}
 
+  nextStep(result: Result<unknown>, epoch: number): StepType {
+    if (this.epoch !== epoch || this.state === "finalized") {
+      return "drop";
+    } else if (!result.ok) {
+      return "throw";
+    } else if (this.state === "cancelling") {
+      this.state = "running";
+      return "return";
+    } else {
+      return "next";
+    }
+  }
+
   raise(error: Error): void {
     let failure = Just(Err<T>(error));
-    if (this.finalized) {
-      this.parent?.exit(failure);
+    if (this.state === "finalized") {
+      this.parent?.signal(failure);
     } else {
-      this.exit(failure);
+      this.signal(failure);
     }
   }
 
   interrupt(): void {
-    this.exit(Nothing());
+    this.signal(Nothing());
   }
 
   *close(): Operation<void> {
     let done = this.future.operation;
-    let interrupted = !this.computed;
 
     this.close = function* close() {
       let outcome = yield* done;
-      if (interrupted && outcome.exists && !outcome.value.ok) {
+      if (this.epoch > 0 && outcome.exists && !outcome.value.ok) {
         throw outcome.value.error;
       }
     };
@@ -47,40 +59,31 @@ export class Delimiter<T>
       this.interrupt();
       yield* this.close();
     } else {
-      if (interrupted && this.outcome.exists && !this.outcome.value.ok) {
+      if (this.epoch > 0 && this.outcome.exists && !this.outcome.value.ok) {
         throw this.outcome.value.error;
       }
     }
   }
 
-  private exit(outcome: Maybe<Result<T>>): void {
-    if (this.finalized) {
-      return;
-    }
-    this.outcome =
-      (this.outcome && this.outcome.exists && !this.outcome.value.ok)
-        ? this.outcome
-        : outcome;
-    this.level++;
+  private signal(outcome: Maybe<Result<T>>): void {
+    if (this.state === "finalized" || this.epoch > 0) return;
+
+    this.outcome = outcome;
+    this.state = "cancelling";
+    this.epoch++;
     if (!this.routine) {
-      this.finalized = true;
+      this.state = "finalized";
       this.future.resolve(this.outcome);
     } else {
-      this.routine.return(Ok(this.outcome));
+      this.routine.next(Ok(this.outcome));
     }
-  }
-
-  get validator(): () => boolean {
-    let { level } = this;
-    return () => !this.finalized && this.level === level;
   }
 
   [Symbol.iterator] = function* delimiter(this: Delimiter<T>) {
-    this.routine = yield* useCoroutine();
-
     try {
+      this.routine = yield* useCoroutine();
       let value = yield* this.operation();
-      if (this.level === 0) {
+      if (this.epoch === 0) {
         this.computed = true;
         this.outcome = Just(Ok(value));
       }
@@ -88,7 +91,7 @@ export class Delimiter<T>
       this.computed = true;
       this.outcome = Just(Err(error as Error));
     } finally {
-      this.finalized = true;
+      this.state = "finalized";
       this.outcome = this.outcome ?? Nothing();
       this.future.resolve(this.outcome);
       return this.outcome;

--- a/lib/reducer.ts
+++ b/lib/reducer.ts
@@ -1,7 +1,8 @@
 import { createContext } from "./context.ts";
+import type { Delimiter } from "./delimiter.ts";
 import { PriorityQueue } from "./priority-queue.ts";
 import { Err, type Result } from "./result.ts";
-import type { Coroutine } from "./types.ts";
+import type { Coroutine, Effect } from "./types.ts";
 
 export class Reducer {
   reducing = false;
@@ -19,38 +20,34 @@ export class Reducer {
     try {
       this.reducing = true;
 
-      let item = queue.dequeue();
-      while (item) {
-        let [, routine, result, _, method = "next" as const] = item;
+      for (let item = queue.dequeue(); item; item = queue.dequeue()) {
+        let [, routine, result, delim, epoch] = item;
+        let step = delim.nextStep(result, epoch);
+        if (step === "drop") continue;
         try {
           let iterator = routine.data.iterator;
-          if (result.ok) {
-            if (method === "next") {
-              let next = iterator.next(result.value);
-              if (!next.done) {
-                let action = next.value;
-                routine.data.exit = action.enter(routine.next, routine);
-              }
-            } else if (iterator.return) {
-              let next = iterator.return(result.value);
-              if (!next.done) {
-                let action = next.value;
-                routine.data.exit = action.enter(routine.next, routine);
-              }
-            }
-          } else if (iterator.throw) {
-            let next = iterator.throw(result.error);
-            if (!next.done) {
-              let action = next.value;
-              routine.data.exit = action.enter(routine.next, routine);
-            }
+          let next: IteratorResult<Effect<unknown>, unknown>;
+          if (step === "next") {
+            next = iterator.next(result.ok ? result.value : undefined);
+          } else if (step === "return") {
+            next = iterator.return
+              ? iterator.return(result.ok ? result.value : undefined)
+              : { done: true, value: undefined };
           } else {
-            throw result.error;
+            let value = result.ok ? result.value : result.error;
+            if (iterator.throw) {
+              next = iterator.throw(value);
+            } else {
+              throw value;
+            }
+          }
+          if (!next.done) {
+            let action = next.value;
+            routine.data.exit = action.enter(routine.next, routine);
           }
         } catch (error) {
           routine.next(Err(error as Error));
         }
-        item = queue.dequeue();
       }
     } finally {
       this.reducing = false;
@@ -62,8 +59,8 @@ type Instruction = [
   number,
   Coroutine<unknown>,
   Result<unknown>,
-  () => boolean,
-  "return" | "next",
+  Delimiter<unknown>,
+  number,
 ];
 
 class InstructionQueue extends PriorityQueue<Instruction> {
@@ -72,18 +69,7 @@ class InstructionQueue extends PriorityQueue<Instruction> {
     this.push(priority, instruction);
   }
   dequeue(): Instruction | undefined {
-    while (true) {
-      let top = this.pop();
-      if (!top) {
-        return undefined;
-      } else {
-        let validate = top[3];
-        if (!validate()) {
-          continue;
-        }
-        return top;
-      }
-    }
+    return this.pop();
   }
 }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -370,7 +370,6 @@ export interface Coroutine<T = unknown> {
     iterator: Iterator<Effect<unknown>, T, unknown>;
   };
   next(result: Result<unknown>): void;
-  return<R>(result: Result<R>): void;
 }
 
 /**


### PR DESCRIPTION
# Motivation

Issues #1153, #1154, and #1159 share a single root cause: cancellation
in v4 is one-shot.

The proposed fix is to have the co-routine, after cancellation, continually return, and return, and return with each yield, and then protect "critical" sections with a shield that makes normal execution for secments of the effect stream.

This PR is an attempt to enable these refactors by allowing the conetxt control exactly how the co-routine is advanced at every stem.

# Approach

Invert control from the co-routine to the delimiter.