### PR TITLE
📦 Trim npm package size (521 KB → 213 KB, no runtime change)

### DIFF
--- a/tasks/build-npm.ts
+++ b/tasks/build-npm.ts
@@ -17,10 +17,12 @@ await build({
   },
   test: false,
   typeCheck: false,
+  declaration: "separate",
+  skipSourceOutput: true,
   compilerOptions: {
     lib: ["ESNext", "DOM"],
     target: "ES2020",
-    sourceMap: true,
+    sourceMap: false,
   },
   package: {
     // package.json properties


### PR DESCRIPTION
# Motivation

`pkg-size.dev/effection` reports the published package at ~580 KB, which looks alarming. On inspection almost all of it is **install-only dev artifacts, not code that lands in a consumer's app bundle** — the runtime cost a bundler actually pulls in was already optimal at ~5.8 KB min+gzip. The tarball was ~30% sourcemaps, ~20% duplicated `.d.ts` (emitted into both `esm/` and `script/`), and ~18% raw TS source — none of which a bundler loads. This PR trims that fat without touching the code consumers run.

# Approach

Three dnt build options in `tasks/build-npm.ts`:

| Option | Effect |
|---|---|
| `sourceMap: false` | stop shipping `.js.map` (no runtime value) |
| `declaration: "separate"` | emit `.d.ts` once into a shared `types/` folder instead of duplicating across `esm/` **and** `script/` |
| `skipSourceOutput: true` | stop shipping raw `src/*.ts` |

Works on the currently pinned **dnt 0.41.3** — no toolchain bump required.

### Measured (via `npm pack`)

| Metric | Before | After | Δ |
|---|--:|--:|--:|
| unpacked on disk | 521 KB | **213 KB** | −59% |
| files | 427 | **145** | −66% |
| download (`.tgz` gzip) | 80 KB | **40 KB** | −49% |
| runtime bundle (min+gzip) | 5.8 KB | **5.8 KB** | unchanged |

### Verified

- ✅ ESM `import { run, sleep } from "effection"` runs
- ✅ CJS `require("effection")` runs (CJS output preserved)
- ✅ `tsc --noEmit` resolves types against the new shared `types/` folder

### Notes / decisions

- **`deno bundle --declaration`** (the "bundled single `.d.ts`" idea) was evaluated and **rejected**: it can't type-check effection's cross-runtime `lib/main.ts` (uses `Deno.*`, DOM, and a `node:process` dynamic import at once — no single `lib` satisfies all three), and pre-bundling gave no runtime-size win since bundlers already tree-shake the modular output.
- **`sourceMap: false` is the one debatable line** — it drops the biggest chunk (157 KB) but also removes published debugging maps. If shipping sourcemaps is preferred, revert just that line (unpacked lands at ~370 KB instead of 213 KB).