### PR TITLE
🐛 wrap non-Error causes passed to Err()

### DIFF
--- a/lib/action.ts
+++ b/lib/action.ts
@@ -63,7 +63,7 @@ export function action<T>(executor: Executor<T>, desc?: string): Operation<T> {
               discard();
               discarded(Ok());
             } catch (error) {
-              discarded(Err(error as Error));
+              discarded(Err(error));
             }
           };
         },

--- a/lib/box.ts
+++ b/lib/box.ts
@@ -5,6 +5,6 @@ export function* box<T>(op: () => Operation<T>): Operation<Result<T>> {
   try {
     return Ok(yield* op());
   } catch (error) {
-    return Err(error as Error);
+    return Err(error);
   }
 }

--- a/lib/delimiter.ts
+++ b/lib/delimiter.ts
@@ -86,7 +86,7 @@ export class Delimiter<T>
       }
     } catch (error) {
       this.computed = true;
-      this.outcome = Just(Err(error as Error));
+      this.outcome = Just(Err(error));
     } finally {
       this.finalized = true;
       this.outcome = this.outcome ?? Nothing();

--- a/lib/race.ts
+++ b/lib/race.ts
@@ -45,7 +45,7 @@ export function* race<T extends Operation<unknown>>(
             let value = yield* operation;
             winner.resolve(Ok(value as Yielded<T>));
           } catch (error) {
-            winner.resolve(Err(error as Error));
+            winner.resolve(Err(error));
           }
         }),
       );

--- a/lib/reducer.ts
+++ b/lib/reducer.ts
@@ -48,7 +48,7 @@ export class Reducer {
             throw result.error;
           }
         } catch (error) {
-          routine.next(Err(error as Error));
+          routine.next(Err(error));
         }
         item = queue.dequeue();
       }

--- a/lib/result.ts
+++ b/lib/result.ts
@@ -24,7 +24,24 @@ export function Ok<T>(value?: T): Result<T | undefined> {
 /**
  * @ignore
  */
-export const Err = <T>(error: Error): Result<T> => ({ ok: false, error });
+export const Err = <T>(cause: unknown): Result<T> => ({
+  ok: false,
+  error: toError(cause),
+});
+
+class ThrowValueError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "ThrowValueError";
+  }
+}
+
+function toError(cause: unknown): Error {
+  if (cause instanceof Error) {
+    return cause;
+  }
+  return new ThrowValueError(String(cause), { cause });
+}
 
 /**
  * @ignore

--- a/lib/scope-internal.ts
+++ b/lib/scope-internal.ts
@@ -79,7 +79,7 @@ export function createScopeInternal(
           destructors.delete(destructor);
           yield* destructor();
         } catch (error) {
-          outcome = Err(error as Error);
+          outcome = Err(error);
         }
       }
     } finally {

--- a/test/result.test.ts
+++ b/test/result.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "./suite.ts";
+
+import { Err, Ok } from "../mod.ts";
+
+describe("Result", () => {
+  it("constructs successful results with Ok()", () => {
+    expect(Ok("hello")).toEqual({ ok: true, value: "hello" });
+  });
+
+  it("preserves Error instances passed to Err()", () => {
+    let error = new Error("oh no");
+
+    expect(Err(error)).toEqual({ ok: false, error });
+  });
+
+  it("wraps non-Error causes passed to Err()", () => {
+    let result = Err("oh no");
+
+    if (result.ok) {
+      throw new Error("expected Err() to produce a failed result");
+    }
+
+    expect(result.error).toBeInstanceOf(Error);
+    expect(result.error.name).toEqual("ThrowValueError");
+    expect(result.error.message).toEqual("oh no");
+    expect(result.error.cause).toEqual("oh no");
+  });
+});

--- a/test/until.test.ts
+++ b/test/until.test.ts
@@ -9,13 +9,15 @@ describe("until", () => {
       expect(yield* until(Promise.resolve(42))).toEqual(42);
     });
   });
-  it("throws on error", async () => {
-    expect.assertions(1);
+  it("wraps non-Error promise rejections", async () => {
+    expect.assertions(3);
     await run(function* () {
       try {
         yield* until(Promise.reject("error"));
       } catch (error) {
-        expect(error).toBe("error");
+        expect(error).toBeInstanceOf(Error);
+        expect((error as Error).message).toBe("error");
+        expect((error as Error).cause).toBe("error");
       }
     });
   });


### PR DESCRIPTION
# Motivation

`Err()` currently accepts `Error`, but JavaScript `catch` blocks and promise rejections can produce `unknown` thrown values. That makes it awkward to pass caught values directly to `Err()` and can leak non-`Error` throw values through APIs that model failures as `Error`.

This splits the `Err()` behavior change out so it can target the same base branch as #1149.

# Approach

- change `Err()` to accept `unknown`
- preserve existing `Error` instances as-is
- wrap non-`Error` causes in `ThrowValueError(String(cause), { cause })`
- remove internal `as Error` casts where caught values are passed to `Err()`
- add regression coverage for `Err()` and `until(Promise.reject(...))`