### PR TITLE
🐛 repro: external resolve advances action-orchestrated loop (#1188)

### DIFF
--- a/test/scoped.test.ts
+++ b/test/scoped.test.ts
@@ -1,12 +1,16 @@
 import { box } from "../lib/box.ts";
 import {
+  action,
   createContext,
+  race,
   resource,
   run,
   scoped,
   sleep,
   spawn,
   suspend,
+  type Operation,
+  useScope,
 } from "../mod.ts";
 import { describe, expect, it } from "./suite.ts";
 
@@ -194,5 +198,107 @@ describe("scoped", () => {
     await task.halt();
 
     expect(leaked).toBe(false);
+  });
+
+  it("does not advance loop after external resolve with nested scoped + race", async () => {
+    let events: string[] = [];
+
+    function* scopedAction<T>(
+      op: (
+        resolve: (value: T) => void,
+        reject: (error: Error) => void,
+      ) => Operation<void>,
+    ): Operation<T> {
+      let scope = yield* useScope();
+      return yield* action((resolve, reject) => {
+        let task = scope.run(() => scoped(() => op(resolve, reject)));
+        return () => task.halt();
+      });
+    }
+
+    let task = run(function* () {
+      return yield* scopedAction<{ status: number }>(function* (resolve) {
+        let scope = yield* useScope();
+        for (let round of [1, 2]) {
+          events.push(`round-${round}-start`);
+
+          let result = yield* scoped(function* () {
+            yield* scoped(function* () {
+              yield* race([
+                (function* () {
+                  yield* sleep(5000);
+                  return "timeout";
+                })(),
+                (function* () {
+                  yield* sleep(50);
+                  return "step";
+                })(),
+              ]);
+            });
+
+            if (round === 1) {
+              return { passed: false };
+            }
+
+            return { passed: true };
+          });
+
+          events.push(`round-${round}-result:${result.passed}`);
+
+          if (!result.passed) {
+            events.push("round-failed-trigger-shutdown");
+            scope.run(function* () {
+              resolve({ status: 130 });
+            });
+          }
+        }
+
+        resolve({ status: 0 });
+      });
+    });
+
+    await task;
+
+    expect(events).toContain("round-failed-trigger-shutdown");
+    expect(events).not.toContain("round-2-start");
+  });
+
+  it("does not advance loop after external resolve in minimal action baseline", async () => {
+    let events: string[] = [];
+
+    function* scopedAction<T>(
+      op: (
+        resolve: (value: T) => void,
+        reject: (error: Error) => void,
+      ) => Operation<void>,
+    ): Operation<T> {
+      let scope = yield* useScope();
+      return yield* action((resolve, reject) => {
+        let task = scope.run(() => op(resolve, reject));
+        return () => task.halt();
+      });
+    }
+
+    let task = run(function* () {
+      return yield* scopedAction<{ status: number }>(function* (resolve) {
+        let scope = yield* useScope();
+        for (let round of [1, 2]) {
+          events.push(`round-${round}-start`);
+          yield* sleep(10);
+          if (round === 1) {
+            events.push("round-failed-trigger-shutdown");
+            scope.run(function* () {
+              resolve({ status: 130 });
+            });
+          }
+        }
+        resolve({ status: 0 });
+      });
+    });
+
+    await task;
+
+    expect(events).toContain("round-failed-trigger-shutdown");
+    expect(events).not.toContain("round-2-start");
   });
 });


### PR DESCRIPTION
Reproduction for #1188. **These tests are expected to fail** — they document the bug and should go green once the underlying fix lands.

## What it shows

When shutdown is triggered externally via `scope.run(() => resolve(...))` from inside an `action`-orchestrated loop, the loop advances into the **next iteration** (`round-2-start`) after the shutdown trigger, instead of stopping once the current iteration finishes.

Two tests are added to `test/scoped.test.ts`:

1. **`does not advance loop after external resolve with nested scoped + race`** — mirrors the original report (`action` wrapping a loop, each round runs `scoped(scoped(race(...)))`). Observed events:
   ```
   round-1-start
   round-1-result:false
   round-failed-trigger-shutdown
   round-2-start        ← leaks
   ```

2. **`does not advance loop after external resolve in minimal action baseline`** — strips out `scoped()` and `race()` entirely; just `action` + a `for` loop + `sleep` + external `resolve`. Still leaks:
   ```
   round-1-start
   round-failed-trigger-shutdown
   round-2-start        ← leaks
   ```

## Why the baseline matters

The minimal baseline has no `scoped` and no `race`, yet it still advances to `round-2-start`. That isolates the root cause to the **`action` + external-resolve path** — i.e. resolving an `action` from outside (via `scope.run`) does not unwind the operation that is currently suspended awaiting that action before the loop takes its next step.

This is the broader category #1188 refers to: #1185 was the narrower `scoped` + `race` manifestation (fixed in #1186 / `49fe66f0`), but the same "external resolve doesn't halt the in-flight iteration" problem reproduces with a plain `action` loop.

## Run

```
deno test --allow-run --allow-read --allow-env --allow-ffi test/scoped.test.ts
```