### PR TITLE
🐛 Unify halt around signal + observe scope.destroyed (#1159, #1160)

### DIFF
--- a/lib/coroutine.ts
+++ b/lib/coroutine.ts
@@ -4,6 +4,8 @@ import { ReducerContext } from "./reducer.ts";
 import { Ok } from "./result.ts";
 import type { Coroutine, Operation, Scope } from "./types.ts";
 
+export type StepType = "next" | "return" | "throw" | "drop";
+
 export interface CoroutineOptions<T> {
   scope: Scope;
   operation(): Operation<T>;
@@ -30,24 +32,13 @@ export function createCoroutine<T>(
     next(result) {
       routine.data.exit((exitResult) => {
         routine.data.exit = (didExit) => didExit(Ok());
+        let delim = scope.expect(DelimiterContext);
         reducer.reduce([
           scope.expect(Priority),
           routine,
           exitResult.ok ? result : exitResult,
-          scope.expect(DelimiterContext).validator,
-          "next",
-        ]);
-      });
-    },
-    return(result) {
-      routine.data.exit((exitResult) => {
-        routine.data.exit = (didExit) => didExit(Ok());
-        reducer.reduce([
-          scope.expect(Priority),
-          routine,
-          exitResult.ok ? result : exitResult,
-          scope.expect(DelimiterContext).validator,
-          "return",
+          delim,
+          delim.epoch,
         ]);
       });
     },

--- a/lib/delimiter.ts
+++ b/lib/delimiter.ts
@@ -1,6 +1,6 @@
 // deno-lint-ignore-file no-unsafe-finally
 import { createContext } from "./context.ts";
-import { useCoroutine } from "./coroutine.ts";
+import { type StepType, useCoroutine } from "./coroutine.ts";
 import { Just, type Maybe, Nothing } from "./maybe.ts";
 import { Err, Ok, type Result } from "./result.ts";
 import type { Coroutine, Operation } from "./types.ts";
@@ -8,10 +8,10 @@ import { withResolvers } from "./with-resolvers.ts";
 
 export class Delimiter<T>
   implements Operation<Maybe<Result<T>>>, ErrorBoundary {
-  level = 0;
-  finalized = false;
-  future = withResolvers<Maybe<Result<T>>>();
+  state: "running" | "cancelling" | "finalized" = "running";
+  epoch = 0;
   computed = false;
+  future = withResolvers<Maybe<Result<T>>>();
   routine?: Coroutine;
   outcome?: Maybe<Result<T>>;
 
@@ -20,26 +20,38 @@ export class Delimiter<T>
     public readonly parent?: Delimiter<unknown>,
   ) {}
 
+  nextStep(result: Result<unknown>, epoch: number): StepType {
+    if (this.epoch !== epoch || this.state === "finalized") {
+      return "drop";
+    } else if (!result.ok) {
+      return "throw";
+    } else if (this.state === "cancelling") {
+      this.state = "running";
+      return "return";
+    } else {
+      return "next";
+    }
+  }
+
   raise(error: Error): void {
     let failure = Just(Err<T>(error));
-    if (this.finalized) {
-      this.parent?.exit(failure);
+    if (this.state === "finalized") {
+      this.parent?.signal(failure);
     } else {
-      this.exit(failure);
+      this.signal(failure);
     }
   }
 
   interrupt(): void {
-    this.exit(Nothing());
+    this.signal(Nothing());
   }
 
   *close(): Operation<void> {
     let done = this.future.operation;
-    let interrupted = !this.computed;
 
     this.close = function* close() {
       let outcome = yield* done;
-      if (interrupted && outcome.exists && !outcome.value.ok) {
+      if (this.epoch > 0 && outcome.exists && !outcome.value.ok) {
         throw outcome.value.error;
       }
     };
@@ -47,40 +59,31 @@ export class Delimiter<T>
       this.interrupt();
       yield* this.close();
     } else {
-      if (interrupted && this.outcome.exists && !this.outcome.value.ok) {
+      if (this.epoch > 0 && this.outcome.exists && !this.outcome.value.ok) {
         throw this.outcome.value.error;
       }
     }
   }
 
-  private exit(outcome: Maybe<Result<T>>): void {
-    if (this.finalized) {
-      return;
-    }
-    this.outcome =
-      (this.outcome && this.outcome.exists && !this.outcome.value.ok)
-        ? this.outcome
-        : outcome;
-    this.level++;
+  private signal(outcome: Maybe<Result<T>>): void {
+    if (this.state === "finalized" || this.epoch > 0) return;
+
+    this.outcome = outcome;
+    this.state = "cancelling";
+    this.epoch++;
     if (!this.routine) {
-      this.finalized = true;
+      this.state = "finalized";
       this.future.resolve(this.outcome);
     } else {
-      this.routine.return(Ok(this.outcome));
+      this.routine.next(Ok(this.outcome));
     }
-  }
-
-  get validator(): () => boolean {
-    let { level } = this;
-    return () => !this.finalized && this.level === level;
   }
 
   [Symbol.iterator] = function* delimiter(this: Delimiter<T>) {
-    this.routine = yield* useCoroutine();
-
     try {
+      this.routine = yield* useCoroutine();
       let value = yield* this.operation();
-      if (this.level === 0) {
+      if (this.epoch === 0) {
         this.computed = true;
         this.outcome = Just(Ok(value));
       }
@@ -88,7 +91,7 @@ export class Delimiter<T>
       this.computed = true;
       this.outcome = Just(Err(error as Error));
     } finally {
-      this.finalized = true;
+      this.state = "finalized";
       this.outcome = this.outcome ?? Nothing();
       this.future.resolve(this.outcome);
       return this.outcome;

--- a/lib/reducer.ts
+++ b/lib/reducer.ts
@@ -1,7 +1,8 @@
 import { createContext } from "./context.ts";
+import type { Delimiter } from "./delimiter.ts";
 import { PriorityQueue } from "./priority-queue.ts";
 import { Err, type Result } from "./result.ts";
-import type { Coroutine } from "./types.ts";
+import type { Coroutine, Effect } from "./types.ts";
 
 export class Reducer {
   reducing = false;
@@ -19,38 +20,34 @@ export class Reducer {
     try {
       this.reducing = true;
 
-      let item = queue.dequeue();
-      while (item) {
-        let [, routine, result, _, method = "next" as const] = item;
+      for (let item = queue.dequeue(); item; item = queue.dequeue()) {
+        let [, routine, result, delim, epoch] = item;
+        let step = delim.nextStep(result, epoch);
+        if (step === "drop") continue;
         try {
           let iterator = routine.data.iterator;
-          if (result.ok) {
-            if (method === "next") {
-              let next = iterator.next(result.value);
-              if (!next.done) {
-                let action = next.value;
-                routine.data.exit = action.enter(routine.next, routine);
-              }
-            } else if (iterator.return) {
-              let next = iterator.return(result.value);
-              if (!next.done) {
-                let action = next.value;
-                routine.data.exit = action.enter(routine.next, routine);
-              }
-            }
-          } else if (iterator.throw) {
-            let next = iterator.throw(result.error);
-            if (!next.done) {
-              let action = next.value;
-              routine.data.exit = action.enter(routine.next, routine);
-            }
+          let next: IteratorResult<Effect<unknown>, unknown>;
+          if (step === "next") {
+            next = iterator.next(result.ok ? result.value : undefined);
+          } else if (step === "return") {
+            next = iterator.return
+              ? iterator.return(result.ok ? result.value : undefined)
+              : { done: true, value: undefined };
           } else {
-            throw result.error;
+            let value = result.ok ? result.value : result.error;
+            if (iterator.throw) {
+              next = iterator.throw(value);
+            } else {
+              throw value;
+            }
+          }
+          if (!next.done) {
+            let action = next.value;
+            routine.data.exit = action.enter(routine.next, routine);
           }
         } catch (error) {
           routine.next(Err(error as Error));
         }
-        item = queue.dequeue();
       }
     } finally {
       this.reducing = false;
@@ -62,8 +59,8 @@ type Instruction = [
   number,
   Coroutine<unknown>,
   Result<unknown>,
-  () => boolean,
-  "return" | "next",
+  Delimiter<unknown>,
+  number,
 ];
 
 class InstructionQueue extends PriorityQueue<Instruction> {
@@ -72,18 +69,7 @@ class InstructionQueue extends PriorityQueue<Instruction> {
     this.push(priority, instruction);
   }
   dequeue(): Instruction | undefined {
-    while (true) {
-      let top = this.pop();
-      if (!top) {
-        return undefined;
-      } else {
-        let validate = top[3];
-        if (!validate()) {
-          continue;
-        }
-        return top;
-      }
-    }
+    return this.pop();
   }
 }
 

--- a/lib/scope-internal.ts
+++ b/lib/scope-internal.ts
@@ -1,13 +1,14 @@
 import { Children, Priority } from "./contexts.ts";
+import { createFuture } from "./future.ts";
 import { Err, Ok, unbox } from "./result.ts";
 import { createTask } from "./task.ts";
-import type { Context, Operation, Scope, Task } from "./types.ts";
-import { type WithResolvers, withResolvers } from "./with-resolvers.ts";
+import type { Context, Future, Operation, Scope, Task } from "./types.ts";
 
 export function createScopeInternal(
   parent?: Scope,
 ): [ScopeInternal, () => Operation<void>] {
   let destructors = new Set<() => Operation<void>>();
+  let destruction = createFuture<void>();
 
   let contexts: Record<string, unknown> = Object.create(
     parent ? (parent as ScopeInternal).contexts : null,
@@ -15,6 +16,7 @@ export function createScopeInternal(
   let scope: ScopeInternal = Object.create({
     [Symbol.toStringTag]: "Scope",
     contexts,
+    destroyed: destruction.future,
     get<T>(context: Context<T>): T | undefined {
       return (contexts[context.name] ?? context.defaultValue) as T | undefined;
     },
@@ -61,15 +63,9 @@ export function createScopeInternal(
   scope.set(Children, new Set());
   parent?.expect(Children).add(scope);
 
-  let unbind = parent ? (parent as ScopeInternal).ensure(destroy) : () => {};
+  let destroy = function* (): Operation<void> {
+    destroy = () => destruction.future;
 
-  let destruction: WithResolvers<void> | undefined = undefined;
-
-  function* destroy(): Operation<void> {
-    if (destruction) {
-      return yield* destruction.operation;
-    }
-    destruction = withResolvers<void>();
     parent?.expect(Children).delete(scope);
     unbind();
     let outcome = Ok();
@@ -91,12 +87,17 @@ export function createScopeInternal(
     }
 
     unbox(outcome);
-  }
+  };
 
-  return [scope, destroy];
+  let unbind = parent
+    ? (parent as ScopeInternal).ensure(() => destroy())
+    : () => {};
+
+  return [scope, () => destroy()];
 }
 
 export interface ScopeInternal extends Scope, AsyncDisposable {
   contexts: Record<string, unknown>;
+  destroyed: Future<void>;
   ensure(op: () => Operation<void>): () => void;
 }

--- a/lib/task.ts
+++ b/lib/task.ts
@@ -5,7 +5,7 @@ import { Delimiter } from "./delimiter.ts";
 import { createFuture } from "./future.ts";
 import { Ok } from "./result.ts";
 import { createScopeInternal, type ScopeInternal } from "./scope-internal.ts";
-import type { Coroutine, Operation, Scope, Task } from "./types.ts";
+import type { Coroutine, Effect, Operation, Scope, Task } from "./types.ts";
 import { encapsulate, TaskGroupContext } from "./task-group.ts";
 import { useScope } from "./scope.ts";
 
@@ -24,33 +24,43 @@ export interface NewTask<T> {
 export function createTask<T>(options: TaskOptions<T>): NewTask<T> {
   let { owner, operation } = options;
   let [scope, destroy] = createScopeInternal(owner);
+  let { destroyed } = scope;
   let future = createFuture<T>();
+
+  let top = new Delimiter<T>(() => encapsulate(operation));
 
   let task = Object.defineProperties(future.future, {
     halt: {
       enumerable: false,
       value() {
+        let signal = () => top.interrupt();
         return Object.defineProperties(Object.create(Promise.prototype), {
           [Symbol.iterator]: {
             enumerable: false,
-            value: destroy,
+            value: function* () {
+              signal();
+              yield* destroyed;
+            },
           },
           then: {
             enumerable: false,
             value(...args: Parameters<Promise<void>["then"]>) {
-              return owner.run(destroy).then(...args);
+              signal();
+              return destroyed.then(...args);
             },
           },
           catch: {
             enumerable: false,
             value(...args: Parameters<Promise<void>["catch"]>) {
-              return owner.run(destroy).catch(...args);
+              signal();
+              return destroyed.catch(...args);
             },
           },
           finally: {
             enumerable: false,
             value(...args: Parameters<Promise<void>["finally"]>) {
-              return owner.run(destroy).finally(...args);
+              signal();
+              return destroyed.finally(...args);
             },
           },
         });
@@ -70,40 +80,38 @@ export function createTask<T>(options: TaskOptions<T>): NewTask<T> {
     },
   }) as Task<T>;
 
-  let top = new Delimiter<T>(() => encapsulate(operation));
-  scope.set(DelimiterContext, top as Delimiter<unknown>);
-
-  let group = scope.expect(TaskGroupContext);
-  group.add(task);
-
-  let boundary = owner.expect(ErrorContext);
-  scope.set(ErrorContext, top);
-
-  scope.ensure(function* () {
-    try {
-      yield* top.close();
-    } finally {
-      group.delete(task);
-      let { outcome } = top;
-      if (outcome!.exists) {
-        let result = outcome!.value;
-        if (result.ok) {
-          future.resolve(result.value);
-        } else {
-          let { error } = result;
-          future.reject(error);
-          boundary.raise(error);
-        }
-      } else {
-        future.reject(new Error("halted"));
-      }
-    }
-  });
-
   let routine = createCoroutine({
     scope,
     *operation() {
       try {
+        scope.set(DelimiterContext, top as Delimiter<unknown>);
+        scope.set(ErrorContext, top);
+        let group = scope.expect(TaskGroupContext);
+        group.add(task);
+        let boundary = owner.expect(ErrorContext);
+        scope.ensure(function* () {
+          try {
+            yield* top.close();
+          } finally {
+            group.delete(task);
+            let { outcome } = top;
+            if (outcome!.exists) {
+              let result = outcome!.value;
+              if (result.ok) {
+                future.resolve(result.value);
+              } else {
+                let { error } = result;
+                future.reject(error);
+                boundary.raise(error);
+              }
+            } else {
+              future.reject(new Error("halted"));
+            }
+          }
+        });
+
+        yield started;
+
         yield* top;
       } finally {
         yield* destroy();
@@ -111,7 +119,15 @@ export function createTask<T>(options: TaskOptions<T>): NewTask<T> {
     },
   });
 
-  let start = () => routine.next(Ok());
+  top.routine = routine;
+
+  let start = () => {
+    let { done, value } = routine.data.iterator.next();
+    if (done || value !== started) {
+      throw new Error("Corrupted task: body did not yield the ready sentinel");
+    }
+    routine.next(Ok());
+  };
 
   return { scope, routine, task, start };
 }
@@ -147,3 +163,11 @@ export function* trap<T>(operation: () => Operation<T>): Operation<T> {
     }) as T;
   }
 }
+
+const started = {
+  description:
+    "A sentinel effect that is never evaluated. It just ensures that the routine is entered so that teardown can be treated normally",
+  enter() {
+    return () => {};
+  },
+} satisfies Effect<never>;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -370,7 +370,6 @@ export interface Coroutine<T = unknown> {
     iterator: Iterator<Effect<unknown>, T, unknown>;
   };
   next(result: Result<unknown>): void;
-  return<R>(result: Result<R>): void;
 }
 
 /**

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -12,6 +12,7 @@ import {
   type Task,
   until,
   useScope,
+  withResolvers,
 } from "../mod.ts";
 import { blowUp, createNumber, describe, expect, it } from "./suite.ts";
 
@@ -202,6 +203,13 @@ describe("run()", () => {
     await expect(task).rejects.toMatchObject({ message: "boom" });
   });
 
+  // https://github.com/thefrontside/effection/issues/1160 — self-halt
+  // (`yield* task.halt()` from inside the task being halted) used to risk
+  // wedging the runtime in a self-join. With halt unified around
+  // `signalHalt + observe scope.destroyed`, halt is purely lazy: the
+  // caller's routine signals, then observes the destruction future.
+  // Unwinding and destruction run on the same routine the caller is
+  // already on, with no second routine to wait for.
   it("can halt itself", async () => {
     let task: Task<void> = run(function* () {
       yield* sleep(0);
@@ -223,6 +231,43 @@ describe("run()", () => {
     });
 
     await expect(task).rejects.toMatchObject({ message: "halted" });
+  });
+
+  // https://github.com/thefrontside/effection/issues/1159 — observing
+  // `task.halt()` through its Promise surface used to leave the task in a
+  // state where a subsequent `yield* task` would hang indefinitely. The
+  // dual-routine pattern (Promise side spawned `owner.run(destroy)` while
+  // the task's own routine was being kicked) had two paths racing to
+  // touch the same delimiter. Halt unification collapses this to a
+  // single signal-and-observe; Promise and Operation surfaces converge
+  // on the same `scope.destroyed` future and the same idempotent
+  // `signalHalt` call. `yield* task` after a Promise-side halt now
+  // observes the expected `"halted"` rejection.
+  it("yield* task after Promise-side halt observes halted", async () => {
+    let events: string[] = [];
+    await run(function* () {
+      let ready = withResolvers<void>();
+      let scope = yield* useScope();
+      let task = scope.run(function* () {
+        events.push("child:start");
+        ready.resolve();
+        yield* suspend();
+      });
+      yield* ready.operation;
+      events.push("parent:halt-request");
+      void task.halt().catch(() => {});
+      try {
+        yield* task;
+        events.push("parent:task:ok");
+      } catch (error) {
+        events.push(`parent:task:${(error as Error).message}`);
+      }
+    });
+    expect(events).toEqual([
+      "child:start",
+      "parent:halt-request",
+      "parent:task:halted",
+    ]);
   });
 
   it("can delay halt if child fails", async () => {


### PR DESCRIPTION
# Motivation

Fix #1159 and #1160

`task.halt()` had two surfaces (Promise and Operation), and the Promise surface spawned a second routine via `owner.run(destroy)` to drive teardown. This second task raced the original task's own routine for control of the same delimiter. This resulted in incorrect teardown sequencing.


#1153 and #1154 remain open — they're a different class of fix (sticky-return semantics + capturing `iter.return`'s done value), substantially easier on this substrate but out of scope here.

# Approach

`task.halt()` collapses to a single signal-and-observe pair. We lazily call `top.interrupt()` and then join on `scope.destroyed`. The task's own routine drives unwinding via its existing `try { yield* top } finally { yield* destroy() }`, so all the work happens in the original routine. With one pathway, there is no possibility for a race.


## Alternates

We tried keeping both surfaces with #1155, and just "synchronize them harder", but the problem is the secord routine itself.

## TODO:

- [ ] depends on #1164 (reducer/delimiter inversion) merging first

## Future Direction

Eventually, We'll actually move the signal and halting logic entirely into the scope, using an async like abort signal, so that `task.halt()` just becomes lazy `signal.abort()`