### PR TITLE
🐛 propagate halt out of scoped() + race() when callcc resolves externally

### DIFF
--- a/lib/scoped.ts
+++ b/lib/scoped.ts
@@ -1,7 +1,9 @@
 import type { Operation } from "./types.ts";
-import { trap } from "./trap.ts";
-import { useCoroutine } from "./coroutine.ts";
+import { Trap, trap } from "./trap.ts";
+import { critical, useCoroutine } from "./coroutine.ts";
 import { createScopeInternal } from "./scope-internal.ts";
+import { Just } from "./maybe.ts";
+import { Err, Ok } from "./result.ts";
 
 /**
  * Encapsulate an operation so that no effects will persist outside of
@@ -32,12 +34,17 @@ export function scoped<T>(operation: () => Operation<T>): Operation<T> {
       let routine = yield* useCoroutine();
       let original = routine.scope;
       let [scope, destroy] = createScopeInternal(original);
+      let t = new Trap<T>(routine);
       try {
         routine.scope = scope;
-        return yield* trap(operation);
+        t.outcome = Just(Ok(yield* trap(operation)));
+      } catch (error) {
+        t.outcome = Just(Err(error as Error));
       } finally {
         routine.scope = original;
-        yield* destroy();
+        yield* critical(destroy);
+        // deno-lint-ignore no-unsafe-finally
+        return (yield t.exit()) as T;
       }
     },
   };

--- a/lib/trap.ts
+++ b/lib/trap.ts
@@ -27,7 +27,7 @@ export function* trap<T>(operation: () => Operation<T>): Operation<T> {
   }
 }
 
-class Trap<T> implements ErrorBoundary {
+export class Trap<T> implements ErrorBoundary {
   outcome = Nothing<Result<T>>();
 
   constructor(public routine: Coroutine<unknown>) {}

--- a/test/scoped.test.ts
+++ b/test/scoped.test.ts
@@ -1,12 +1,15 @@
 import { box } from "../lib/box.ts";
+import { callcc } from "../lib/callcc.ts";
 import {
   createContext,
+  race,
   resource,
   run,
   scoped,
   sleep,
   spawn,
   suspend,
+  useScope,
 } from "../mod.ts";
 import { describe, expect, it } from "./suite.ts";
 
@@ -177,5 +180,64 @@ describe("scoped", () => {
     });
 
     await expect(task).rejects.toMatchObject({ message: "boom!" });
+  });
+
+  // regression for https://github.com/thefrontside/effection/issues/1185:
+  // externally resolving a callcc must unwind a scoped() + race() body and
+  // stop the surrounding loop instead of continuing to the next iteration.
+  it("propagates halt out of a scoped() + race() loop when callcc resolves externally", async () => {
+    let events: string[] = [];
+    let triggerShutdown!: () => void;
+
+    let task = run(function* () {
+      return yield* callcc<{ status: number }>(function* (resolve) {
+        let scope = yield* useScope();
+
+        triggerShutdown = () => {
+          scope.run(() => resolve({ status: 130 }));
+        };
+
+        for (let round of [1, 2, 3]) {
+          events.push(`round-${round}-start`);
+
+          yield* scoped(function* () {
+            events.push(`round-${round}-resource`);
+            try {
+              for (let step of [1, 2, 3]) {
+                // both candidates sleep so neither can resolve before the
+                // synchronous triggerShutdown() below; duration only bounds
+                // how fast a regression (no halt) fails.
+                let result = yield* race([
+                  (function* () {
+                    yield* sleep(10);
+                    return "timeout";
+                  })(),
+                  (function* () {
+                    yield* sleep(10);
+                    return `step-${step}`;
+                  })(),
+                ]);
+                events.push(`step-${step}-result: ${result}`);
+              }
+            } finally {
+              events.push(`round-${round}-teardown`);
+            }
+          });
+
+          events.push(`round-${round}-complete`);
+        }
+      });
+    });
+
+    // round 1 is now suspended inside race(); halt it from the outside.
+    triggerShutdown();
+
+    await expect(task).resolves.toEqual({ status: 130 });
+
+    expect(events).toEqual([
+      "round-1-start",
+      "round-1-resource",
+      "round-1-teardown",
+    ]);
   });
 });


### PR DESCRIPTION
Fixes #1185.

## Problem

When `callcc` is resolved externally (`scope.run(() => resolve(...))`) inside a `scoped()` body that uses `race()`, the halt signal failed to stop the surrounding loop — all rounds ran to completion. This broke graceful SIGINT shutdown for the exact `main()` + `scoped()` round-boundary + `race()`-timeout pattern.

## Root cause

`scoped()` runs on the **same** coroutine as its caller. On halt, `routine.unwind()` sets `data.unwinding = true`, and `step()` consumes it **exactly once** — it calls `iterator.return()` and resets the flag. But `scoped`'s teardown (`yield* destroy()`) is async: it halts the `race` children across multiple scheduler turns. By the time teardown finished, `unwinding` had already been reset, so `step()` took the normal `iterator.next()` path and the outer loop simply continued to the next round instead of finishing its own unwind. (`race`/`callcc` matter only because they introduce the spawned children that make teardown span multiple turns.)

## Fix

Localize the fix to `scoped()`/`trap()` and reuse the existing unwind-propagation machinery — **no change to the coroutine `step()` state machine**:

- Route the scoped body through a `Trap` (capturing success/error in `t.outcome`).
- Run teardown as `yield* critical(destroy)` so multi-step async cleanup completes via `.next()` rather than being short-circuited by the unwind branch.
- After teardown, `yield t.exit()` — when no outcome exists (the body was interrupted), `Trap.exit()` calls `routine.unwind()` again, **re-asserting** the unwind so the outer loop finishes instead of continuing.

This preserves the single-use-`return` unwind contract (the `test/coroutine.test.ts` "uses 'return' for a single iteration when unwound" canary still passes) and `export`s `Trap` so `scoped` can reuse it.

## Relationship to #1186

This implements the same approach as #1186 (Trap-routed `scoped` + `critical(destroy)` + `t.exit()`) and additionally adds the missing regression test pinning the `callcc` + `scoped` + `race` halt path — there was previously no test covering this exact combination, so the bug could silently return.

## Test

`test/scoped.test.ts` adds "propagates halt out of a scoped() + race() loop when callcc resolves externally". It reproduces the issue's scenario: the loop must stop after `round-1-teardown` and never start round 2. Verified to **fail on `v4` HEAD** (all 3 rounds run) and **pass with this fix**.