### PR TITLE
🐛 Make context effect errors catchable in-generator

### DIFF
--- a/lib/context.ts
+++ b/lib/context.ts
@@ -1,5 +1,5 @@
 import type { Context, Effect, Operation, Scope } from "./types.ts";
-import { Ok } from "./result.ts";
+import { Err, Ok } from "./result.ts";
 import { Do } from "./do.ts";
 
 /**
@@ -52,7 +52,11 @@ function UseScope<T>(fn: (scope: Scope) => T, description: string): Effect<T> {
   return {
     description,
     enter: (resolve, { scope }) => {
-      resolve(Ok(fn(scope)));
+      try {
+        resolve(Ok(fn(scope)));
+      } catch (error) {
+        resolve(Err(error));
+      }
       return (resolve) => {
         resolve(Ok());
       };

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -41,6 +41,18 @@ describe("context", () => {
     })).rejects.toHaveProperty("name", "MissingContextError");
   });
 
+  it("can catch a missing-context expect() error in-generator", async () => {
+    let caught: unknown;
+    await run(function* () {
+      try {
+        yield* createContext("missing").expect();
+      } catch (error) {
+        caught = error;
+      }
+    });
+    expect((caught as Error)?.name).toEqual("MissingContextError");
+  });
+
   it("inherits values from parent tasks", async () => {
     let context = createContext<string>("just-a-string");
     await run(function* () {


### PR DESCRIPTION
## Problem

`Context.expect()` is meant to throw a catchable `MissingContextError` when a context isn't set. It's catchable at the `run(...)` boundary, but **not** via an in-generator `try/catch` — the natural way to write fallback logic:

```ts
const BaselineImportedContext = createContext<boolean>('baseline-imported');

export function* ensureBaselineImported(path: string) {
  try {
    yield* BaselineImportedContext.expect();
    return;
  } catch {
    // never reached — the error escapes and fails the whole task
    yield* importBaseline(path);
    yield* BaselineImportedContext.set(true);
  }
}
```

Minimal repro:

```ts
await run(function* () {
  try {
    yield* createContext("foo").expect();
  } catch (e) {
    // not reached before this fix
  }
});
```

## Root cause

`expect`/`get`/`set`/`delete` are all built on the private `UseScope` effect in `lib/context.ts`, whose `enter` runs the scope access synchronously:

```ts
enter: (resolve, { scope }) => {
  resolve(Ok(fn(scope)));   // fn(scope) throws here for a missing context
  ...
}
```

`scope.expect()` throws `MissingContextError` synchronously. Because the throw happens *inside* `enter` rather than being wrapped in an `Err` result, it propagates synchronously out of `coroutine.perform` and is caught by the reducer's top-level handler, which settles the **entire task** as errored — bypassing the generator's own `try/catch`.

## Fix

Wrap `fn(scope)` in `UseScope` with a `try/catch` and deliver a thrown error as `Err(error)`. This routes it through the normal `Do` → `iterator.throw` path, so it surfaces at the `yield*` point and is catchable by a surrounding `try/catch`. The single fix covers `expect()` and hardens `get`/`set`/`delete` against any future synchronous throw.

## Test

Added a regression test in `test/context.test.ts` asserting a missing-context `expect()` error is catchable from within a generator. It fails before the fix and passes after. The existing top-level "is an error to expect() when context is missing" behavior is unchanged.