### PR TITLE
✨ Add "experimental" entry point for new APIs

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,8 +1,7 @@
 {
   "name": "@effection/effection",
-  "exports": "./mod.ts",
   "license": "ISC",
-  "publish": { "include": ["lib", "mod.ts", "README.md"] },
+  "publish": { "include": ["lib", "mod.ts", "experimental.ts", "README.md"] },
   "lock": false,
   "tasks": {
     "test": "deno test --allow-run --allow-read --allow-env --allow-ffi",
@@ -27,6 +26,10 @@
     "ctrlc-windows": "npm:ctrlc-windows@2.2.0",
     "tinyexec": "npm:tinyexec@1.0.1",
     "https://deno.land/x/path_to_regexp@v6.2.1/index.ts": "npm:path-to-regexp@8.2.0"
+  },
+  "exports": {
+    ".": "./mod.ts",
+    "./experimental": "./experimental.ts"
   },
   "nodeModulesDir": "auto",
   "workspace": [

--- a/tasks/build-npm.ts
+++ b/tasks/build-npm.ts
@@ -1,4 +1,5 @@
-import { build, emptyDir } from "jsr:@deno/dnt@0.41.3";
+import { build, emptyDir } from "jsr:@deno/dnt@0.42.3";
+import denoJSON from "../deno.json" with { type: "json" };
 
 const outDir = "./build/npm";
 
@@ -10,7 +11,10 @@ if (!version) {
 }
 
 await build({
-  entryPoints: ["./mod.ts"],
+  entryPoints: Object.entries(denoJSON.exports).map(([key, value]) => ({
+    name: key,
+    path: value,
+  })),
   outDir,
   shims: {
     deno: false,


### PR DESCRIPTION
# Motivation

We've been staging new API surface (context APIs, inspectable attributes, `api()` decorator machinery) on the `v4-1-alpha` branch behind an `./experimental` export. Rather than land that alpha branch as a single mega-merge, we're peeling it apart into feature PRs against `v4`.

This first PR is the foundation: it wires up the `./experimental` entry point so subsequent PRs (context APIs, etc.) have somewhere to land without touching the stable `mod.ts` surface.

# Approach

- `deno.json` — split `exports` into `.` (mod) and `./experimental` (experimental); include `experimental.ts` in publish set.
- `experimental.ts` — empty for now; content lands with follow-up PRs.
