### PR TITLE
Optimized middleware

### DIFF
--- a/lib/api-internal.ts
+++ b/lib/api-internal.ts
@@ -9,18 +9,16 @@ import type {
   Operation,
   Scope,
 } from "./types.ts";
-import type { ScopeInternal } from "./scope-internal.ts";
 import { Children } from "./contexts.ts";
 import { Ok } from "./result.ts";
 
 export interface ApiInternal<A> extends Api<A> {
   context: Context<{
-    max: Partial<Around<A>>[];
-    min: Partial<Around<A>>[];
+    local: Decorator<A>;
+    total: Decorator<A>;
+    handle: A;
   }>;
   core: A;
-  cache: WeakMap<Scope, A>;
-  invalidate(scope: Scope): void;
 }
 
 export function createApiInternal<A extends {}>(
@@ -31,27 +29,13 @@ export function createApiInternal<A extends {}>(
 
   let context = createContext(`api::${name}`) as ApiInternal<A>["context"];
 
-  let cache = new WeakMap<Scope, A>();
-
   let api: ApiInternal<A> = {
     core,
     context,
-    cache,
-    invalidate(scope: Scope) {
-      cache.delete(scope);
-      let children = scope.get(Children);
-      if (children) {
-        for (let child of children) {
-          api.invalidate(child);
-        }
-      }
-    },
+
     invoke: (scope, key, args) => {
-      let handle = cache.get(scope);
-      if (!handle) {
-        handle = createHandle(api, scope as ScopeInternal);
-        cache.set(scope, handle);
-      }
+      let handle = scope.get(api.context)?.handle ?? core;
+
       let member = handle[key];
       if (typeof member === "function") {
         return member(...args);
@@ -62,7 +46,7 @@ export function createApiInternal<A extends {}>(
     around: (decorator, options = { at: "max" }) => ({
       *[Symbol.iterator]() {
         let scope = (yield GetScope) as Scope;
-        scope.around(api, decorator, options);
+        decorateApi(scope, api, decorator, options);
       },
     }),
     operations: fields.reduce((sum, field) => {
@@ -93,50 +77,107 @@ export function createApiInternal<A extends {}>(
   return api;
 }
 
-function createHandle<A extends {}>(
+export function decorateApi<A>(
+  scope: Scope,
   api: ApiInternal<A>,
-  scope: ScopeInternal,
-): A {
-  // there is no middleware at all for this api, so the handle _is_ the core.
-  if (!scope.get(api.context)) {
-    return api.core;
+  decorator: Partial<Around<A>>,
+  options?: {
+    at: "min" | "max";
+  },
+) {
+  // read existing total and local
+  let current = scope.get(api.context) ?? { total: {}, local: {} };
+
+  let local = decorate(current.local, {
+    [options?.at ?? "max"]: decorator,
+  });
+
+  if (!scope.hasOwn(api.context)) {
+    scope.set(api.context, {
+      local,
+      total: current.total,
+      handle: api.core,
+    });
+  } else {
+    current.local = local;
   }
 
-  let handle = Object.create(api.core);
+  install(scope, api, current.total);
+}
 
-  for (let key of Object.keys(api.core) as Array<keyof A>) {
-    let { min, max } = scope.reduce(api.context, (sum, current) => {
-      let min = current.min.flatMap((around) =>
-        around[key] ? [around[key]] : []
-      );
-      let max = current.max.flatMap((around) =>
-        around[key] ? [around[key]] : []
-      );
+function decorate<A>(base: Decorator<A>, next: Decorator<A>): Decorator<A> {
+  return {
+    max: base.max ? next.max ? append(base.max, next.max) : base.max : next.max,
+    min: next.min ? base.min ? append(next.min, base.min) : next.min : base.min,
+  };
+}
 
-      sum.min.push(...min);
-      sum.max.unshift(...max);
-
-      return sum;
-    }, {
-      min: [] as Around<A>[typeof key][],
-      max: [] as Around<A>[typeof key][],
-    });
-
-    let stack = combine(max.concat(min) as Middleware<unknown[], unknown>[]);
-
-    if (typeof api.core[key] === "function") {
-      handle[key] = (...args: unknown[]) =>
-        stack(args, api.core[key] as (...args: unknown[]) => unknown);
+function append<A>(
+  outer: Partial<Around<A>>,
+  inner: Partial<Around<A>>,
+): Partial<Around<A>> {
+  let result: Partial<Around<A>> = { ...outer };
+  for (let key of Object.keys(inner) as (keyof A)[]) {
+    let current = outer[key];
+    let decoration = inner[key];
+    if (!current) {
+      result[key] = decoration;
     } else {
-      Object.defineProperty(handle, key, {
-        enumerable: true,
-        get() {
-          return stack([], () => api.core[key]);
-        },
-      });
+      let pair = [current, decoration] as Middleware<unknown[], unknown>[];
+      result[key] = combine(pair) as Around<A>[keyof A];
     }
   }
+  return result;
+}
 
+function install<A>(
+  scope: Scope,
+  api: ApiInternal<A>,
+  total: Decorator<A>,
+): void {
+  if (scope.hasOwn(api.context)) {
+    let context = scope.expect(api.context);
+
+    context.total = total;
+
+    total = decorate(context.total, context.local);
+
+    context.handle = createApiHandle(total, api.core);
+  }
+
+  for (let child of scope.expect(Children)) {
+    install(child, api, total);
+  }
+}
+
+function createApiHandle<A>(decoration: Decorator<A>, core: A): A {
+  let around = decoration.max
+    ? decoration.min ? append(decoration.max, decoration.min) : decoration.max
+    : decoration.min;
+  if (!around) {
+    return core;
+  }
+  let handle: A = {} as A;
+  for (let key of Object.keys(core as object) as Array<keyof A>) {
+    let middleware = around[key] as Middleware<unknown[], unknown> | undefined;
+    if (middleware) {
+      if (typeof core[key] === "function") {
+        handle[key] = ((...args: unknown[]) =>
+          middleware(args, core[key] as (...args: unknown[]) => unknown)) as A[
+            keyof A
+          ];
+      } else {
+        Object.defineProperty(handle, key, {
+          enumerable: true,
+          get() {
+            return middleware([], () => core[key]);
+          },
+        });
+      }
+    } else {
+      handle[key] = core[key];
+    }
+  }
   return handle;
 }
 
@@ -163,6 +204,11 @@ function combine<TArgs extends unknown[], TReturn>(
   return middlewares.reduceRight((sum, middleware) => (args, next) =>
     middleware(args, (...args) => sum(args, next))
   );
+}
+
+interface Decorator<A> {
+  min?: Partial<Around<A>>;
+  max?: Partial<Around<A>>;
 }
 
 const GetScope: Effect<Scope> = {

--- a/lib/scope-internal.ts
+++ b/lib/scope-internal.ts
@@ -1,4 +1,4 @@
-import type { ApiInternal } from "./api-internal.ts";
+import { type ApiInternal, decorateApi } from "./api-internal.ts";
 import { api as effection } from "./api.ts";
 import { Children, Priority } from "./contexts.ts";
 import { createFuture } from "./future.ts";
@@ -71,50 +71,16 @@ export function buildScopeInternal(
         },
       };
     },
-
     around<A extends {}>(
       api: ApiInternal<A>,
       ...params: Parameters<ApiInternal<A>["around"]>
     ) {
-      let [around, options] = params;
-      if (!scope.hasOwn(api.context)) {
-        scope.set(api.context, { min: [], max: [] });
-      }
-
-      let { min, max } = scope.expect(api.context);
-
-      if (options?.at === "min") {
-        min.push(around);
-      } else {
-        max.push(around);
-      }
-
-      api.invalidate(scope);
+      decorateApi(scope, api, ...params);
     },
 
     ensure(op: () => Operation<void>): () => void {
       destructors.add(op);
       return () => destructors.delete(op);
-    },
-
-    reduce<T, S>(
-      context: Context<T>,
-      fn: (sum: S, item: T) => S,
-      initial: S,
-    ): S {
-      let sum = initial;
-      let current = contexts;
-      while (current) {
-        if (Object.hasOwn(current, context.name)) {
-          let item = current[context.name] as T;
-          if (item) {
-            sum = fn(sum, item);
-          }
-        }
-
-        current = Object.getPrototypeOf(current);
-      }
-      return sum;
     },
   });
 

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -1,7 +1,13 @@
 import { run } from "../mod.ts";
 import { createApi } from "../experimental.ts";
 import { constant } from "../lib/constant.ts";
-import { type Operation, spawn } from "../lib/mod.ts";
+import {
+  type Operation,
+  resource,
+  scoped,
+  spawn,
+  useScope,
+} from "../lib/mod.ts";
 import { describe, expect, it } from "./suite.ts";
 
 describe("api", () => {
@@ -154,11 +160,14 @@ describe("api", () => {
   });
 
   it("applies outer scope maxima more maximally than inner scopes maxima", async () => {
-    let api = createApi("test", {
-      *test(order: string[]): Operation<string[]> {
-        return order;
-      },
-    });
+    let api = createApi(
+      "test",
+      {
+        *test(order: string[]): Operation<string[]> {
+          return order;
+        },
+      } as const,
+    );
 
     await run(function* outer() {
       yield* api.around({
@@ -205,6 +214,212 @@ describe("api", () => {
         "/innermax",
         "/outermax",
       ]);
+    });
+  });
+
+  it("propagates new ancestor middleware to existing child scopes", async () => {
+    let api = createApi("test", {
+      *num(value: number): Operation<number> {
+        return value;
+      },
+    });
+
+    await run(function* () {
+      let nummer = yield* resource<{ num(): Operation<number> }>(
+        function* (provide) {
+          let scope = yield* useScope();
+          yield* provide({
+            *num() {
+              return yield* scope.run(() => api.operations.num(5));
+            },
+          });
+        },
+      );
+
+      yield* api.around({
+        *num(args, next) {
+          return (yield* next(...args)) * 2;
+        },
+      });
+
+      expect(yield* nummer.num()).toEqual(10);
+    });
+  });
+
+  it("propagates new ancestor middleware to existing child scopes that also have middleware", async () => {
+    let api = createApi("test", {
+      *test(order: string[]): Operation<string[]> {
+        return order;
+      },
+    });
+
+    await run(function* () {
+      let tester = yield* resource<{ test(): Operation<string[]> }>(
+        function* (provide) {
+          let scope = yield* useScope();
+          yield* api.around({
+            *test(args, next) {
+              let [input] = args;
+              let output = yield* next(input.concat("child"));
+              return output.concat("/child");
+            },
+          });
+          yield* provide({
+            *test() {
+              return yield* scope.run(() => api.operations.test([]));
+            },
+          });
+        },
+      );
+
+      yield* api.around({
+        *test(args, next) {
+          let [input] = args;
+          let output = yield* next(input.concat("parent"));
+          return output.concat("/parent");
+        },
+      });
+
+      expect(yield* tester.test()).toEqual([
+        "parent",
+        "child",
+        "/child",
+        "/parent",
+      ]);
+    });
+  });
+
+  it("isolates sibling scopes from each other's middleware", async () => {
+    let api = createApi("test", {
+      *test(order: string[]): Operation<string[]> {
+        return order;
+      },
+    });
+
+    function sibling(label: string) {
+      return resource<{ test(): Operation<string[]> }>(function* (provide) {
+        let scope = yield* useScope();
+        yield* api.around({
+          *test(args, next) {
+            let [input] = args;
+            return (yield* next(input.concat(label))).concat(`/${label}`);
+          },
+        });
+        yield* provide({
+          *test() {
+            return yield* scope.run(() => api.operations.test([]));
+          },
+        });
+      });
+    }
+
+    await run(function* () {
+      let a = yield* sibling("a");
+      let b = yield* sibling("b");
+
+      expect(yield* a.test()).toEqual(["a", "/a"]);
+      expect(yield* b.test()).toEqual(["b", "/b"]);
+      expect(yield* api.operations.test([])).toEqual([]);
+    });
+  });
+
+  it("composes middleware across a three-level scope tree", async () => {
+    let api = createApi("test", {
+      *test(order: string[]): Operation<string[]> {
+        return order;
+      },
+    });
+
+    function layer(label: string) {
+      return resource<{ test(): Operation<string[]> }>(function* (provide) {
+        let scope = yield* useScope();
+        yield* api.around({
+          *test(args, next) {
+            let [input] = args;
+            return (yield* next(input.concat(label))).concat(`/${label}`);
+          },
+        });
+        yield* provide({
+          *test() {
+            return yield* scope.run(() => api.operations.test([]));
+          },
+        });
+      });
+    }
+
+    await run(function* () {
+      yield* api.around({
+        *test(args, next) {
+          let [input] = args;
+          return (yield* next(input.concat("grand"))).concat("/grand");
+        },
+      });
+
+      let leaf = yield* resource<{ test(): Operation<string[]> }>(
+        function* (provide) {
+          yield* api.around({
+            *test(args, next) {
+              let [input] = args;
+              return (yield* next(input.concat("parent"))).concat("/parent");
+            },
+          });
+          let child = yield* layer("child");
+          yield* provide(child);
+        },
+      );
+
+      expect(yield* leaf.test()).toEqual([
+        "grand",
+        "parent",
+        "child",
+        "/child",
+        "/parent",
+        "/grand",
+      ]);
+    });
+  });
+
+  it("does not affect un-aroundified keys when middleware is installed for a different key", async () => {
+    let api = createApi("test", {
+      *foo(): Operation<number> {
+        return 1;
+      },
+      *bar(): Operation<number> {
+        return 1;
+      },
+    });
+
+    await run(function* () {
+      yield* api.around({
+        *foo(args, next) {
+          return (yield* next(...args)) * 100;
+        },
+      });
+
+      expect(yield* api.operations.foo()).toEqual(100);
+      expect(yield* api.operations.bar()).toEqual(1);
+    });
+  });
+
+  it("does not leak middleware from a finished child scope back to its parent", async () => {
+    let api = createApi("test", {
+      *num(value: number): Operation<number> {
+        return value;
+      },
+    });
+
+    await run(function* () {
+      let result = yield* scoped(function* () {
+        yield* api.around({
+          *num(args, next) {
+            return (yield* next(...args)) * 2;
+          },
+        });
+        return yield* api.operations.num(5);
+      });
+
+      expect(result).toEqual(10);
+      expect(yield* api.operations.num(5)).toEqual(5);
     });
   });
 });


### PR DESCRIPTION
# Motivation
The computational complexity of reifying an api handle was being deferred until the moment the api was being called, and then every invocation paid the cost of calculating the _entire_ middleware stack from the root all they way back to the decorate scope. The handle was cached for subsequent invocations, but any new `around()` invalidated that scope and every descendant, which meant that every single one had to walk the entire scope chain on the next invocation.

## Approach

The handle is now materialized at decoration time. Each api context carries `local` (this scope's contributions), `total` (the inherited stack), and `handle` (the assembled api). `around()` appends the new decorator onto `local` and then walks the subtree in `install()`, rebuilding each descendant's handle in place. Critically, the inherited middleware stack is cached at every scope that has middleware, so any subsequent calls to around() can begin from that total, and do not need to walk back up the entire scope chain.

In all cases, because the api handle is computed eagerly, `invoke()` is single context lookup and dispatch.

## AI Generated Visual Synopsis

### Before: lazy reification, eager invalidation

```
 Scope tree                api.context per scope          Cache
 ┌────────┐                ┌─────────────────────┐        ┌───────────────┐
 │ root   │ ─── ctx ───►   │ min: [...]          │        │ WeakMap<Scope │
 └───┬────┘                │ max: [...]          │        │      , A>     │
     │                     └─────────────────────┘        └───────┬───────┘
 ┌───┴────┐                ┌─────────────────────┐                │
 │ child  │ ─── ctx ───►   │ min: [...]          │                │
 └───┬────┘                │ max: [...]          │                │
     │                     └─────────────────────┘                │
 ┌───┴────┐                ┌─────────────────────┐                │
 │ leaf   │ ─── ctx ───►   │ min: [...]          │                │
 └────────┘                │ max: [...]          │                │
                           └─────────────────────┘                │
                                                                  │
 around(scope, decorator):                                        │
   ctx.min.push(...)  or  ctx.max.push(...)                       │
   api.invalidate(scope) ─────► cache.delete(scope)               │
                                cache.delete(child) recursively ──┘

 invoke(scope, key, args):
   handle = cache.get(scope)
   if (!handle):
     ┌── createHandle(scope) ──────────────────────────────────┐
     │   for each key in core:                                 │
     │     scope.reduce(api.context, ...) ── walks ancestors → │
     │     gather min[key], max[key]                           │
     │     stack = combine(max ++ min)                         │
     │     handle[key] = (...a) => stack(a, core[key])         │
     └─────────────────────────────────────────────────────────┘
     cache.set(scope, handle)
   return handle[key](...args)
```

Hot-path work: full scope-chain reduction + per-key stack build, once per
cache miss, after every `around()`.

---

# After: eager reification, O(1) invocation

```
 Scope tree                api.context per scope
 ┌────────┐                ┌──────────────────────────────────┐
 │ root   │ ─── ctx ───►   │ local  : { min?, max? }          │
 └───┬────┘                │ total  : { min?, max? }  (empty) │
     │                     │ handle : A   ◄── pre-built       │
     │                     └──────────────────────────────────┘
 ┌───┴────┐                ┌──────────────────────────────────┐
 │ child  │ ─── ctx ───►   │ local  : { min?, max? }          │
 └───┬────┘                │ total  : decorate(root.total,    │
     │                     │                   root.local)    │
     │                     │ handle : A   ◄── pre-built       │
     │                     └──────────────────────────────────┘
 ┌───┴────┐                ┌──────────────────────────────────┐
 │ leaf   │ ─── ctx ───►   │ local                            │
 └────────┘                │ total  : decorate(child.total,   │
                           │                   child.local)   │
                           │ handle                           │
                           └──────────────────────────────────┘

 around(scope, decorator) ≡ decorateApi:
   ctx.local = append(ctx.local, decorator)
   install(scope, ctx.total) ──┐
                               │
   install(scope, total):      ▼
     ctx.total  = total
     around     = append(total, ctx.local)
     ctx.handle = createApiHandle(around, core)   ── rebuild once
     for each child:
       install(child, around)                      ── recurse with
                                                      new effective total

 invoke(scope, key, args):
   handle = scope.get(api.context)?.handle ?? core   ── single ctx read
   return handle[key](...args)
```

Hot-path work: one context lookup, one dispatch. All composition has been
paid up front and re-paid only when the tree of decorators actually changes.

---

# The shift at a glance

```
                  Before                        After
                  ─────────                     ────────
 Storage          min[], max[]                  local, total, handle
 around()         push + invalidate subtree     fold local; rebuild
                                                  handle for self + subtree
 invoke()         walk ancestors → combine →    handle lookup
                    build → cache → call
 Cost paid by     callers (lazy, repeated       writers (eager, amortized
                  per cache miss)                 over many invocations)
```

