### PR TITLE
✨ Show experimental APIs on the API docs

### DIFF
--- a/www/components/api/api-page.tsx
+++ b/www/components/api/api-page.tsx
@@ -1,34 +1,39 @@
-import { all } from "effection";
+import { all, type Operation } from "effection";
 import type { JSXElement } from "revolution";
 import { useConfig } from "../../context/config.ts";
 import { LocalDocPage } from "../../hooks/use-deno-doc.tsx";
 import { ResolveLinkFunction, useMarkdown } from "../../hooks/use-markdown.tsx";
 import { Package, usePackage } from "../../lib/package.ts";
-import { major } from "../../lib/semver.ts";
-import { createRootUrl, createSibling } from "../../lib/links-resolvers.ts";
+import { gt, major } from "../../lib/semver.ts";
+import { createRootUrl, useApiSeries } from "../../lib/links-resolvers.ts";
 import { SourceCodeIcon } from "../icons/source-code.tsx";
 import { GithubPill } from "../package/source-link.tsx";
-import { Icon } from "../type/icon.tsx";
+import { ExperimentalBadge, Icon } from "../type/icon.tsx";
 import { Type } from "../type/jsx.tsx";
 import { Keyword } from "../type/tokens.tsx";
+
+/**
+ * Root-based URL for a symbol's doc page. Experimental symbols live under a
+ * `/experimental` segment, so linking cannot be relative to the current page
+ * (which would resolve into or out of the wrong namespace).
+ */
+function* pageHref(page: LocalDocPage): Operation<string> {
+  let series = yield* useApiSeries();
+  let base = page.experimental ? `api/${series}/experimental` : `api/${series}`;
+  return yield* createRootUrl(base)(page.name);
+}
 
 export function* ApiPage({
   pages,
   current,
   pkg,
-  externalLinkResolver,
   banner,
 }: {
-  current: string;
+  current: LocalDocPage;
   pages: LocalDocPage[];
   pkg: Package;
   banner?: JSXElement;
-  externalLinkResolver: ResolveLinkFunction;
 }) {
-  const page = pages.find((node) => node.name === current);
-
-  if (!page) throw new Error(`Could not find a doc page for ${current}`);
-
   const linkResolver: ResolveLinkFunction = function* resolve(
     symbol,
     connector,
@@ -38,11 +43,11 @@ export function* ApiPage({
       pages.find((page) => page.name === symbol);
 
     if (target) {
-      return `[${
-        [symbol, connector, method].join(
-          "",
-        )
-      }](${yield* externalLinkResolver(symbol, connector, method)})`;
+      let href = yield* pageHref(target);
+      if (connector && method) {
+        href = `${href}#${method}`;
+      }
+      return `[${[symbol, connector, method].join("")}](${href})`;
     } else {
       return symbol;
     }
@@ -57,40 +62,64 @@ export function* ApiPage({
         content: (
           <>
             <>{banner}</>
-            {yield* SymbolHeader({ pkg, page })}
-            {yield* ApiBody({ page, linkResolver })}
+            {yield* SymbolHeader({ pkg, page: current })}
+            {yield* ApiBody({ page: current, linkResolver })}
           </>
         ),
-        linkResolver: createSibling,
         versionToggle: yield* (function* () {
-          const { series } = yield* useConfig();
-          // Only show stable series in version toggle (no prereleases)
-          const stableSeries = series.filter((s) => !s.includePrerelease);
-          const currentSeries = `v${major(pkg.version)}`;
+          const { series: allSeries } = yield* useConfig();
+          const series = yield* useApiSeries();
+          const entrypoint = current.experimental ? "./experimental" : ".";
+          const suffix = current.experimental ? "/experimental" : "";
 
+          // Toggle across every series that documents the current symbol:
+          // stable releases show their version (e.g. 3.6.1, 4.0.3), and the
+          // prerelease shows as "next" — but only when it's actually newer
+          // than its stable parent (otherwise there's nothing to switch to).
           const links = yield* all(
-            stableSeries.map(function* (s) {
+            allSeries.map(function* (s) {
               const seriesPkg = yield* usePackage({
                 type: "worktree",
                 series: s.name,
               });
+
+              if (s.includePrerelease) {
+                const parent = allSeries.find((p) => p.name === s.parent);
+                if (parent) {
+                  const parentPkg = yield* usePackage({
+                    type: "worktree",
+                    series: parent.name,
+                  });
+                  if (!gt(seriesPkg.version, parentPkg.version)) {
+                    return null;
+                  }
+                }
+              }
+
               const seriesDocs = yield* seriesPkg.docs();
-              const hasSymbol = seriesDocs["."].some((node) =>
-                node.name === current
+              const hasSymbol = (seriesDocs[entrypoint] ?? []).some((node) =>
+                node.name === current.name
               );
 
-              if (!hasSymbol) return null;
+              if (!hasSymbol) {
+                return null;
+              }
+
+              const isCurrent = s.name === series;
+              const label = s.includePrerelease ? "next" : seriesPkg.version;
 
               return (
                 <a
-                  href={yield* createRootUrl(`api/${s.name}`)(current)}
+                  href={yield* createRootUrl(`api/${s.name}${suffix}`)(
+                    current.name,
+                  )}
                   class={`text-base ${
-                    s.name === currentSeries
+                    isCurrent
                       ? "font-bold text-sky-500"
                       : "text-gray-600 dark:text-gray-400 hover:text-sky-500"
                   }`}
                 >
-                  {seriesPkg.version}
+                  {label}
                 </a>
               );
             }),
@@ -157,14 +186,12 @@ export function* ApiReference({
   content,
   current,
   pages,
-  linkResolver,
   versionToggle,
 }: {
   pkg: Package;
   content: JSXElement;
-  current: string;
+  current: LocalDocPage;
   pages: LocalDocPage[];
-  linkResolver: ResolveLinkFunction;
   versionToggle: JSXElement;
 }) {
   return (
@@ -175,7 +202,7 @@ export function* ApiReference({
             <span class="font-bold">API Reference</span>
             {versionToggle}
           </h3>
-          {yield* Menu({ pages, current, linkResolver })}
+          {yield* Menu({ pages, current })}
         </nav>
       </aside>
       <article
@@ -213,30 +240,32 @@ export function* SymbolHeader(
 function* Menu({
   pages,
   current,
-  linkResolver,
 }: {
-  current: string;
+  current: LocalDocPage;
   pages: LocalDocPage[];
-  linkResolver: ResolveLinkFunction;
 }) {
   const elements = [];
   for (const page of pages.sort((a, b) => a.name.localeCompare(b.name))) {
+    const isCurrent = page.name === current.name &&
+      !!page.experimental === !!current.experimental;
     elements.push(
       <li>
-        {current === page.name
+        {isCurrent
           ? (
             <span class="rounded px-2 block w-full py-2 bg-gray-100 dark:bg-gray-700 cursor-default ">
               <Icon kind={page.kind} />
               {page.name}
+              {page.experimental ? <ExperimentalBadge class="ml-1" /> : ""}
             </span>
           )
           : (
             <a
               class="rounded px-2 block w-full py-2 hover:bg-gray-100 dark:hover:bg-gray-800"
-              href={yield* linkResolver(page.name)}
+              href={yield* pageHref(page)}
             >
               <Icon kind={page.kind} />
               {page.name}
+              {page.experimental ? <ExperimentalBadge class="ml-1" /> : ""}
             </a>
           )}
       </li>,

--- a/www/components/type/icon.tsx
+++ b/www/components/type/icon.tsx
@@ -44,3 +44,20 @@ export function Icon(props: { kind: string; class?: string }) {
   }
   return <></>;
 }
+
+/**
+ * A small pill marking a symbol that is exported from the package's
+ * `./experimental` entrypoint. Rendered inline next to a symbol's name.
+ */
+export function ExperimentalBadge(props: { class?: string }) {
+  return (
+    <span
+      class={`${
+        props.class ? props.class : ""
+      } inline-block align-middle rounded bg-amber-100 dark:bg-amber-900 px-1.5 text-xs font-medium text-amber-800 dark:text-amber-200`}
+      title="Experimental API — may change or be removed in a future release"
+    >
+      experimental
+    </span>
+  );
+}

--- a/www/hooks/use-deno-doc.tsx
+++ b/www/hooks/use-deno-doc.tsx
@@ -53,6 +53,11 @@ export interface DocPage {
   description: string;
   kind: Declaration["kind"];
   dependencies: Dependency[];
+  /**
+   * True when this symbol is exported from the package's `./experimental`
+   * entrypoint. Drives the "experimental" badge and the namespaced doc URL.
+   */
+  experimental?: boolean;
 }
 
 export interface DocPageSection {

--- a/www/lib/links-resolvers.ts
+++ b/www/lib/links-resolvers.ts
@@ -3,6 +3,16 @@ import { CurrentRequest } from "../context/request.ts";
 import { dirname, join } from "@std/path";
 import { ResolveLinkFunction } from "../hooks/use-markdown.tsx";
 
+/**
+ * The API series being viewed, read from the current request. Symbol pages are
+ * always `/api/<series>/…` (or `/api/<series>/experimental/…`), so the series
+ * is the second path segment.
+ */
+export function* useApiSeries(): Operation<string> {
+  let request = yield* CurrentRequest.expect();
+  return new URL(request.url).pathname.split("/")[2];
+}
+
 export const createSibling: ResolveLinkFunction = function* (
   pathname,
   connector,

--- a/www/lib/package.ts
+++ b/www/lib/package.ts
@@ -166,6 +166,7 @@ function* initPackage(
         docs[entrypoint] = pages[`${url}`].map((page) => {
           return {
             ...page,
+            experimental: entrypoint === "./experimental",
             sections: page.sections.map((section) => ({
               ...section,
               declaration: {

--- a/www/main.tsx
+++ b/www/main.tsx
@@ -86,6 +86,17 @@ if (import.meta.main) {
             apiReferenceRoute(s.name, { search: true }),
           )
         ),
+        // Experimental API docs (namespaced; empty for series without the
+        // `./experimental` entrypoint)
+        ...series.map((s) =>
+          route(
+            `/api/${s.name}/experimental/:symbol`,
+            apiReferenceRoute(s.name, {
+              search: true,
+              entrypoint: "./experimental",
+            }),
+          )
+        ),
         route("/blog", blogIndexRoute({ search: true })),
         route("/blog/feed.xml", blogFeedRoute()),
         route("/llms.txt", llmsTxtRoute()),

--- a/www/routes/api-index-route.tsx
+++ b/www/routes/api-index-route.tsx
@@ -1,6 +1,6 @@
 import { type JSXElement } from "revolution";
 
-import { Icon } from "../components/type/icon.tsx";
+import { ExperimentalBadge, Icon } from "../components/type/icon.tsx";
 import { DocPage } from "../hooks/use-deno-doc.tsx";
 import { ResolveLinkFunction } from "../hooks/use-markdown.tsx";
 import { usePackage } from "../lib/package.ts";
@@ -35,8 +35,10 @@ export function apiIndexRoute(
       // Only show prerelease link if it's newer than stable
       let showV4Prerelease = gt(v4Next.version, v4.version);
 
-      // Get first symbol for prerelease link
-      let v4NextDocs = showV4Prerelease ? yield* v4Next.docs() : null;
+      // v4-next docs feed the "also available" prerelease link. The
+      // prerelease's own experimental APIs are surfaced when you click through
+      // to its symbol pages (their sidebar lists them, badged).
+      let v4NextDocs = yield* v4Next.docs();
       let v4NextFirstSymbol = v4NextDocs?.["."]?.[0]?.name ?? "run";
 
       let docs = {
@@ -77,8 +79,20 @@ export function apiIndexRoute(
               </h3>
               <ul class="columns-3 pl-0">
                 {yield* listPages({
-                  pages: docs.v4["."],
-                  linkResolver: createChildURL("v4"),
+                  groups: [
+                    {
+                      pages: docs.v4["."],
+                      linkResolver: createChildURL("v4"),
+                      experimental: false,
+                    },
+                    {
+                      // Experimental APIs for the stable release itself (empty
+                      // until a stable version exports `./experimental`).
+                      pages: docs.v4["./experimental"] ?? [],
+                      linkResolver: createChildURL("v4/experimental"),
+                      experimental: true,
+                    },
+                  ],
                 })}
               </ul>
             </section>
@@ -95,8 +109,18 @@ export function apiIndexRoute(
               </h3>
               <ul class="columns-3 pl-0">
                 {yield* listPages({
-                  pages: docs.v3["."],
-                  linkResolver: createChildURL("v3"),
+                  groups: [
+                    {
+                      pages: docs.v3["."],
+                      linkResolver: createChildURL("v3"),
+                      experimental: false,
+                    },
+                    {
+                      pages: docs.v3["./experimental"] ?? [],
+                      linkResolver: createChildURL("v3/experimental"),
+                      experimental: true,
+                    },
+                  ],
                 })}
               </ul>
             </section>
@@ -107,23 +131,35 @@ export function apiIndexRoute(
   };
 }
 
-function* listPages({
-  pages,
-  linkResolver,
-}: {
+interface PageGroup {
   pages: DocPage[];
   linkResolver: ResolveLinkFunction;
-}) {
-  let elements = [];
+  experimental: boolean;
+}
 
-  for (let page of pages.sort((a, b) => a.name.localeCompare(b.name))) {
-    let link = yield* linkResolver(page.name);
+function* listPages({ groups }: { groups: PageGroup[] }) {
+  // Resolve links first (linkResolver is an Operation), then merge every
+  // group into a single alphabetically-sorted list so experimental symbols
+  // sit inline with stable ones, each carrying its own badge and link.
+  let items: Array<{ page: DocPage; link: string; experimental: boolean }> = [];
+  for (let group of groups) {
+    for (let page of group.pages) {
+      let link = yield* group.linkResolver(page.name);
+      items.push({ page, link, experimental: group.experimental });
+    }
+  }
+
+  items.sort((a, b) => a.page.name.localeCompare(b.page.name));
+
+  let elements = [];
+  for (let { page, link, experimental } of items) {
     elements.push(
       <li class="list-none pb-1">
         <a class="text-blue-700 dark:text-blue-400" href={link}>
           <Icon kind={page.kind} class="mr-2" />
           {page.name}
         </a>
+        {experimental ? <ExperimentalBadge class="ml-2" /> : ""}
       </li>,
     );
   }

--- a/www/routes/api-reference-route.tsx
+++ b/www/routes/api-reference-route.tsx
@@ -5,13 +5,29 @@ import { useAppHtml } from "./app.html.tsx";
 
 import { ApiPage } from "../components/api/api-page.tsx";
 import { usePackage } from "../lib/package.ts";
-import { createSibling } from "../lib/links-resolvers.ts";
+
+function ExperimentalNotice(): JSXElement {
+  return (
+    <div class="not-prose border-l-4 border-amber-500 bg-amber-50 dark:bg-amber-950/40 pl-4 pr-3 py-2 mb-6 rounded-r">
+      <p class="font-bold text-amber-700 dark:text-amber-300 my-0">
+        Experimental
+      </p>
+      <p class="text-amber-800 dark:text-amber-200 my-0 text-sm">
+        This API is exported from <code>effection/experimental</code>{" "}
+        and may change or be removed in a future release.
+      </p>
+    </div>
+  );
+}
 
 export function apiReferenceRoute(series: string, {
   search,
+  entrypoint = ".",
 }: {
   search: boolean;
+  entrypoint?: string;
 }): SitemapRoute<JSXElement> {
+  let isExperimental = entrypoint === "./experimental";
   return {
     *routemap(generate) {
       let pkg = yield* usePackage({
@@ -21,7 +37,7 @@ export function apiReferenceRoute(series: string, {
 
       let docs = yield* pkg.docs();
 
-      return docs["."]
+      return (docs[entrypoint] ?? [])
         .map((node) => node.name)
         .flatMap((symbol) => {
           return [
@@ -41,11 +57,20 @@ export function apiReferenceRoute(series: string, {
 
       let docs = yield* pkg.docs();
 
-      let pages = docs["."];
+      let stablePages = docs["."] ?? [];
+      let experimentalPages = docs["./experimental"] ?? [];
 
-      let page = pages.find((node) => node.name === symbol);
+      // The sidebar lists stable + experimental symbols together (experimental
+      // ones badged); the current symbol is resolved within its own entrypoint.
+      let pages = [...stablePages, ...experimentalPages];
 
-      if (!page) throw new Error(`Could not find a doc page for ${symbol}`);
+      let page = (isExperimental ? experimentalPages : stablePages).find(
+        (node) => node.name === symbol,
+      );
+
+      if (!page) {
+        throw new Error(`Could not find a doc page for ${symbol}`);
+      }
 
       let AppHtml = yield* useAppHtml({
         title: `${symbol} | API Reference | Effection`,
@@ -56,9 +81,9 @@ export function apiReferenceRoute(series: string, {
         <AppHtml search={search}>
           {yield* ApiPage({
             pages,
-            current: symbol,
+            current: page,
             pkg,
-            externalLinkResolver: createSibling,
+            banner: isExperimental ? <ExperimentalNotice /> : undefined,
           })}
         </AppHtml>
       );


### PR DESCRIPTION
# Motivation

Closes #1200.

We're adding experimental APIs in 4.1, but we don't currently have a way to show experimental APIs on the website. 

# Approach

1. `useDenoDoc` includes `experimental` flag which is added for symbols that are exported from `./experimental` package export
2. added a route that shows experimental symbols at `/api/${s.name}/experimental/:symbol``
3. list pages now takes groups of symbols to show which includes experimental and default export
4. showing a banner on experimental routes

<img width="1512" height="860" alt="image" src="https://github.com/user-attachments/assets/e83995d8-7d18-439f-83ff-356b7f0ecd18" />

<img width="1512" height="645" alt="image" src="https://github.com/user-attachments/assets/7db02270-402b-4b02-90c2-7dd5b7fb5100" />
