### PR TITLE
🐛 make sure to propagate unwind outside scoped

### DIFF
--- a/lib/scoped.ts
+++ b/lib/scoped.ts
@@ -1,7 +1,9 @@
 import type { Operation } from "./types.ts";
-import { trap } from "./trap.ts";
-import { useCoroutine } from "./coroutine.ts";
+import { Trap, trap } from "./trap.ts";
+import { critical, useCoroutine } from "./coroutine.ts";
 import { createScopeInternal } from "./scope-internal.ts";
+import { Just } from "./maybe.ts";
+import { Err, Ok } from "./result.ts";
 
 /**
  * Encapsulate an operation so that no effects will persist outside of
@@ -32,12 +34,17 @@ export function scoped<T>(operation: () => Operation<T>): Operation<T> {
       let routine = yield* useCoroutine();
       let original = routine.scope;
       let [scope, destroy] = createScopeInternal(original);
+      let t = new Trap<T>(routine);
       try {
         routine.scope = scope;
-        return yield* trap(operation);
+        t.outcome = Just(Ok(yield* trap(operation)));
+      } catch (error) {
+        t.outcome = Just(Err(error));
       } finally {
         routine.scope = original;
-        yield* destroy();
+        yield* critical(destroy);
+        // deno-lint-ignore no-unsafe-finally
+        return (yield t.exit()) as T;
       }
     },
   };

--- a/lib/trap.ts
+++ b/lib/trap.ts
@@ -27,7 +27,7 @@ export function* trap<T>(operation: () => Operation<T>): Operation<T> {
   }
 }
 
-class Trap<T> implements ErrorBoundary {
+export class Trap<T> implements ErrorBoundary {
   outcome = Nothing<Result<T>>();
 
   constructor(public routine: Coroutine<unknown>) {}

--- a/test/scoped.test.ts
+++ b/test/scoped.test.ts
@@ -178,4 +178,21 @@ describe("scoped", () => {
 
     await expect(task).rejects.toMatchObject({ message: "boom!" });
   });
+
+  it("does not execute code after scoped() when halted during async teardown", async () => {
+    let leaked = false;
+    let task = run(function* () {
+      yield* scoped(function* () {
+        yield* spawn(function* () {
+          yield* sleep(5000);
+        });
+        yield* suspend();
+      });
+      leaked = true;
+    });
+
+    await task.halt();
+
+    expect(leaked).toBe(false);
+  });
 });


### PR DESCRIPTION
# Motivation

Fix #1185.

 If a routine was halted while suspended inside scoped(), code after yield* scoped(...) would still run.

iter.return() yielded the destroy() effects in scoped's finally, but the resume came back as iter.next() which takes the frame out of return-mode. trap() re-arms via trap.exit(); scoped() had no equivalent. 

Fix: inline the Trap, run destroy() in critical() so cleanup completes, then yield trap.exit() to re-arm unwind based on the inner trap's outcome.