### PR TITLE
🐛 Fix API-doc pages that crash the MDX renderer on type signatures

### DIFF
--- a/www/hooks/use-markdown.test.ts
+++ b/www/hooks/use-markdown.test.ts
@@ -3,8 +3,8 @@ import { expect } from "expect";
 import { createJsDocSanitizer, escapeMdxSyntax } from "./use-markdown.tsx";
 
 describe("createJsDocSanitizer", () => {
-  const sanitizer = createJsDocSanitizer();
-  const cases: [string, string][] = [
+  let sanitizer = createJsDocSanitizer();
+  let cases: [string, string][] = [
     ["{@link Context}", "[Context](Context)"],
     ["@{link Scope}", "[Scope](Scope)"],
     ["{@link spawn()}", "[spawn](spawn)"],
@@ -20,7 +20,7 @@ describe("createJsDocSanitizer", () => {
     ],
   ];
 
-  for (const [input, expected] of cases) {
+  for (let [input, expected] of cases) {
     it(`rewrites ${input}`, function* () {
       expect(yield* sanitizer(input)).toEqual(expected);
     });

--- a/www/hooks/use-markdown.test.ts
+++ b/www/hooks/use-markdown.test.ts
@@ -1,6 +1,6 @@
 import { assertEquals } from "@std/assert";
 import { run } from "effection";
-import { createJsDocSanitizer } from "./use-markdown.tsx";
+import { createJsDocSanitizer, escapeMdxSyntax } from "./use-markdown.tsx";
 
 const sanitizer = createJsDocSanitizer();
 
@@ -26,3 +26,58 @@ sanitizedEquals(
   "{@link Operation}&lt;{@link T}&gt;",
   "[Operation](Operation)&lt;[T](T)&gt;",
 );
+
+Deno.test("escapeMdxSyntax: escapes `<` opening a type expression", () => {
+  // These previously leaked a raw `<Name>` into MDX, which parsed it as a JSX
+  // component and threw `ReferenceError: Name is not defined`.
+  assertEquals(
+    escapeMdxSyntax("Operation<Chain<T>>"),
+    "Operation&lt;Chain&lt;T>>",
+  );
+  assertEquals(escapeMdxSyntax("From<A | B>"), "From&lt;A | B>");
+  assertEquals(
+    escapeMdxSyntax("Middleware<[], Promise<void>>"),
+    "Middleware&lt;[], Promise&lt;void>>",
+  );
+  assertEquals(escapeMdxSyntax("Api<Scope>"), "Api&lt;Scope>");
+  // after {@link} sanitizing turns `{@link B}` into `[B](B)`
+  assertEquals(
+    escapeMdxSyntax("[Operation](Operation)<[B](B)>"),
+    "[Operation](Operation)&lt;[B](B)>",
+  );
+});
+
+Deno.test("escapeMdxSyntax: neutralizes stray `{...}` expressions", () => {
+  // A bare `{Scope}` / `{Api}` (e.g. from a malformed `{@link}`) is a JSX
+  // expression to MDX and throws `ReferenceError: Scope is not defined`.
+  assertEquals(
+    escapeMdxSyntax("surround a particular {Api}"),
+    "surround a particular &#123;Api&#125;",
+  );
+  assertEquals(escapeMdxSyntax("{Scope}"), "&#123;Scope&#125;");
+});
+
+Deno.test("escapeMdxSyntax: leaves real HTML tags intact", () => {
+  assertEquals(escapeMdxSyntax("<div>hello</div>"), "<div>hello</div>");
+  assertEquals(escapeMdxSyntax(" <img src=x>"), " <img src=x>");
+  assertEquals(escapeMdxSyntax("<br>"), "<br>");
+  assertEquals(
+    escapeMdxSyntax("<details><summary>x</summary></details>"),
+    "<details><summary>x</summary></details>",
+  );
+});
+
+Deno.test("escapeMdxSyntax: never touches angles or braces inside code", () => {
+  assertEquals(
+    escapeMdxSyntax("use `Array<string>` inline"),
+    "use `Array<string>` inline",
+  );
+  assertEquals(
+    escapeMdxSyntax("an empty `{}` object"),
+    "an empty `{}` object",
+  );
+  assertEquals(
+    escapeMdxSyntax("```ts\nlet x: Operation<Chain<T>> = { a: 1 }\n```"),
+    "```ts\nlet x: Operation<Chain<T>> = { a: 1 }\n```",
+  );
+});

--- a/www/hooks/use-markdown.test.ts
+++ b/www/hooks/use-markdown.test.ts
@@ -1,83 +1,77 @@
-import { assertEquals } from "@std/assert";
-import { run } from "effection";
+import { describe, it } from "../testing.ts";
+import { expect } from "expect";
 import { createJsDocSanitizer, escapeMdxSyntax } from "./use-markdown.tsx";
 
-const sanitizer = createJsDocSanitizer();
+describe("createJsDocSanitizer", () => {
+  const sanitizer = createJsDocSanitizer();
+  const cases: [string, string][] = [
+    ["{@link Context}", "[Context](Context)"],
+    ["@{link Scope}", "[Scope](Scope)"],
+    ["{@link spawn()}", "[spawn](spawn)"],
+    ["{@link Scope.run}", "[Scope.run](Scope.run)"],
+    ["{@link Scope#run}", "[Scope#run](Scope#run)"],
+    [
+      "{@link  * establish error boundaries https://frontside.com/effection/docs/errors | error boundaries}",
+      "",
+    ],
+    [
+      "{@link Operation}&lt;{@link T}&gt;",
+      "[Operation](Operation)&lt;[T](T)&gt;",
+    ],
+  ];
 
-function sanitizedEquals(a: string, b: string) {
-  Deno.test(`${a} => ${b}`, async function () {
-    let result = await run(function* () {
-      return yield* sanitizer(a);
+  for (const [input, expected] of cases) {
+    it(`rewrites ${input}`, function* () {
+      expect(yield* sanitizer(input)).toEqual(expected);
     });
-    assertEquals(result, b);
+  }
+});
+
+describe("escapeMdxSyntax", () => {
+  it("escapes `<` opening a type expression", function* () {
+    // These previously leaked a raw `<Name>` into MDX, which parsed it as a JSX
+    // component and threw `ReferenceError: Name is not defined`.
+    expect(escapeMdxSyntax("Operation<Chain<T>>")).toEqual(
+      "Operation&lt;Chain&lt;T>>",
+    );
+    expect(escapeMdxSyntax("From<A | B>")).toEqual("From&lt;A | B>");
+    expect(escapeMdxSyntax("Middleware<[], Promise<void>>")).toEqual(
+      "Middleware&lt;[], Promise&lt;void>>",
+    );
+    expect(escapeMdxSyntax("Api<Scope>")).toEqual("Api&lt;Scope>");
+    // after {@link} sanitizing turns `{@link B}` into `[B](B)`
+    expect(escapeMdxSyntax("[Operation](Operation)<[B](B)>")).toEqual(
+      "[Operation](Operation)&lt;[B](B)>",
+    );
   });
-}
 
-sanitizedEquals("{@link Context}", "[Context](Context)");
-sanitizedEquals("@{link Scope}", "[Scope](Scope)");
-sanitizedEquals("{@link spawn()}", "[spawn](spawn)");
-sanitizedEquals("{@link Scope.run}", "[Scope.run](Scope.run)");
-sanitizedEquals("{@link Scope#run}", "[Scope#run](Scope#run)");
-sanitizedEquals(
-  "{@link  * establish error boundaries https://frontside.com/effection/docs/errors | error boundaries}",
-  "",
-);
-sanitizedEquals(
-  "{@link Operation}&lt;{@link T}&gt;",
-  "[Operation](Operation)&lt;[T](T)&gt;",
-);
+  it("neutralizes stray `{...}` expressions", function* () {
+    // A bare `{Scope}` / `{Api}` (e.g. from a malformed `{@link}`) is a JSX
+    // expression to MDX and throws `ReferenceError: Scope is not defined`.
+    expect(escapeMdxSyntax("surround a particular {Api}")).toEqual(
+      "surround a particular &#123;Api&#125;",
+    );
+    expect(escapeMdxSyntax("{Scope}")).toEqual("&#123;Scope&#125;");
+  });
 
-Deno.test("escapeMdxSyntax: escapes `<` opening a type expression", () => {
-  // These previously leaked a raw `<Name>` into MDX, which parsed it as a JSX
-  // component and threw `ReferenceError: Name is not defined`.
-  assertEquals(
-    escapeMdxSyntax("Operation<Chain<T>>"),
-    "Operation&lt;Chain&lt;T>>",
-  );
-  assertEquals(escapeMdxSyntax("From<A | B>"), "From&lt;A | B>");
-  assertEquals(
-    escapeMdxSyntax("Middleware<[], Promise<void>>"),
-    "Middleware&lt;[], Promise&lt;void>>",
-  );
-  assertEquals(escapeMdxSyntax("Api<Scope>"), "Api&lt;Scope>");
-  // after {@link} sanitizing turns `{@link B}` into `[B](B)`
-  assertEquals(
-    escapeMdxSyntax("[Operation](Operation)<[B](B)>"),
-    "[Operation](Operation)&lt;[B](B)>",
-  );
-});
+  it("leaves real HTML tags intact", function* () {
+    expect(escapeMdxSyntax("<div>hello</div>")).toEqual("<div>hello</div>");
+    expect(escapeMdxSyntax(" <img src=x>")).toEqual(" <img src=x>");
+    expect(escapeMdxSyntax("<br>")).toEqual("<br>");
+    expect(escapeMdxSyntax("<details><summary>x</summary></details>")).toEqual(
+      "<details><summary>x</summary></details>",
+    );
+  });
 
-Deno.test("escapeMdxSyntax: neutralizes stray `{...}` expressions", () => {
-  // A bare `{Scope}` / `{Api}` (e.g. from a malformed `{@link}`) is a JSX
-  // expression to MDX and throws `ReferenceError: Scope is not defined`.
-  assertEquals(
-    escapeMdxSyntax("surround a particular {Api}"),
-    "surround a particular &#123;Api&#125;",
-  );
-  assertEquals(escapeMdxSyntax("{Scope}"), "&#123;Scope&#125;");
-});
-
-Deno.test("escapeMdxSyntax: leaves real HTML tags intact", () => {
-  assertEquals(escapeMdxSyntax("<div>hello</div>"), "<div>hello</div>");
-  assertEquals(escapeMdxSyntax(" <img src=x>"), " <img src=x>");
-  assertEquals(escapeMdxSyntax("<br>"), "<br>");
-  assertEquals(
-    escapeMdxSyntax("<details><summary>x</summary></details>"),
-    "<details><summary>x</summary></details>",
-  );
-});
-
-Deno.test("escapeMdxSyntax: never touches angles or braces inside code", () => {
-  assertEquals(
-    escapeMdxSyntax("use `Array<string>` inline"),
-    "use `Array<string>` inline",
-  );
-  assertEquals(
-    escapeMdxSyntax("an empty `{}` object"),
-    "an empty `{}` object",
-  );
-  assertEquals(
-    escapeMdxSyntax("```ts\nlet x: Operation<Chain<T>> = { a: 1 }\n```"),
-    "```ts\nlet x: Operation<Chain<T>> = { a: 1 }\n```",
-  );
+  it("never touches angles or braces inside code", function* () {
+    expect(escapeMdxSyntax("use `Array<string>` inline")).toEqual(
+      "use `Array<string>` inline",
+    );
+    expect(escapeMdxSyntax("an empty `{}` object")).toEqual(
+      "an empty `{}` object",
+    );
+    expect(
+      escapeMdxSyntax("```ts\nlet x: Operation<Chain<T>> = { a: 1 }\n```"),
+    ).toEqual("```ts\nlet x: Operation<Chain<T>> = { a: 1 }\n```");
+  });
 });

--- a/www/hooks/use-markdown.tsx
+++ b/www/hooks/use-markdown.tsx
@@ -47,15 +47,7 @@ export function* useMarkdown(
   let sanitize = createJsDocSanitizer(
     options?.linkResolver ?? defaultLinkResolver,
   );
-  let sanitized = yield* sanitize(markdown);
-
-  // Escape generic type parameters like <T>, <TSend, TRecv> that MDX
-  // would interpret as JSX tags. Only matches uppercase-starting identifiers
-  // inside angle brackets to avoid escaping actual HTML tags.
-  sanitized = sanitized.replace(
-    /<([A-Z]\w*(?:\s*,\s*[A-Z]\w*)*)>/g,
-    "&lt;$1&gt;",
-  );
+  let sanitized = escapeMdxSyntax(yield* sanitize(markdown));
 
   let mod = yield* useMDX(sanitized, {
     remarkPlugins: [remarkGfm, ...(options?.remarkPlugins ?? [])],
@@ -108,6 +100,52 @@ export function* useMarkdown(
       return <></>;
     }
   });
+}
+
+/**
+ * Escape `<` that opens a type expression (e.g. `Operation<Chain<T>>`,
+ * `From<A | B>`, `Middleware<[], Promise<void>>`) so MDX doesn't parse it as a
+ * JSX tag and throw `ReferenceError: <Name> is not defined` for the type name,
+ * and neutralize stray `{...}` expressions (e.g. a bare `{Scope}` left by a
+ * malformed `{@link}`) that MDX would otherwise evaluate as JavaScript.
+ *
+ * A `<` is treated as a type opener when it is followed by an uppercase
+ * identifier, `[`, or `{`, or when it attaches to a preceding identifier
+ * (`Promise<`, `)<`). Real HTML — `<div>`, ` <img>`, closing `</div>` — sits at
+ * a word boundary starting lowercase (or is a closing tag) and is left intact.
+ * `{`/`}` become their HTML entities so they render as literal braces.
+ * Everything inside inline code and fenced code blocks is left untouched.
+ */
+export function escapeMdxSyntax(markdown: string): string {
+  return markdown
+    .split(/(```[\s\S]*?```|`[^`]*`)/g)
+    .map((part, i) => (i % 2 === 0 ? escapeOutsideCode(part) : part))
+    .join("");
+}
+
+function escapeOutsideCode(text: string): string {
+  let out = "";
+  for (let i = 0; i < text.length; i++) {
+    let char = text[i];
+    if (char === "<") {
+      let next = text[i + 1] ?? "";
+      let prev = text[i - 1] ?? "";
+      let isTypeOpener = next !== "/" &&
+        (/[A-Z[{]/.test(next) || /[A-Za-z0-9_$)\]}]/.test(prev));
+      if (isTypeOpener) {
+        out += "&lt;";
+        continue;
+      }
+    } else if (char === "{") {
+      out += "&#123;";
+      continue;
+    } else if (char === "}") {
+      out += "&#125;";
+      continue;
+    }
+    out += char;
+  }
+  return out;
 }
 
 export function createJsDocSanitizer(


### PR DESCRIPTION
Fixes #1222.

# Problem

Several API-documentation pages fail to render server-side. The markdown→JSX conversion (`www/hooks/use-markdown.tsx`) throws `ReferenceError: <Name> is not defined`, the description block renders empty, and — because the docs crawler is non-strict — the pages are silently dropped from the deployed site and the search index.

Two causes, both in JSDoc-derived content:

1. **Type expressions leak into MDX as JSX.** The existing escape only handled flat `<T>` / `<T, U>`. Anything richer left a raw `<Name>` that MDX parsed as a JSX component:
   - nested generics — `Operation<Chain<T>>`
   - unions — `From<A | B>`
   - arrays / nested — `Middleware<[], Promise<void>>`
   - `{@link}` inside a generic — `{@link Operation}<{@link B}>`
   → `ReferenceError: Chain / Api / Process / Scope is not defined`.

2. **Bare `{Name}` braces** (e.g. a malformed `{@link}` that lost its `@link`, leaving `{Scope}` / `{Api}`) are evaluated by MDX as JavaScript expressions → the same `ReferenceError`.

# Fix

Replace the narrow regex with `escapeMdxSyntax`, which walks the text **outside inline code and fenced blocks** and:

- escapes a `<` whenever it opens a type expression — followed by an uppercase identifier, `[`, or `{`, **or** attached to a preceding identifier (`Promise<`, `)<`);
- neutralizes stray `{` / `}` to their HTML entities so they render as literal braces.

Real HTML (`<div>`, ` <img>`, closing `</div>`) sits at a word boundary starting lowercase (or is a closing tag) and is left intact, and nothing inside code is touched. The `.mdx` guides and package READMEs that also go through `useMarkdown` use no `{expr}` / `<Component>` outside code, so they're unaffected.

# Verification

- **Unit tests** (`www/hooks/use-markdown.test.ts`): the type-expression cases, the stray-brace cases, HTML-preserved cases, and code-span/fence preservation.
- **End-to-end**: crawling all **149** `/api/*` pages against a local server now logs **0** render failures (was 4). The pages that previously failed:
  - https://effection.netlify.app/api/v4-next/Api
  - https://effection.netlify.app/api/v4-next/Around
  - (plus the `Chain` / `Process` / `Scope` references on other pages)

## How to verify

```
cd www && deno task test        # unit tests, incl. escapeMdxSyntax
# or end-to-end:
cd www && GITHUB_TOKEN=… deno run -A main.tsx &      # serve
for p in $(curl -s localhost:8000/sitemap.xml | grep -oE '/api/[^< ]+' | sort -u); do
  curl -s -o /dev/null "localhost:8000$p"
done
# server log should contain no "is not defined" / "Failed to convert markdown to JSXElement"
```

Surfaced while working on Pagefind indexing (#1220): the search crawl tolerated these failures, so search still worked, but the affected doc pages were missing.