### PR TITLE
🐛 Catch errors in effect.enter()

### DIFF
--- a/lib/coroutine.ts
+++ b/lib/coroutine.ts
@@ -1,5 +1,5 @@
 import { ReducerContext } from "./reducer.ts";
-import { Ok } from "./result.ts";
+import { Err, Ok } from "./result.ts";
 import type { Coroutine, Effect, Operation, Scope } from "./types.ts";
 import type { Maybe } from "./maybe.ts";
 import type { Result } from "./result.ts";
@@ -92,7 +92,11 @@ export function createCoroutine<T>(
           routine.resume(result);
         }
       };
-      routine.data.exit = effect.enter(resolve, routine);
+      try {
+        routine.data.exit = effect.enter(resolve, routine);
+      } catch (error) {
+        routine.resume(Err(error));
+      }
     },
   } as Coroutine<T>;
 

--- a/test/coroutine.test.ts
+++ b/test/coroutine.test.ts
@@ -114,4 +114,31 @@ describe("Coroutine", () => {
     ]);
     expect(events).not.toContain("after-unreachable");
   });
+
+  it("it raises errors that happen in effect.enter()", async () => {
+    await using scope = createScope();
+    let { resume: next, future } = createCoroutine({
+      scope,
+      *operation() {
+        try {
+          yield {
+            description: "throws on enter",
+            enter() {
+              throw new Error("boom!");
+            },
+          };
+          return "unreachable";
+        } catch (error) {
+          return error;
+        }
+      },
+    });
+
+    next(Ok());
+
+    await expect(future).resolves.toMatchObject({
+      exists: true,
+      value: { ok: true, value: { message: "boom!" } },
+    });
+  });
 });


### PR DESCRIPTION
# Motivation

If there is a straightup error that happens synchronously inside an effect's executor, it will actually be caught inside the reducer and crash the entire co-routine. But instead, it should just raise an error inside the current yield point.

# Approach

This catches any exception that happens synchronously while entering an action and then resumes the coroutine with it.

closes #1178 
