### PR TITLE
🐛 Run scope destructors in reverse order of registration

### DIFF
--- a/lib/scope-internal.ts
+++ b/lib/scope-internal.ts
@@ -99,7 +99,8 @@ export function buildScopeInternal(
         while (destructors.size > 0) {
           let current = [...destructors];
           destructors.clear();
-          for (let destructor of current) {
+          for (let i = current.length - 1; i >= 0; i--) {
+            let destructor = current[i];
             try {
               yield* destructor();
             } catch (error) {

--- a/test/scope.test.ts
+++ b/test/scope.test.ts
@@ -1,6 +1,7 @@
 import {
   createContext,
   createScope,
+  ensure,
   resource,
   run,
   sleep,
@@ -51,6 +52,28 @@ describe("Scope", () => {
 
     await expect(destroy()).resolves.toBeUndefined();
     expect(halted).toEqual(true);
+  });
+
+  it("runs destructors in reverse order of registration", async () => {
+    let order: string[] = [];
+    let [scope, destroy] = createScope();
+
+    scope.run(function* () {
+      yield* ensure(() => {
+        order.push("first");
+      });
+      yield* ensure(() => {
+        order.push("second");
+      });
+      yield* ensure(() => {
+        order.push("third");
+      });
+      yield* suspend();
+    });
+
+    await destroy();
+
+    expect(order).toEqual(["third", "second", "first"]);
   });
 
   it("errors on close if there is an problem in teardown", async () => {


### PR DESCRIPTION
# Motivation

I noticed this problem in TestKit using resources that wrap Playwright and using daemon from @effectionx/process. I didn't have a chance to figure out what it was while I was working on TestKit, but I was able to narrow it down for a problem I had with executable.md.

The problem occurs when async teardown expect another value to be present that was setup by an earlier resource. This dependency chain requires that the dependant resource is torn down before the dependency.  This seems to work correctly when the scope runs to completion, but not when the scope is destroyed explicitly.

# Approach

Invoke teardown operations in reverse (last first) to ensure that dependent teardown are invoked before the dependency. This makes explicit `destroy()` consistent with `TaskGroup.halt()` and normal task unwinding, which already tear down last-in, first-out.