### PR TITLE
🐛 Refresh each package clone once, not on every request

### DIFF
--- a/www/lib/clones.ts
+++ b/www/lib/clones.ts
@@ -1,13 +1,17 @@
-import { createContext, type Operation, type Task, useScope } from "effection";
+import {
+  createContext,
+  Err,
+  Ok,
+  type Operation,
+  type Result,
+  type Task,
+  useScope,
+} from "effection";
 import { $ } from "../context/shell.ts";
 import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 
 type Checkout = (nameWithOwner: string) => Operation<string>;
-
-type Attempt =
-  | { ok: true; dirpath: string }
-  | { ok: false; error: unknown };
 
 const Clones = createContext<Checkout>("clones");
 
@@ -16,7 +20,7 @@ export function* initClones(path: string): Operation<void> {
   yield* $(`mkdir -p ${path}`);
 
   let scope = yield* useScope();
-  let attempts = new Map<string, Task<Attempt>>();
+  let attempts = new Map<string, Task<Result<string>>>();
 
   // `git fetch` / `reset --hard` mutate a single working tree shared by every
   // request, so running them concurrently corrupts it (index-lock contention,
@@ -41,7 +45,7 @@ export function* initClones(path: string): Operation<void> {
         attempts.delete(nameWithOwner);
         throw outcome.error;
       }
-      return outcome.dirpath;
+      return outcome.value;
     },
   }));
 }
@@ -54,7 +58,7 @@ export function* useClone(nameWithOwner: string): Operation<string> {
 function* cloneOrRefresh(
   basepath: string,
   nameWithOwner: string,
-): Operation<Attempt> {
+): Operation<Result<string>> {
   let dirpath = resolve(`${basepath}/${nameWithOwner}`);
   try {
     if (!existsSync(dirpath)) {
@@ -63,8 +67,8 @@ function* cloneOrRefresh(
       yield* $(`git -C ${dirpath} fetch origin`);
       yield* $(`git -C ${dirpath} reset --hard origin/main`);
     }
-    return { ok: true, dirpath };
+    return Ok(dirpath);
   } catch (error) {
-    return { ok: false, error };
+    return Err(error as Error);
   }
 }

--- a/www/lib/clones.ts
+++ b/www/lib/clones.ts
@@ -22,17 +22,11 @@ export function* initClones(path: string): Operation<void> {
   let scope = yield* useScope();
   let attempts = new Map<string, Task<Result<string>>>();
 
-  // `git fetch` / `reset --hard` mutate a single working tree shared by every
-  // request, so running them concurrently corrupts it (index-lock contention,
-  // half-applied resets) — which surfaces as intermittent 500s when a wide
-  // crawl hits many `/x` and `/contrib` pages at once. Memoize the checkout per
-  // repository on the root scope so each is fetched and reset exactly once, with
-  // concurrent callers awaiting the same task.
-  //
-  // `cloneOrRefresh` returns an outcome rather than throwing: a task that throws
-  // would tear down the shared scope and take every other checkout — and the
-  // server — down with it. On failure we surface the error to the caller and
-  // drop the entry so a later request can retry.
+  // Concurrent `git fetch` / `reset --hard` on the shared working tree corrupt
+  // it (index-lock contention, half-applied resets), so each repo is fetched
+  // exactly once. A `scope.run` task that throws would tear down this shared
+  // scope and every other checkout with it, so failures come back as a Result
+  // and the entry is evicted to allow a retry.
   yield* Clones.set((nameWithOwner) => ({
     *[Symbol.iterator]() {
       let attempt = attempts.get(nameWithOwner);

--- a/www/lib/clones.ts
+++ b/www/lib/clones.ts
@@ -1,52 +1,39 @@
-import {
-  createContext,
-  type Operation,
-  type Scope,
-  type Task,
-  useScope,
-} from "effection";
+import { createContext, type Operation, useScope } from "effection";
 import { $ } from "../context/shell.ts";
 import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 
-interface Clones {
-  basepath: string;
-  scope: Scope;
-  checkouts: Map<string, Task<string>>;
-}
+type Checkout = (nameWithOwner: string) => Operation<string>;
 
-const ClonesContext = createContext<Clones>("clones");
+const Clones = createContext<Checkout>("clones");
 
 export function* initClones(path: string): Operation<void> {
   yield* $(`rm -rf ${path}`);
   yield* $(`mkdir -p ${path}`);
+
   let scope = yield* useScope();
-  yield* ClonesContext.set({ basepath: path, scope, checkouts: new Map() });
+  let checkouts = new Map<string, Operation<string>>();
+
+  // `git fetch` / `reset --hard` mutate a single working tree shared by every
+  // request, so running them concurrently corrupts it (index-lock contention,
+  // half-applied resets) — which surfaces as intermittent 500s when a wide
+  // crawl hits many `/x` and `/contrib` pages at once. Memoize the checkout per
+  // repository on the root scope: the first caller runs the git commands and
+  // every concurrent or later caller awaits that same task, so each repository
+  // is fetched and reset exactly once.
+  yield* Clones.set((nameWithOwner) => {
+    let checkout = checkouts.get(nameWithOwner);
+    if (!checkout) {
+      checkout = scope.run(() => cloneOrRefresh(path, nameWithOwner));
+      checkouts.set(nameWithOwner, checkout);
+    }
+    return checkout;
+  });
 }
 
-/**
- * Resolve a local checkout of `nameWithOwner`, cloning it on first use and
- * refreshing it to `origin/main`.
- *
- * The checkout is a single working tree shared by every request, and
- * `git fetch` / `reset --hard` mutate it — running them concurrently corrupts
- * the tree (index-lock contention, half-applied resets), which surfaces as
- * intermittent 500s when a wide crawl hits many `/x` and `/contrib` pages at
- * once. So the work is memoized per repository on the root scope: the first
- * caller runs the git commands and every concurrent or later caller awaits that
- * same task, so each repository is fetched and reset exactly once.
- */
 export function* useClone(nameWithOwner: string): Operation<string> {
-  let clones = yield* ClonesContext.expect();
-
-  let checkout = clones.checkouts.get(nameWithOwner);
-  if (!checkout) {
-    checkout = clones.scope.run(() =>
-      cloneOrRefresh(clones.basepath, nameWithOwner)
-    );
-    clones.checkouts.set(nameWithOwner, checkout);
-  }
-  return yield* checkout;
+  let checkout = yield* Clones.expect();
+  return yield* checkout(nameWithOwner);
 }
 
 function* cloneOrRefresh(

--- a/www/lib/clones.ts
+++ b/www/lib/clones.ts
@@ -1,9 +1,13 @@
-import { createContext, type Operation, useScope } from "effection";
+import { createContext, type Operation, type Task, useScope } from "effection";
 import { $ } from "../context/shell.ts";
 import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 
 type Checkout = (nameWithOwner: string) => Operation<string>;
+
+type Attempt =
+  | { ok: true; dirpath: string }
+  | { ok: false; error: unknown };
 
 const Clones = createContext<Checkout>("clones");
 
@@ -12,23 +16,34 @@ export function* initClones(path: string): Operation<void> {
   yield* $(`mkdir -p ${path}`);
 
   let scope = yield* useScope();
-  let checkouts = new Map<string, Operation<string>>();
+  let attempts = new Map<string, Task<Attempt>>();
 
   // `git fetch` / `reset --hard` mutate a single working tree shared by every
   // request, so running them concurrently corrupts it (index-lock contention,
   // half-applied resets) — which surfaces as intermittent 500s when a wide
   // crawl hits many `/x` and `/contrib` pages at once. Memoize the checkout per
-  // repository on the root scope: the first caller runs the git commands and
-  // every concurrent or later caller awaits that same task, so each repository
-  // is fetched and reset exactly once.
-  yield* Clones.set((nameWithOwner) => {
-    let checkout = checkouts.get(nameWithOwner);
-    if (!checkout) {
-      checkout = scope.run(() => cloneOrRefresh(path, nameWithOwner));
-      checkouts.set(nameWithOwner, checkout);
-    }
-    return checkout;
-  });
+  // repository on the root scope so each is fetched and reset exactly once, with
+  // concurrent callers awaiting the same task.
+  //
+  // `cloneOrRefresh` returns an outcome rather than throwing: a task that throws
+  // would tear down the shared scope and take every other checkout — and the
+  // server — down with it. On failure we surface the error to the caller and
+  // drop the entry so a later request can retry.
+  yield* Clones.set((nameWithOwner) => ({
+    *[Symbol.iterator]() {
+      let attempt = attempts.get(nameWithOwner);
+      if (!attempt) {
+        attempt = scope.run(() => cloneOrRefresh(path, nameWithOwner));
+        attempts.set(nameWithOwner, attempt);
+      }
+      let outcome = yield* attempt;
+      if (!outcome.ok) {
+        attempts.delete(nameWithOwner);
+        throw outcome.error;
+      }
+      return outcome.dirpath;
+    },
+  }));
 }
 
 export function* useClone(nameWithOwner: string): Operation<string> {
@@ -39,13 +54,17 @@ export function* useClone(nameWithOwner: string): Operation<string> {
 function* cloneOrRefresh(
   basepath: string,
   nameWithOwner: string,
-): Operation<string> {
+): Operation<Attempt> {
   let dirpath = resolve(`${basepath}/${nameWithOwner}`);
-  if (!existsSync(dirpath)) {
-    yield* $(`git clone https://github.com/${nameWithOwner} ${dirpath}`);
-  } else {
-    yield* $(`git -C ${dirpath} fetch origin`);
-    yield* $(`git -C ${dirpath} reset --hard origin/main`);
+  try {
+    if (!existsSync(dirpath)) {
+      yield* $(`git clone https://github.com/${nameWithOwner} ${dirpath}`);
+    } else {
+      yield* $(`git -C ${dirpath} fetch origin`);
+      yield* $(`git -C ${dirpath} reset --hard origin/main`);
+    }
+    return { ok: true, dirpath };
+  } catch (error) {
+    return { ok: false, error };
   }
-  return dirpath;
 }

--- a/www/lib/clones.ts
+++ b/www/lib/clones.ts
@@ -27,21 +27,19 @@ export function* initClones(path: string): Operation<void> {
   // exactly once. A `scope.run` task that throws would tear down this shared
   // scope and every other checkout with it, so failures come back as a Result
   // and the entry is evicted to allow a retry.
-  yield* Clones.set((nameWithOwner) => ({
-    *[Symbol.iterator]() {
-      let attempt = attempts.get(nameWithOwner);
-      if (!attempt) {
-        attempt = scope.run(() => cloneOrRefresh(path, nameWithOwner));
-        attempts.set(nameWithOwner, attempt);
-      }
-      let outcome = yield* attempt;
-      if (!outcome.ok) {
-        attempts.delete(nameWithOwner);
-        throw outcome.error;
-      }
-      return outcome.value;
-    },
-  }));
+  yield* Clones.set(function* (nameWithOwner) {
+    let attempt = attempts.get(nameWithOwner);
+    if (!attempt) {
+      attempt = scope.run(() => cloneOrRefresh(path, nameWithOwner));
+      attempts.set(nameWithOwner, attempt);
+    }
+    let outcome = yield* attempt;
+    if (!outcome.ok) {
+      attempts.delete(nameWithOwner);
+      throw outcome.error;
+    }
+    return outcome.value;
+  });
 }
 
 export function* useClone(nameWithOwner: string): Operation<string> {

--- a/www/lib/clones.ts
+++ b/www/lib/clones.ts
@@ -1,18 +1,58 @@
-import { createContext, type Operation } from "effection";
+import {
+  createContext,
+  type Operation,
+  type Scope,
+  type Task,
+  useScope,
+} from "effection";
 import { $ } from "../context/shell.ts";
 import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 
-const Clones = createContext<string>("clones");
+interface Clones {
+  basepath: string;
+  scope: Scope;
+  checkouts: Map<string, Task<string>>;
+}
+
+const ClonesContext = createContext<Clones>("clones");
 
 export function* initClones(path: string): Operation<void> {
   yield* $(`rm -rf ${path}`);
   yield* $(`mkdir -p ${path}`);
-  yield* Clones.set(path);
+  let scope = yield* useScope();
+  yield* ClonesContext.set({ basepath: path, scope, checkouts: new Map() });
 }
 
+/**
+ * Resolve a local checkout of `nameWithOwner`, cloning it on first use and
+ * refreshing it to `origin/main`.
+ *
+ * The checkout is a single working tree shared by every request, and
+ * `git fetch` / `reset --hard` mutate it — running them concurrently corrupts
+ * the tree (index-lock contention, half-applied resets), which surfaces as
+ * intermittent 500s when a wide crawl hits many `/x` and `/contrib` pages at
+ * once. So the work is memoized per repository on the root scope: the first
+ * caller runs the git commands and every concurrent or later caller awaits that
+ * same task, so each repository is fetched and reset exactly once.
+ */
 export function* useClone(nameWithOwner: string): Operation<string> {
-  let basepath = yield* Clones.expect();
+  let clones = yield* ClonesContext.expect();
+
+  let checkout = clones.checkouts.get(nameWithOwner);
+  if (!checkout) {
+    checkout = clones.scope.run(() =>
+      cloneOrRefresh(clones.basepath, nameWithOwner)
+    );
+    clones.checkouts.set(nameWithOwner, checkout);
+  }
+  return yield* checkout;
+}
+
+function* cloneOrRefresh(
+  basepath: string,
+  nameWithOwner: string,
+): Operation<string> {
   let dirpath = resolve(`${basepath}/${nameWithOwner}`);
   if (!existsSync(dirpath)) {
     yield* $(`git clone https://github.com/${nameWithOwner} ${dirpath}`);


### PR DESCRIPTION
# Motivation

`useClone` (`www/lib/clones.ts`) runs `git fetch` + `git reset --hard origin/main` against a **single shared working tree on every call**. The `/x` and `/contrib` package pages call it on each render (via `useWorkspaces` and `useTaxonomy`), all pointing at the same `build/clones/thefrontside/effectionx` checkout.

Under a wide concurrent crawl (e.g. building the Pagefind search index), dozens of these git mutations run against the same repository simultaneously — `.git/index.lock` contention and half-applied resets — which surface as intermittent `500`s (`GET /contrib/watch 500 Internal Server Error`).

# Approach

Memoize the checkout per repository on the root scope: the first caller runs the git commands and every concurrent or later caller awaits that same task, so each repository is fetched and reset **exactly once** per server lifetime. This removes the races and the redundant fetches. Uses the same `useScope()` + `scope.run(...)` pattern already used in `lib/octokit.ts`.

# Verification

- 54 `/x` and `/contrib` pages hammered concurrently (40-way parallel) over 3 rounds: **all 200, zero non-200**, and no `index.lock` errors in the server log.
- `deno fmt`, `deno lint`, `deno check` on the changed file.

This is the root cause behind the transient failures the Pagefind indexing work (#1220) had to paper over with crawl retries.