### PR TITLE
✨ Introduce context APIs for algebraic effects

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -10,7 +10,7 @@
     "build:jsr": "deno run -A tasks/build-jsr.ts"
   },
   "lint": {
-    "rules": { "exclude": ["prefer-const", "require-yield"] },
+    "rules": { "exclude": ["prefer-const", "require-yield", "ban-types"] },
     "exclude": ["build", "docs", "tasks", "bench"],
     "plugins": ["lint/prefer-let.ts"]
   },

--- a/experimental.ts
+++ b/experimental.ts
@@ -1,0 +1,1 @@
+export * from "./lib/api.ts";

--- a/lib/api-internal.ts
+++ b/lib/api-internal.ts
@@ -9,18 +9,16 @@ import type {
   Operation,
   Scope,
 } from "./types.ts";
-import type { ScopeInternal } from "./scope-internal.ts";
 import { Children } from "./contexts.ts";
 import { Ok } from "./result.ts";
 
 export interface ApiInternal<A> extends Api<A> {
   context: Context<{
-    max: Partial<Around<A>>[];
-    min: Partial<Around<A>>[];
+    local: Decorator<A>;
+    total: Decorator<A>;
+    handle: A;
   }>;
   core: A;
-  cache: WeakMap<Scope, A>;
-  invalidate(scope: Scope): void;
 }
 
 export function createApiInternal<A extends {}>(
@@ -31,27 +29,13 @@ export function createApiInternal<A extends {}>(
 
   let context = createContext(`api::${name}`) as ApiInternal<A>["context"];
 
-  let cache = new WeakMap<Scope, A>();
-
   let api: ApiInternal<A> = {
     core,
     context,
-    cache,
-    invalidate(scope: Scope) {
-      cache.delete(scope);
-      let children = scope.get(Children);
-      if (children) {
-        for (let child of children) {
-          api.invalidate(child);
-        }
-      }
-    },
+
     invoke: (scope, key, args) => {
-      let handle = cache.get(scope);
-      if (!handle) {
-        handle = createHandle(api, scope as ScopeInternal);
-        cache.set(scope, handle);
-      }
+      let handle = scope.get(api.context)?.handle ?? core;
+
       let member = handle[key];
       if (typeof member === "function") {
         return member(...args);
@@ -62,7 +46,7 @@ export function createApiInternal<A extends {}>(
     around: (decorator, options = { at: "max" }) => ({
       *[Symbol.iterator]() {
         let scope = (yield GetScope) as Scope;
-        scope.around(api, decorator, options);
+        decorateApi(scope, api, decorator, options);
       },
     }),
     operations: fields.reduce((sum, field) => {
@@ -93,50 +77,107 @@ export function createApiInternal<A extends {}>(
   return api;
 }
 
-function createHandle<A extends {}>(
+export function decorateApi<A>(
+  scope: Scope,
   api: ApiInternal<A>,
-  scope: ScopeInternal,
-): A {
-  // there is no middleware at all for this api, so the handle _is_ the core.
-  if (!scope.get(api.context)) {
-    return api.core;
+  decorator: Partial<Around<A>>,
+  options?: {
+    at: "min" | "max";
+  },
+) {
+  // read existing total and local
+  let current = scope.get(api.context) ?? { total: {}, local: {} };
+
+  let local = decorate(current.local, {
+    [options?.at ?? "max"]: decorator,
+  });
+
+  if (!scope.hasOwn(api.context)) {
+    scope.set(api.context, {
+      local,
+      total: current.total,
+      handle: api.core,
+    });
+  } else {
+    current.local = local;
   }
 
-  let handle = Object.create(api.core);
+  install(scope, api, current.total);
+}
 
-  for (let key of Object.keys(api.core) as Array<keyof A>) {
-    let { min, max } = scope.reduce(api.context, (sum, current) => {
-      let min = current.min.flatMap((around) =>
-        around[key] ? [around[key]] : []
-      );
-      let max = current.max.flatMap((around) =>
-        around[key] ? [around[key]] : []
-      );
+function decorate<A>(base: Decorator<A>, next: Decorator<A>): Decorator<A> {
+  return {
+    max: base.max ? next.max ? append(base.max, next.max) : base.max : next.max,
+    min: next.min ? base.min ? append(next.min, base.min) : next.min : base.min,
+  };
+}
 
-      sum.min.push(...min);
-      sum.max.unshift(...max);
-
-      return sum;
-    }, {
-      min: [] as Around<A>[typeof key][],
-      max: [] as Around<A>[typeof key][],
-    });
-
-    let stack = combine(max.concat(min) as Middleware<unknown[], unknown>[]);
-
-    if (typeof api.core[key] === "function") {
-      handle[key] = (...args: unknown[]) =>
-        stack(args, api.core[key] as (...args: unknown[]) => unknown);
+function append<A>(
+  outer: Partial<Around<A>>,
+  inner: Partial<Around<A>>,
+): Partial<Around<A>> {
+  let result: Partial<Around<A>> = { ...outer };
+  for (let key of Object.keys(inner) as (keyof A)[]) {
+    let current = outer[key];
+    let decoration = inner[key];
+    if (!current) {
+      result[key] = decoration;
     } else {
-      Object.defineProperty(handle, key, {
-        enumerable: true,
-        get() {
-          return stack([], () => api.core[key]);
-        },
-      });
+      let pair = [current, decoration] as Middleware<unknown[], unknown>[];
+      result[key] = combine(pair) as Around<A>[keyof A];
     }
   }
+  return result;
+}
 
+function install<A>(
+  scope: Scope,
+  api: ApiInternal<A>,
+  total: Decorator<A>,
+): void {
+  if (scope.hasOwn(api.context)) {
+    let context = scope.expect(api.context);
+
+    context.total = total;
+
+    total = decorate(context.total, context.local);
+
+    context.handle = createApiHandle(total, api.core);
+  }
+
+  for (let child of scope.expect(Children)) {
+    install(child, api, total);
+  }
+}
+
+function createApiHandle<A>(decoration: Decorator<A>, core: A): A {
+  let around = decoration.max
+    ? decoration.min ? append(decoration.max, decoration.min) : decoration.max
+    : decoration.min;
+  if (!around) {
+    return core;
+  }
+  let handle: A = {} as A;
+  for (let key of Object.keys(core as object) as Array<keyof A>) {
+    let middleware = around[key] as Middleware<unknown[], unknown> | undefined;
+    if (middleware) {
+      if (typeof core[key] === "function") {
+        handle[key] = ((...args: unknown[]) =>
+          middleware(args, core[key] as (...args: unknown[]) => unknown)) as A[
+            keyof A
+          ];
+      } else {
+        Object.defineProperty(handle, key, {
+          enumerable: true,
+          get() {
+            return middleware([], () => core[key]);
+          },
+        });
+      }
+    } else {
+      handle[key] = core[key];
+    }
+  }
   return handle;
 }
 
@@ -163,6 +204,11 @@ function combine<TArgs extends unknown[], TReturn>(
   return middlewares.reduceRight((sum, middleware) => (args, next) =>
     middleware(args, (...args) => sum(args, next))
   );
+}
+
+interface Decorator<A> {
+  min?: Partial<Around<A>>;
+  max?: Partial<Around<A>>;
 }
 
 const GetScope: Effect<Scope> = {

--- a/lib/api-internal.ts
+++ b/lib/api-internal.ts
@@ -1,0 +1,174 @@
+// deno-lint-ignore-file ban-types no-explicit-any
+import { createContext } from "./context.ts";
+import type {
+  Api,
+  Around,
+  Context,
+  Effect,
+  Middleware,
+  Operation,
+  Scope,
+} from "./types.ts";
+import type { ScopeInternal } from "./scope-internal.ts";
+import { Children } from "./contexts.ts";
+import { Ok } from "./result.ts";
+
+export interface ApiInternal<A> extends Api<A> {
+  context: Context<{
+    max: Partial<Around<A>>[];
+    min: Partial<Around<A>>[];
+  }>;
+  core: A;
+  cache: WeakMap<Scope, A>;
+  invalidate(scope: Scope): void;
+}
+
+export function createApiInternal<A extends {}>(
+  name: string,
+  core: A,
+): ApiInternal<A> {
+  let fields = Object.keys(core) as (keyof A)[];
+
+  let context = createContext(`api::${name}`) as ApiInternal<A>["context"];
+
+  let cache = new WeakMap<Scope, A>();
+
+  let api: ApiInternal<A> = {
+    core,
+    context,
+    cache,
+    invalidate(scope: Scope) {
+      cache.delete(scope);
+      let children = scope.get(Children);
+      if (children) {
+        for (let child of children) {
+          api.invalidate(child);
+        }
+      }
+    },
+    invoke: (scope, key, args) => {
+      let handle = cache.get(scope);
+      if (!handle) {
+        handle = createHandle(api, scope as ScopeInternal);
+        cache.set(scope, handle);
+      }
+      let member = handle[key];
+      if (typeof member === "function") {
+        return member(...args);
+      } else {
+        return member;
+      }
+    },
+    around: (decorator, options = { at: "max" }) => ({
+      *[Symbol.iterator]() {
+        let scope = (yield GetScope) as Scope;
+        scope.around(api, decorator, options);
+      },
+    }),
+    operations: fields.reduce((sum, field) => {
+      if (typeof core[field] === "function") {
+        return Object.assign(sum, {
+          [field]: (...args: any) => ({
+            *[Symbol.iterator]() {
+              let scope = (yield GetScope) as Scope;
+              let target = api.invoke(scope, field, args);
+
+              return isOperation(target) ? yield* target : target;
+            },
+          }),
+        });
+      } else {
+        return Object.assign(sum, {
+          [field]: {
+            *[Symbol.iterator]() {
+              let scope = (yield GetScope) as Scope;
+              let target = api.invoke(scope, field, [] as any);
+              return isOperation(target) ? yield* target : target;
+            },
+          },
+        });
+      }
+    }, {} as Api<A>["operations"]),
+  };
+  return api;
+}
+
+function createHandle<A extends {}>(
+  api: ApiInternal<A>,
+  scope: ScopeInternal,
+): A {
+  // there is no middleware at all for this api, so the handle _is_ the core.
+  if (!scope.get(api.context)) {
+    return api.core;
+  }
+
+  let handle = Object.create(api.core);
+
+  for (let key of Object.keys(api.core) as Array<keyof A>) {
+    let { min, max } = scope.reduce(api.context, (sum, current) => {
+      let min = current.min.flatMap((around) =>
+        around[key] ? [around[key]] : []
+      );
+      let max = current.max.flatMap((around) =>
+        around[key] ? [around[key]] : []
+      );
+
+      sum.min.push(...min);
+      sum.max.unshift(...max);
+
+      return sum;
+    }, {
+      min: [] as Around<A>[typeof key][],
+      max: [] as Around<A>[typeof key][],
+    });
+
+    let stack = combine(max.concat(min) as Middleware<unknown[], unknown>[]);
+
+    if (typeof api.core[key] === "function") {
+      handle[key] = (...args: unknown[]) =>
+        stack(args, api.core[key] as (...args: unknown[]) => unknown);
+    } else {
+      Object.defineProperty(handle, key, {
+        enumerable: true,
+        get() {
+          return stack([], () => api.core[key]);
+        },
+      });
+    }
+  }
+
+  return handle;
+}
+
+function isOperation<T>(
+  target: Operation<T> | T,
+): target is Operation<T> {
+  return target && !isNativeIterable(target) &&
+    typeof (target as Operation<T>)[Symbol.iterator] === "function";
+}
+
+function isNativeIterable(target: unknown): boolean {
+  return (
+    typeof target === "string" || Array.isArray(target) ||
+    target instanceof Map || target instanceof Set
+  );
+}
+
+function combine<TArgs extends unknown[], TReturn>(
+  middlewares: Middleware<TArgs, TReturn>[],
+): Middleware<TArgs, TReturn> {
+  if (middlewares.length === 0) {
+    return (args, next) => next(...args);
+  }
+  return middlewares.reduceRight((sum, middleware) => (args, next) =>
+    middleware(args, (...args) => sum(args, next))
+  );
+}
+
+const GetScope: Effect<Scope> = {
+  description: "Fast, non-typesafe lookup of co-routine scope",
+  enter: (resolve, routine) => {
+    resolve(Ok(routine.scope));
+    return (didExit) => didExit(Ok());
+  },
+};

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,0 +1,34 @@
+// deno-lint-ignore-file ban-types
+import type { Api, Context, Operation, Scope } from "./types.ts";
+import { createApiInternal } from "./api-internal.ts";
+import type { ScopeInternal } from "./scope-internal.ts";
+
+export function createApi<A extends {}>(name: string, core: A): Api<A> {
+  return createApiInternal(name, core);
+}
+
+interface ScopeApi {
+  create(parent: Scope): [Scope, () => Operation<void>];
+  destroy(scope: Scope): Operation<void>;
+  set<T>(scope: Scope, context: Context<T>, value: T): T;
+  delete<T>(scope: Scope, context: Context<T>): boolean;
+}
+
+interface Apis {
+  Scope: Api<ScopeApi>;
+}
+
+export const api: Apis = {
+  Scope: createApi<ScopeApi>("Scope", {
+    create() {
+      throw new TypeError(`no handler for Scope.create()`);
+    },
+    *destroy() {},
+    set(scope, context, value) {
+      return (scope as ScopeInternal).contexts[context.name] = value;
+    },
+    delete(scope, context) {
+      return delete (scope as ScopeInternal).contexts[context.name];
+    },
+  }),
+};

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -23,7 +23,9 @@ export const api: Apis = {
     create() {
       throw new TypeError(`no handler for Scope.create()`);
     },
-    *destroy() {},
+    destroy(scope) {
+      return (scope as ScopeInternal).destroy();
+    },
     set(scope, context, value) {
       return (scope as ScopeInternal).contexts[context.name] = value;
     },

--- a/lib/scope-internal.ts
+++ b/lib/scope-internal.ts
@@ -33,6 +33,10 @@ export function buildScopeInternal(
 ): [ScopeInternal, () => Operation<void>] {
   let destructors = new Set<() => Operation<void>>();
   let destruction = createFuture<void>();
+  let signaled = false;
+  let unbind = parent
+    ? (parent as ScopeInternal).ensure(() => destroy())
+    : () => {};
 
   let contexts: Record<string, unknown> = Object.create(
     parent ? (parent as ScopeInternal).contexts : null,
@@ -82,21 +86,12 @@ export function buildScopeInternal(
       destructors.add(op);
       return () => destructors.delete(op);
     },
-  });
 
-  scope.set(Priority, scope.expect(Priority) + 1);
-  scope.set(Children, new Set());
-  parent?.expect(Children).add(scope);
-
-  let destroy = () => api.invoke(scope, "destroy", [scope]);
-  let unbind = parent
-    ? (parent as ScopeInternal).ensure(() => destroy())
-    : () => {};
-
-  scope.around(api, {
     *destroy(): Operation<void> {
-      destroy = () => destruction.future;
-
+      if (signaled) {
+        return yield* destruction.future;
+      }
+      signaled = true;
       parent?.expect(Children).delete(scope);
       unbind();
       let outcome = Ok();
@@ -122,17 +117,19 @@ export function buildScopeInternal(
 
       unbox(outcome);
     },
-  }, { at: "min" });
+  });
 
-  return [scope, () => destroy()];
+  scope.set(Priority, scope.expect(Priority) + 1);
+  scope.set(Children, new Set());
+  parent?.expect(Children).add(scope);
+
+  let destroy = () => api.invoke(scope, "destroy", [scope]);
+
+  return [scope, destroy];
 }
 
 export interface ScopeInternal extends Scope, AsyncDisposable {
   contexts: Record<string, unknown>;
   ensure(op: () => Operation<void>): () => void;
-  reduce<T, TSum>(
-    context: Context<T>,
-    fn: (sum: TSum, item: T) => TSum,
-    initial: TSum,
-  ): TSum;
+  destroy(): Operation<void>;
 }

--- a/lib/scope-internal.ts
+++ b/lib/scope-internal.ts
@@ -1,4 +1,4 @@
-import type { ApiInternal } from "./api-internal.ts";
+import { type ApiInternal, decorateApi } from "./api-internal.ts";
 import { api as effection } from "./api.ts";
 import { Children, Priority } from "./contexts.ts";
 import { createFuture } from "./future.ts";
@@ -71,50 +71,16 @@ export function buildScopeInternal(
         },
       };
     },
-
     around<A extends {}>(
       api: ApiInternal<A>,
       ...params: Parameters<ApiInternal<A>["around"]>
     ) {
-      let [around, options] = params;
-      if (!scope.hasOwn(api.context)) {
-        scope.set(api.context, { min: [], max: [] });
-      }
-
-      let { min, max } = scope.expect(api.context);
-
-      if (options?.at === "min") {
-        min.push(around);
-      } else {
-        max.push(around);
-      }
-
-      api.invalidate(scope);
+      decorateApi(scope, api, ...params);
     },
 
     ensure(op: () => Operation<void>): () => void {
       destructors.add(op);
       return () => destructors.delete(op);
-    },
-
-    reduce<T, S>(
-      context: Context<T>,
-      fn: (sum: S, item: T) => S,
-      initial: S,
-    ): S {
-      let sum = initial;
-      let current = contexts;
-      while (current) {
-        if (Object.hasOwn(current, context.name)) {
-          let item = current[context.name] as T;
-          if (item) {
-            sum = fn(sum, item);
-          }
-        }
-
-        current = Object.getPrototypeOf(current);
-      }
-      return sum;
     },
   });
 

--- a/lib/scope-internal.ts
+++ b/lib/scope-internal.ts
@@ -1,3 +1,5 @@
+import type { ApiInternal } from "./api-internal.ts";
+import { api as effection } from "./api.ts";
 import { Children, Priority } from "./contexts.ts";
 import { createFuture } from "./future.ts";
 import { Err, Ok, unbox } from "./result.ts";
@@ -5,7 +7,28 @@ import { createTask } from "./task.ts";
 
 import type { Context, Operation, Scope, Task } from "./types.ts";
 
+const api = effection.Scope;
+
 export function createScopeInternal(
+  parent?: Scope,
+): [ScopeInternal, () => Operation<void>] {
+  if (!parent) {
+    let [global, destroy] = buildScopeInternal();
+    global.around(api, {
+      create([parent]) {
+        return buildScopeInternal(parent);
+      },
+    }, { at: "min" });
+    return [global, destroy] as const;
+  } else {
+    return api.invoke(parent, "create", [parent]) as [
+      ScopeInternal,
+      () => Operation<void>,
+    ];
+  }
+}
+
+export function buildScopeInternal(
   parent?: Scope,
 ): [ScopeInternal, () => Operation<void>] {
   let destructors = new Set<() => Operation<void>>();
@@ -21,7 +44,7 @@ export function createScopeInternal(
       return (contexts[context.name] ?? context.defaultValue) as T | undefined;
     },
     set<T>(context: Context<T>, value: T): T {
-      return contexts[context.name] = value;
+      return api.invoke(scope, "set", [scope, context, value]) as T;
     },
     expect<T>(context: Context<T>): T {
       let value = scope.get(context);
@@ -33,7 +56,7 @@ export function createScopeInternal(
       return value;
     },
     delete<T>(context: Context<T>): boolean {
-      return delete contexts[context.name];
+      return api.invoke(scope, "delete", [scope, context]);
     },
     hasOwn<T>(context: Context<T>): boolean {
       return !!Reflect.getOwnPropertyDescriptor(contexts, context.name);
@@ -49,9 +72,49 @@ export function createScopeInternal(
       };
     },
 
+    around<A extends {}>(
+      api: ApiInternal<A>,
+      ...params: Parameters<ApiInternal<A>["around"]>
+    ) {
+      let [around, options] = params;
+      if (!scope.hasOwn(api.context)) {
+        scope.set(api.context, { min: [], max: [] });
+      }
+
+      let { min, max } = scope.expect(api.context);
+
+      if (options?.at === "min") {
+        min.push(around);
+      } else {
+        max.push(around);
+      }
+
+      api.invalidate(scope);
+    },
+
     ensure(op: () => Operation<void>): () => void {
       destructors.add(op);
       return () => destructors.delete(op);
+    },
+
+    reduce<T, S>(
+      context: Context<T>,
+      fn: (sum: S, item: T) => S,
+      initial: S,
+    ): S {
+      let sum = initial;
+      let current = contexts;
+      while (current) {
+        if (Object.hasOwn(current, context.name)) {
+          let item = current[context.name] as T;
+          if (item) {
+            sum = fn(sum, item);
+          }
+        }
+
+        current = Object.getPrototypeOf(current);
+      }
+      return sum;
     },
   });
 
@@ -59,38 +122,41 @@ export function createScopeInternal(
   scope.set(Children, new Set());
   parent?.expect(Children).add(scope);
 
-  let destroy = function* (): Operation<void> {
-    destroy = () => destruction.future;
-
-    parent?.expect(Children).delete(scope);
-    unbind();
-    let outcome = Ok();
-    try {
-      while (destructors.size > 0) {
-        let current = [...destructors];
-        destructors.clear();
-        for (let destructor of current) {
-          try {
-            yield* destructor();
-          } catch (error) {
-            outcome = Err(error as Error);
-          }
-        }
-      }
-    } finally {
-      if (outcome.ok) {
-        destruction.resolve();
-      } else {
-        destruction.reject(outcome.error);
-      }
-    }
-
-    unbox(outcome);
-  };
-
+  let destroy = () => api.invoke(scope, "destroy", [scope]);
   let unbind = parent
     ? (parent as ScopeInternal).ensure(() => destroy())
     : () => {};
+
+  scope.around(api, {
+    *destroy(): Operation<void> {
+      destroy = () => destruction.future;
+
+      parent?.expect(Children).delete(scope);
+      unbind();
+      let outcome = Ok();
+      try {
+        while (destructors.size > 0) {
+          let current = [...destructors];
+          destructors.clear();
+          for (let destructor of current) {
+            try {
+              yield* destructor();
+            } catch (error) {
+              outcome = Err(error);
+            }
+          }
+        }
+      } finally {
+        if (outcome.ok) {
+          destruction.resolve();
+        } else {
+          destruction.reject(outcome.error);
+        }
+      }
+
+      unbox(outcome);
+    },
+  }, { at: "min" });
 
   return [scope, () => destroy()];
 }
@@ -98,4 +164,9 @@ export function createScopeInternal(
 export interface ScopeInternal extends Scope, AsyncDisposable {
   contexts: Record<string, unknown>;
   ensure(op: () => Operation<void>): () => void;
+  reduce<T, TSum>(
+    context: Context<T>,
+    fn: (sum: TSum, item: T) => TSum,
+    initial: TSum,
+  ): TSum;
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,3 +1,4 @@
+// deno-lint-ignore-file no-explicit-any
 import type { Maybe } from "./maybe.ts";
 import type { Result } from "./result.ts";
 
@@ -336,7 +337,97 @@ export interface Scope {
    * @returns `true` if scope has its own context, `false` if context is not present, or inherited from its parent.
    */
   hasOwn<T>(context: Context<T>): boolean;
+
+  /**
+   * Enhance an {@link Api} within this scope by surrounding it with
+   * middleware.
+   *
+   * @param api - the api being enhanced
+   * @param middlewares - collection of {@link Middleware} to be added to this {@link Api}
+   * @param options - specifies which layer of dispatch `middlewares` will be applied
+   * @see {@link Api.around}
+   * @since 4.1
+   */
+  around<A>(api: Api<A>, ...options: Parameters<Api<A>["around"]>): void;
 }
+
+/**
+ * A set of methods and values that can be decorated on a per-scope
+ * basis. Apis are ideal for situations that require context
+ * sensitivity such as dependency injection, test mocking, and
+ * instrumentation.
+ *
+ * @template A - core shape of the Api
+ * @see {@link createApi}
+ * @since 4.1
+ */
+export interface Api<A> {
+  /**
+   * Every member of `A` "lifted" into an operation that invokes that
+   * member on the current {Scope}
+   */
+  operations: {
+    [K in keyof A]: A[K] extends Operation<unknown> ? A[K]
+      : A[K] extends (...args: infer TArgs) => infer TReturn
+        ? TReturn extends Operation<unknown> ? A[K]
+        : (...args: TArgs) => Operation<TReturn>
+      : Operation<A[K]>;
+  };
+  /**
+   * Enhance an {@link Api} within this scope by surrounding it with
+   * middleware.
+   *
+   * @param middlewares - a set of decorators that will surround the api core
+   * @param options - specify at which layer of dispatch, `middleware` will apply
+   * @returns an {Operation} that installs the middleware in the current {Scope}
+   */
+  around: (
+    middlewares: Partial<Around<A>>,
+    options?: {
+      at: "min" | "max";
+    },
+  ) => Operation<void>;
+
+  /**
+   * Call an API as it exists on `scope`.
+   */
+  invoke: <K extends keyof A>(
+    scope: Scope,
+    key: K,
+    args: A[K] extends (...args: any) => unknown ? Parameters<A[K]> : [],
+  ) => A[K] extends (...args: any) => unknown ? ReturnType<A[K]> : A[K];
+}
+
+/**
+ * An general function that can be used to surround any other function
+ * or value.
+ *
+ * @since 4.1
+ */
+export interface Middleware<TArgs extends unknown[], TReturn> {
+  /**
+   * Execute a single link in the middleware stack by doing whatever
+   * computation is necessary and then optionally delegating to the
+   * next link.
+   *
+   * @param args - the arguments to the value being surrounded.
+   * @param next - the next function in the change. It will accept the
+   * arguments contained in `args`
+   * @returns a value with the same shape as `next()`'s return value
+   */
+  (args: TArgs, next: (...args: TArgs) => TReturn): TReturn;
+}
+
+/**
+ * The shape of middlewares can surround a particular {Api}
+ *
+ * Members of an Api that are values are surrounded by no-arg functions.
+ */
+export type Around<Api> = {
+  [K in keyof Api]: Api[K] extends (...args: infer TArgs) => infer TReturn
+    ? Middleware<TArgs, TReturn>
+    : Middleware<[], Api[K]>;
+};
 
 /**
  * Unwrap the type of an `Operation`.

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -1,7 +1,13 @@
 import { run } from "../mod.ts";
 import { createApi } from "../experimental.ts";
 import { constant } from "../lib/constant.ts";
-import { type Operation, spawn } from "../lib/mod.ts";
+import {
+  type Operation,
+  resource,
+  scoped,
+  spawn,
+  useScope,
+} from "../lib/mod.ts";
 import { describe, expect, it } from "./suite.ts";
 
 describe("api", () => {
@@ -154,11 +160,14 @@ describe("api", () => {
   });
 
   it("applies outer scope maxima more maximally than inner scopes maxima", async () => {
-    let api = createApi("test", {
-      *test(order: string[]): Operation<string[]> {
-        return order;
-      },
-    });
+    let api = createApi(
+      "test",
+      {
+        *test(order: string[]): Operation<string[]> {
+          return order;
+        },
+      } as const,
+    );
 
     await run(function* outer() {
       yield* api.around({
@@ -205,6 +214,212 @@ describe("api", () => {
         "/innermax",
         "/outermax",
       ]);
+    });
+  });
+
+  it("propagates new ancestor middleware to existing child scopes", async () => {
+    let api = createApi("test", {
+      *num(value: number): Operation<number> {
+        return value;
+      },
+    });
+
+    await run(function* () {
+      let nummer = yield* resource<{ num(): Operation<number> }>(
+        function* (provide) {
+          let scope = yield* useScope();
+          yield* provide({
+            *num() {
+              return yield* scope.run(() => api.operations.num(5));
+            },
+          });
+        },
+      );
+
+      yield* api.around({
+        *num(args, next) {
+          return (yield* next(...args)) * 2;
+        },
+      });
+
+      expect(yield* nummer.num()).toEqual(10);
+    });
+  });
+
+  it("propagates new ancestor middleware to existing child scopes that also have middleware", async () => {
+    let api = createApi("test", {
+      *test(order: string[]): Operation<string[]> {
+        return order;
+      },
+    });
+
+    await run(function* () {
+      let tester = yield* resource<{ test(): Operation<string[]> }>(
+        function* (provide) {
+          let scope = yield* useScope();
+          yield* api.around({
+            *test(args, next) {
+              let [input] = args;
+              let output = yield* next(input.concat("child"));
+              return output.concat("/child");
+            },
+          });
+          yield* provide({
+            *test() {
+              return yield* scope.run(() => api.operations.test([]));
+            },
+          });
+        },
+      );
+
+      yield* api.around({
+        *test(args, next) {
+          let [input] = args;
+          let output = yield* next(input.concat("parent"));
+          return output.concat("/parent");
+        },
+      });
+
+      expect(yield* tester.test()).toEqual([
+        "parent",
+        "child",
+        "/child",
+        "/parent",
+      ]);
+    });
+  });
+
+  it("isolates sibling scopes from each other's middleware", async () => {
+    let api = createApi("test", {
+      *test(order: string[]): Operation<string[]> {
+        return order;
+      },
+    });
+
+    function sibling(label: string) {
+      return resource<{ test(): Operation<string[]> }>(function* (provide) {
+        let scope = yield* useScope();
+        yield* api.around({
+          *test(args, next) {
+            let [input] = args;
+            return (yield* next(input.concat(label))).concat(`/${label}`);
+          },
+        });
+        yield* provide({
+          *test() {
+            return yield* scope.run(() => api.operations.test([]));
+          },
+        });
+      });
+    }
+
+    await run(function* () {
+      let a = yield* sibling("a");
+      let b = yield* sibling("b");
+
+      expect(yield* a.test()).toEqual(["a", "/a"]);
+      expect(yield* b.test()).toEqual(["b", "/b"]);
+      expect(yield* api.operations.test([])).toEqual([]);
+    });
+  });
+
+  it("composes middleware across a three-level scope tree", async () => {
+    let api = createApi("test", {
+      *test(order: string[]): Operation<string[]> {
+        return order;
+      },
+    });
+
+    function layer(label: string) {
+      return resource<{ test(): Operation<string[]> }>(function* (provide) {
+        let scope = yield* useScope();
+        yield* api.around({
+          *test(args, next) {
+            let [input] = args;
+            return (yield* next(input.concat(label))).concat(`/${label}`);
+          },
+        });
+        yield* provide({
+          *test() {
+            return yield* scope.run(() => api.operations.test([]));
+          },
+        });
+      });
+    }
+
+    await run(function* () {
+      yield* api.around({
+        *test(args, next) {
+          let [input] = args;
+          return (yield* next(input.concat("grand"))).concat("/grand");
+        },
+      });
+
+      let leaf = yield* resource<{ test(): Operation<string[]> }>(
+        function* (provide) {
+          yield* api.around({
+            *test(args, next) {
+              let [input] = args;
+              return (yield* next(input.concat("parent"))).concat("/parent");
+            },
+          });
+          let child = yield* layer("child");
+          yield* provide(child);
+        },
+      );
+
+      expect(yield* leaf.test()).toEqual([
+        "grand",
+        "parent",
+        "child",
+        "/child",
+        "/parent",
+        "/grand",
+      ]);
+    });
+  });
+
+  it("does not affect un-aroundified keys when middleware is installed for a different key", async () => {
+    let api = createApi("test", {
+      *foo(): Operation<number> {
+        return 1;
+      },
+      *bar(): Operation<number> {
+        return 1;
+      },
+    });
+
+    await run(function* () {
+      yield* api.around({
+        *foo(args, next) {
+          return (yield* next(...args)) * 100;
+        },
+      });
+
+      expect(yield* api.operations.foo()).toEqual(100);
+      expect(yield* api.operations.bar()).toEqual(1);
+    });
+  });
+
+  it("does not leak middleware from a finished child scope back to its parent", async () => {
+    let api = createApi("test", {
+      *num(value: number): Operation<number> {
+        return value;
+      },
+    });
+
+    await run(function* () {
+      let result = yield* scoped(function* () {
+        yield* api.around({
+          *num(args, next) {
+            return (yield* next(...args)) * 2;
+          },
+        });
+        return yield* api.operations.num(5);
+      });
+
+      expect(result).toEqual(10);
+      expect(yield* api.operations.num(5)).toEqual(5);
     });
   });
 });

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -1,0 +1,210 @@
+import { run } from "../mod.ts";
+import { createApi } from "../experimental.ts";
+import { constant } from "../lib/constant.ts";
+import { type Operation, spawn } from "../lib/mod.ts";
+import { describe, expect, it } from "./suite.ts";
+
+describe("api", () => {
+  it("invokes operation functions as operations", async () => {
+    let api = createApi("test", {
+      *test() {
+        return 5;
+      },
+    });
+
+    await run(function* () {
+      expect(yield* api.operations.test()).toEqual(5);
+    });
+  });
+
+  it("invokes synchronous functions as operations", async () => {
+    let api = createApi("test", {
+      five: () => 5,
+    });
+
+    await run(function* () {
+      expect(yield* api.operations.five()).toEqual(5);
+    });
+  });
+
+  it("invokes operations as operations", async () => {
+    let api = createApi("test", {
+      five: {
+        *[Symbol.iterator]() {
+          return 5;
+        },
+      } as Operation<number>,
+    });
+
+    await run(function* () {
+      expect(yield* api.operations.five).toEqual(5);
+    });
+  });
+
+  it("invokes constants as operations", async () => {
+    let api = createApi("test", {
+      five: 5,
+    });
+
+    await run(function* () {
+      expect(yield* api.operations.five).toEqual(5);
+    });
+  });
+
+  it("can have middleware installed", async () => {
+    let api = createApi("test", {
+      constFive: 5,
+      *operationFnFive() {
+        return 5;
+      },
+      operationFive: constant(5),
+      syncFive: () => 5 as number,
+    });
+
+    await run(function* () {
+      yield* api.around({
+        constFive(args, next) {
+          return next(...args) * 2;
+        },
+        *operationFnFive(args, next) {
+          return (yield* next(...args)) * 2;
+        },
+        *operationFive(args, next) {
+          return (yield* next(...args)) * 2;
+        },
+        syncFive: (args, next) => next(...args) * 2,
+      });
+
+      expect(yield* api.operations.constFive).toEqual(10);
+      expect(yield* api.operations.operationFnFive()).toEqual(10);
+      expect(yield* api.operations.operationFive).toEqual(10);
+      expect(yield* api.operations.syncFive()).toEqual(10);
+    });
+  });
+
+  it("inherits middleware from scope", async () => {
+    let api = createApi("test", {
+      *num(value: number): Operation<number> {
+        return value;
+      },
+    });
+
+    await run(function* () {
+      yield* api.around({
+        *num(args, next) {
+          return (yield* next(...args)) * 2;
+        },
+      });
+      let task = yield* spawn(function* () {
+        return yield* api.operations.num(5);
+      });
+
+      expect(yield* task).toEqual(10);
+    });
+  });
+
+  it("applies maximal middleware before minimal middleware", async () => {
+    let api = createApi("test", {
+      *test(order: string[]): Operation<string[]> {
+        return order;
+      },
+    });
+
+    await run(function* () {
+      yield* api.around({
+        *test(args, next) {
+          let [input] = args;
+          let output = yield* next(input.concat("max1"));
+          return output.concat("/max1");
+        },
+      });
+      yield* api.around({
+        *test(args, next) {
+          let [input] = args;
+          let output = yield* next(input.concat("max2"));
+          return output.concat("/max2");
+        },
+      });
+      yield* api.around({
+        *test(args, next) {
+          let [input] = args;
+          let output = yield* next(input.concat("min1"));
+          return output.concat("/min1");
+        },
+      });
+      yield* api.around({
+        *test(args, next) {
+          let [input] = args;
+          let output = yield* next(input.concat("min2"));
+          return output.concat("/min2");
+        },
+      });
+
+      expect(yield* api.operations.test([])).toEqual([
+        "max1",
+        "max2",
+        "min1",
+        "min2",
+        "/min2",
+        "/min1",
+        "/max2",
+        "/max1",
+      ]);
+    });
+  });
+
+  it("applies outer scope maxima more maximally than inner scopes maxima", async () => {
+    let api = createApi("test", {
+      *test(order: string[]): Operation<string[]> {
+        return order;
+      },
+    });
+
+    await run(function* outer() {
+      yield* api.around({
+        *test(args, next) {
+          let [input] = args;
+          let output = yield* next(input.concat("outermax"));
+          return output.concat("/outermax");
+        },
+      });
+      yield* api.around({
+        *test(args, next) {
+          let [input] = args;
+          let output = yield* next(input.concat("outermin"));
+          return output.concat("/outermin");
+        },
+      }, { at: "min" });
+
+      let task = yield* spawn(function* inner() {
+        yield* api.around({
+          *test(args, next) {
+            let [input] = args;
+            let output = yield* next(input.concat("innermax"));
+            return output.concat("/innermax");
+          },
+        });
+        yield* api.around({
+          *test(args, next) {
+            let [input] = args;
+            let output = yield* next(input.concat("innermin"));
+            return output.concat("/innermin");
+          },
+        }, { at: "min" });
+
+        return yield* api.operations.test([]);
+      });
+
+      expect(yield* task).toEqual([
+        "outermax",
+        "innermax",
+        "innermin",
+        "outermin",
+        "/outermin",
+        "/innermin",
+        "/innermax",
+        "/outermax",
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
# Motivation

Bring the Api api onto v4 from where it was on the alpha branch.

# Approach

Three cherry-picks from `v4-1-alpha`, in dependency order:

1. **Context APIs (`#1101`, `e062096e`)** — the primary change. Adds `lib/api.ts` (public `api()` / `createApi()` surface), `lib/api-internal.ts` (dispatch machinery), 91 lines of new types in `lib/types.ts`, and refactors `lib/scope-internal.ts` to route context ops (`set` / `delete` / `destroy`) through the api decorator system. `experimental.ts` starts exporting from `lib/api.ts`.

2. **Static api tree (`#1183`, `60abb25d`)** — bundled here rather than as a follow-up because it changes the same subsystem and would otherwise ship a slower version first. Moves middleware-stack materialization from *call time* to *decorate time*: each api-context caches `local` / `total` / `handle`, `around()` walks only the affected subtree, and `invoke()` becomes a single context lookup + dispatch. See commit message for details.

3. **`scope.destroy` cleanup (`01219739`)** — same rationale. `destroy` doesn't need the decorator machinery — it's the same function everywhere. Pulled it to a plain prototype method on `ScopeInternal`; the default api handle just invokes it. Removes per-scope decorate overhead.
