### PR TITLE
document critical()

### DIFF
--- a/lib/coroutine.ts
+++ b/lib/coroutine.ts
@@ -125,6 +125,23 @@ export const SettleContext = createContext<Settleware>(
   (outcome, next) => next(outcome),
 );
 
+/**
+ * Prevents `operation` from being interrupted by unwind, ensuring teardown runs
+ * to completion. Use this inside a `finally` block when teardown needs
+ * multiple steps before the coroutine can exit.
+ *
+ * @example
+ * ```ts
+ * try {
+ *   yield* something();
+ * } finally {
+ *   yield* critical(function* () {
+ *     releaseLock();
+ *     yield* closeHandle();
+ *   });
+ * }
+ * ```
+ */
 export function* critical<T>(operation: () => Operation<T>): Operation<T> {
   let routine = yield* useCoroutine();
   let original = routine.data.critical;

--- a/lib/mod.ts
+++ b/lib/mod.ts
@@ -26,3 +26,4 @@ export * from "./with-resolvers.ts";
 export * from "./async.ts";
 export * from "./scoped.ts";
 export * from "./until.ts";
+export { critical } from "./coroutine.ts";


### PR DESCRIPTION
# Motivation

We want people to be able to use `critical` for which it needs to be exported and documented.

# Approach

Added JSDoc to explain that `critical()` prevents unwind from interrupting teardown, and included an example showing the intended `finally` usage with multiple teardown steps. Also exported `critical` from `lib/mod.ts` so it is available through the public entry point.
