### PR TITLE
📌 Pin Deno to 2.9.1 in CI workflows

### DIFF
--- a/.github/workflows/codspeed.yaml
+++ b/.github/workflows/codspeed.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: setup deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.x
+          deno-version: v2.9.1
 
       - name: setup node
         uses: actions/setup-node@v4

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -17,7 +17,7 @@ jobs:
       - name: setup deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.x
+          deno-version: v2.9.1
 
       - name: Get Version
         id: vars

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
       - name: setup deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.x
+          deno-version: v2.9.1
 
       - name: dry run publish
         run: deno publish --dry-run
@@ -33,7 +33,7 @@ jobs:
       - name: setup deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.x
+          deno-version: v2.9.1
 
       - name: Get Version
         id: vars
@@ -88,7 +88,7 @@ jobs:
       - name: setup deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.x
+          deno-version: v2.9.1
 
       - name: Get Version
         id: vars

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: setup deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.x
+          deno-version: v2.9.1
 
       - name: format
         run: deno fmt --check
@@ -50,7 +50,7 @@ jobs:
       - name: setup deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.x
+          deno-version: v2.9.1
 
       - name: dry run publish
         run: deno publish --dry-run
@@ -65,7 +65,7 @@ jobs:
       - name: setup deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.x
+          deno-version: v2.9.1
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -95,7 +95,7 @@ jobs:
       - name: setup deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.x
+          deno-version: v2.9.1
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/www.yaml
+++ b/.github/workflows/www.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.6.1
+          deno-version: v2.9.1
 
       - name: Serve Website
         run: |

--- a/.github/workflows/www.yaml
+++ b/.github/workflows/www.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.9.1
+          deno-version: v2.6.1
 
       - name: Serve Website
         run: |

--- a/www/assets/prism-atom-one-dark.css
+++ b/www/assets/prism-atom-one-dark.css
@@ -24,11 +24,11 @@ pre {
   margin-right: -16px;
   border-left: 4px solid
     rgba(
-      0,
-      0,
-      0,
-      0
-    ); /* Set placeholder for highlight accent border color to transparent */
+    0,
+    0,
+    0,
+    0
+  ); /* Set placeholder for highlight accent border color to transparent */
 }
 
 .code-line.inserted {
@@ -275,10 +275,7 @@ pre[class*="language-"] {
   color: var(--prism-hue-3);
 }
 
-.language-javascript
-  .token.template-string
-  > .token.interpolation
-  > .token.interpolation-punctuation.punctuation {
+.language-javascript .token.template-string > .token.interpolation > .token.interpolation-punctuation.punctuation {
   color: var(--prism-hue-5-2);
 }
 
@@ -406,9 +403,7 @@ div.code-toolbar > .toolbar.toolbar > .toolbar-item > span:focus {
 
 /* Hovering over a linkable line number (in the gutter area) */
 /* Requires Line Numbers plugin as well */
-pre[id].linkable-line-numbers.linkable-line-numbers
-  span.line-numbers-rows
-  > span:hover:before {
+pre[id].linkable-line-numbers.linkable-line-numbers span.line-numbers-rows > span:hover:before {
   background-color: var(--prism-syntax-cursor-line);
 }
 

--- a/www/blog/2026-02-06-structured-concurrency-for-javascript/structured-concurrency-js.svg
+++ b/www/blog/2026-02-06-structured-concurrency-for-javascript/structured-concurrency-js.svg
@@ -133,7 +133,8 @@
       />
     </filter>
 
-    <style>/* ---- Font stacks ---- */
+    <style>
+    /* ---- Font stacks ---- */
     .svg-title {
       font-family:
         ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica,
@@ -410,7 +411,8 @@
       .svg-label-heading {
         fill: #f3f4f6;
       }
-    }</style>
+    }
+    </style>
   </defs>
 
   <!-- ======== BACKGROUND ======== -->

--- a/www/blog/2026-02-13-abortcontroller-abort-doesnt-mean-it-stopped/abortcontroller-abort.svg
+++ b/www/blog/2026-02-13-abortcontroller-abort-doesnt-mean-it-stopped/abortcontroller-abort.svg
@@ -94,7 +94,8 @@
       />
     </filter>
 
-    <style>/* ---- Font stacks ---- */
+    <style>
+    /* ---- Font stacks ---- */
     .svg-title {
       font-family:
         ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica,
@@ -282,223 +283,280 @@
     /* ---- Terminal animation ---- */
     /*
      * 10s total cycle: 3s animation + 5s hold + 2s pause
-     * 
+     *
      * Timeline:
      * 0-0.2s (0-2%): Cursor blinks
-     * 0.2-3s (2-30%): Lines appear sequentially  
+     * 0.2-3s (2-30%): Lines appear sequentially
      * 3-8s (30-80%): Hold final state (5s reading time)
      * 8-10s (80-100%): Blank pause before restart
      */
 
     /* Left terminal line keyframes */
     @keyframes line-L1 {
-      0%, 1.9% {
+      0%,
+      1.9% {
         opacity: 0;
       }
-      2%, 80% {
+      2%,
+      80% {
         opacity: 1;
       }
-      80.1%, 100% {
+      80.1%,
+      100% {
         opacity: 0;
       }
     }
     @keyframes line-L2 {
-      0%, 3.9% {
+      0%,
+      3.9% {
         opacity: 0;
       }
-      4%, 80% {
+      4%,
+      80% {
         opacity: 1;
       }
-      80.1%, 100% {
+      80.1%,
+      100% {
         opacity: 0;
       }
     }
     @keyframes line-L3 {
-      0%, 5.9% {
+      0%,
+      5.9% {
         opacity: 0;
       }
-      6%, 80% {
+      6%,
+      80% {
         opacity: 1;
       }
-      80.1%, 100% {
+      80.1%,
+      100% {
         opacity: 0;
       }
     }
     @keyframes line-L4 {
-      0%, 6.9% {
+      0%,
+      6.9% {
         opacity: 0;
       }
-      7%, 80% {
+      7%,
+      80% {
         opacity: 1;
       }
-      80.1%, 100% {
+      80.1%,
+      100% {
         opacity: 0;
       }
     }
     @keyframes line-L5 {
-      0%, 8.4% {
+      0%,
+      8.4% {
         opacity: 0;
       }
-      8.5%, 80% {
+      8.5%,
+      80% {
         opacity: 1;
       }
-      80.1%, 100% {
+      80.1%,
+      100% {
         opacity: 0;
       }
     }
     @keyframes line-L6 {
-      0%, 9.9% {
+      0%,
+      9.9% {
         opacity: 0;
       }
-      10%, 80% {
+      10%,
+      80% {
         opacity: 1;
       }
-      80.1%, 100% {
+      80.1%,
+      100% {
         opacity: 0;
       }
     }
     @keyframes line-L7 {
-      0%, 11.4% {
+      0%,
+      11.4% {
         opacity: 0;
       }
-      11.5%, 80% {
+      11.5%,
+      80% {
         opacity: 1;
       }
-      80.1%, 100% {
+      80.1%,
+      100% {
         opacity: 0;
       }
     }
     @keyframes line-L8 {
-      0%, 13.9% {
+      0%,
+      13.9% {
         opacity: 0;
       }
-      14%, 80% {
+      14%,
+      80% {
         opacity: 1;
       }
-      80.1%, 100% {
+      80.1%,
+      100% {
         opacity: 0;
       }
     }
     @keyframes line-L9 {
-      0%, 15.9% {
+      0%,
+      15.9% {
         opacity: 0;
       }
-      16%, 80% {
+      16%,
+      80% {
         opacity: 1;
       }
-      80.1%, 100% {
+      80.1%,
+      100% {
         opacity: 0;
       }
     }
     @keyframes line-L10 {
-      0%, 17.9% {
+      0%,
+      17.9% {
         opacity: 0;
       }
-      18%, 80% {
+      18%,
+      80% {
         opacity: 1;
       }
-      80.1%, 100% {
+      80.1%,
+      100% {
         opacity: 0;
       }
     }
     @keyframes line-L11 {
-      0%, 19.9% {
+      0%,
+      19.9% {
         opacity: 0;
       }
-      20%, 80% {
+      20%,
+      80% {
         opacity: 1;
       }
-      80.1%, 100% {
+      80.1%,
+      100% {
         opacity: 0;
       }
     }
     @keyframes line-L12 {
-      0%, 21.9% {
+      0%,
+      21.9% {
         opacity: 0;
       }
-      22%, 80% {
+      22%,
+      80% {
         opacity: 1;
       }
-      80.1%, 100% {
+      80.1%,
+      100% {
         opacity: 0;
       }
     }
     @keyframes line-L13 {
-      0%, 23.9% {
+      0%,
+      23.9% {
         opacity: 0;
       }
-      24%, 80% {
+      24%,
+      80% {
         opacity: 1;
       }
-      80.1%, 100% {
+      80.1%,
+      100% {
         opacity: 0;
       }
     }
 
     /* Right terminal line keyframes */
     @keyframes line-R1 {
-      0%, 1.9% {
+      0%,
+      1.9% {
         opacity: 0;
       }
-      2%, 80% {
+      2%,
+      80% {
         opacity: 1;
       }
-      80.1%, 100% {
+      80.1%,
+      100% {
         opacity: 0;
       }
     }
     @keyframes line-R2 {
-      0%, 3.9% {
+      0%,
+      3.9% {
         opacity: 0;
       }
-      4%, 80% {
+      4%,
+      80% {
         opacity: 1;
       }
-      80.1%, 100% {
+      80.1%,
+      100% {
         opacity: 0;
       }
     }
     @keyframes line-R3 {
-      0%, 5.9% {
+      0%,
+      5.9% {
         opacity: 0;
       }
-      6%, 80% {
+      6%,
+      80% {
         opacity: 1;
       }
-      80.1%, 100% {
+      80.1%,
+      100% {
         opacity: 0;
       }
     }
     @keyframes line-R4 {
-      0%, 6.9% {
+      0%,
+      6.9% {
         opacity: 0;
       }
-      7%, 80% {
+      7%,
+      80% {
         opacity: 1;
       }
-      80.1%, 100% {
+      80.1%,
+      100% {
         opacity: 0;
       }
     }
     @keyframes line-R5 {
-      0%, 8.4% {
+      0%,
+      8.4% {
         opacity: 0;
       }
-      8.5%, 80% {
+      8.5%,
+      80% {
         opacity: 1;
       }
-      80.1%, 100% {
+      80.1%,
+      100% {
         opacity: 0;
       }
     }
     @keyframes line-R6 {
-      0%, 11.4% {
+      0%,
+      11.4% {
         opacity: 0;
       }
-      11.5%, 80% {
+      11.5%,
+      80% {
         opacity: 1;
       }
-      80.1%, 100% {
+      80.1%,
+      100% {
         opacity: 0;
       }
     }
@@ -635,7 +693,8 @@
         opacity: 0;
         animation: none;
       }
-    }</style>
+    }
+    </style>
   </defs>
 
   <!-- ======== BACKGROUND ======== -->

--- a/www/blog/2026-04-07-strict-structured-concurrency/foreground-background.svg
+++ b/www/blog/2026-04-07-strict-structured-concurrency/foreground-background.svg
@@ -114,7 +114,8 @@
       <path d="M 0 1 L 9 5 L 0 9 z" class="svg-ret-arrow-fill" />
     </marker>
 
-    <style>.svg-mono {
+    <style>
+    .svg-mono {
       font-family:
         ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
         "Liberation Mono", "Courier New", monospace;
@@ -346,7 +347,8 @@
       .svg-annotation {
         fill: #9ca3af;
       }
-    }</style>
+    }
+    </style>
   </defs>
 
   <!-- ======== BACKGROUND (transparent) ======== -->

--- a/www/blog/2026-04-07-strict-structured-concurrency/strict-structured-concurrency.svg
+++ b/www/blog/2026-04-07-strict-structured-concurrency/strict-structured-concurrency.svg
@@ -152,7 +152,8 @@
       <rect x="0" y="0" width="920" height="630" />
     </clipPath>
 
-    <style>/* ---- Font stacks ---- */
+    <style>
+    /* ---- Font stacks ---- */
     .svg-title {
       font-family:
         ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica,
@@ -520,7 +521,8 @@
         animation: none;
         opacity: 1;
       }
-    }</style>
+    }
+    </style>
   </defs>
 
   <!-- ======== BACKGROUND ======== -->

--- a/www/blog/blog-image-template.svg
+++ b/www/blog/blog-image-template.svg
@@ -148,7 +148,8 @@
       />
     </filter>
 
-    <style>/* ---- Font stacks ---- */
+    <style>
+    /* ---- Font stacks ---- */
     .svg-title {
       font-family:
         ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica,
@@ -425,7 +426,8 @@
       .svg-label-heading {
         fill: #f3f4f6;
       }
-    }</style>
+    }
+    </style>
   </defs>
 
   <!-- ======== BACKGROUND ======== -->


### PR DESCRIPTION
# Motivation

The `v2.x` floating tag on `denoland/setup-deno` lets `deno fmt` and `deno lint` rules shift under us between CI runs, producing surprise reformatting churn on unrelated branches (see the recent "format website assets for Deno 2.9" commit). Pinning a specific patch makes formatting and linting output reproducible until we choose to bump.

# Approach

Replace `deno-version: v2.x` with `v2.9.1` (current 2.9.x) in `verify.yaml`, `publish.yml`, `codspeed.yaml`, and `preview.yml`. and `www.yaml`