### PR TITLE
🤖 Document that async teardown must use ensure()

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -220,6 +220,7 @@ const task = yield * op; // returns a TASK (Future) and starts it
 **Shape (ordering matters)**
 
 ```ts
+// synchronous teardown
 resource(function* (provide) {
   try {
     yield* provide(value);
@@ -227,16 +228,25 @@ resource(function* (provide) {
     cleanup();
   }
 });
+
+// asynchronous teardown — ensure(), never finally
+resource(function* (provide) {
+  yield* ensure(function* () {
+    yield* cleanup();
+  });
+
+  yield* provide(value);
+});
 ```
 
 **Rules**
 
 - Setup happens before `provide()`.
-- Cleanup must be in `finally` (or after `provide()` guarded by `finally`) so it
-  runs on return/error/halt.
-- Teardown can be asynchronous. If cleanup needs async work, express it as an
-  `Operation` and `yield*` it inside `finally` (wait for teardown to finish)—do
-  not fire-and-forget cleanup.
+- Synchronous cleanup must be in `finally` (or after `provide()` guarded by
+  `finally`) so it runs on return/error/halt.
+- Teardown can be asynchronous, but asynchronous teardown must go in `ensure()`.
+  Do not fire-and-forget cleanup.
+- You must not `yield*` inside a `finally`. See the rationale under `ensure()`.
 
 ## `ensure()`
 
@@ -245,6 +255,38 @@ resource(function* (provide) {
 - `ensure(fn)` registers cleanup to run when the current operation shuts down.
 - `fn` may return `void` (sync cleanup) or an `Operation` (async cleanup).
 - You should wrap sync cleanup bodies in braces so the function returns `void`.
+- **Cleanup that needs `yield*` must use `ensure()`, not a `finally` block.**
+
+**Why `yield*` in a `finally` is unsafe**
+
+When a task is halted, a coroutine is unwound by calling `iterator.return()` on
+its generator. If a `finally` block then yields, the generator suspends _inside_
+the finally and reports `{ done: false }`, so the routine resumes it with
+`iterator.next()` — and that takes the frame out of return-mode. The frame is no
+longer unwinding, so once cleanup finishes, execution continues past the
+operation that was being halted. The halt is lost.
+
+This is the defect fixed inside `scoped()` in #1185: `iter.return()` yielded the
+`destroy()` effects in scoped's finally, but the resume came back as
+`iter.next()`. `scoped()` re-arms the unwind explicitly via `trap.exit()`.
+Ordinary user code has no way to do that.
+
+`ensure()` is not affected. It is implemented as a `resource()`, so its
+`finally` runs in its own task frame with nothing after it, and it is driven by
+scope destruction — which `createTask` wraps in `critical()`, making it
+non-interruptible.
+
+**Gotchas**
+
+- `ensure()` registers on the **current scope**, and `call()` does not create
+  one — it delegates to the target's iterator in the same coroutine frame. An
+  `ensure()` inside `call(function* () { ... })` attaches to the _enclosing
+  task's_ scope and fires far too late. Use `scoped()` or `spawn()` when you
+  need a boundary. Note that `scoped()`'s own async teardown was not correct
+  until 4.1, so code supporting older versions should prefer `spawn()`.
+- Scope destructors run in **reverse order of registration**. Register the
+  `ensure()` where the `try {` would have been — after any `spawn()` calls its
+  cleanup depends on — so cleanup still runs while those children are alive.
 
 ## `useAbortSignal()`
 

--- a/lib/resource.ts
+++ b/lib/resource.ts
@@ -25,12 +25,13 @@ import { useScope } from "./scope.ts";
  *     let socket = new WebSocket(url);
  *     yield* once(socket, 'open');
  *
- *     try {
- *       yield* provide(socket);
- *     } finally {
+ *     // teardown that needs `yield*` goes in ensure(), not finally
+ *     yield* ensure(function*() {
  *       socket.close();
  *       yield* once(socket, 'close');
- *     }
+ *     });
+ *
+ *     yield* provide(socket);
  *   })
  * }
  *

--- a/lib/resource.ts
+++ b/lib/resource.ts
@@ -25,7 +25,6 @@ import { useScope } from "./scope.ts";
  *     let socket = new WebSocket(url);
  *     yield* once(socket, 'open');
  *
- *     // teardown that needs `yield*` goes in ensure(), not finally
  *     yield* ensure(function*() {
  *       socket.close();
  *       yield* once(socket, 'close');


### PR DESCRIPTION
## Why

`AGENTS.md` currently tells agents to do the **opposite** of what is safe:

> Teardown can be asynchronous. If cleanup needs async work, express it as an `Operation` and `yield*` it inside `finally` (wait for teardown to finish)—do not fire-and-forget cleanup.

That loses halts.

When a task is halted, a coroutine is unwound by calling `iterator.return()` on its generator. If a `finally` block then yields, the generator suspends *inside* the finally and reports `{ done: false }`, so the routine resumes it with `iterator.next()` — **and that takes the frame out of return-mode**. The frame is no longer unwinding, so once cleanup finishes, execution continues past the operation that was being halted.

This is precisely the defect fixed inside `scoped()` in #1185 / #1186:

> `iter.return()` yielded the `destroy()` effects in scoped's finally, but the resume came back as `iter.next()` — which takes the frame out of return-mode.

`scoped()` re-arms the unwind via `trap.exit()`. **Ordinary user code has no way to do that.**

Measured on 4.1.0, logging what runs after `task.halt()`:

| Shape | Result |
|---|---|
| `try/finally` + `yield*`, in a delegated helper | `["cleanup", "outer-after"]` ← leaked |
| `try/finally` + `yield*`, inside `call()` | `["cleanup", "outer-after"]` ← leaked |
| `try/finally` + `yield*`, inside `scoped()` | `["cleanup", "outer-after"]` ← leaked |
| `ensure()` + `yield*` | `["cleanup"]` ← correct |

`ensure()` is safe because it is a `resource()`: its `finally` runs in its own task frame with nothing after it, driven by scope destruction, which `createTask` wraps in `critical()`.

## What's here

**`AGENTS.md`**
- `resource()` — shows both shapes, sync teardown in `finally` and async teardown in `ensure()`; replaces the incorrect bullet
- `ensure()` — adds the rationale above, plus two gotchas that are easy to get wrong:
  - `ensure()` inside `call()` registers on the **enclosing task's** scope, because `call()` creates none. Use `scoped()` or `spawn()`. (Worth noting for downstream: `scoped()`'s own async teardown was only correct from 4.1, so code supporting older versions should prefer `spawn()`.)
  - Scope destructors run in **reverse registration order**, so the `ensure()` goes where the `try {` was — after any `spawn()` its cleanup depends on.

**`lib/resource.ts`** — the JSDoc example was the canonical illustration of the unsafe pattern (closing a socket and awaiting `'close'` inside a `finally`). Updated to `ensure()`.

> The `resource.ts` JSDoc is slightly beyond a pure AGENTS.md change — happy to drop it if you'd rather keep this PR to the agent contract. I included it because leaving the library's flagship example doing the thing AGENTS.md now forbids seemed worse.

## Not touched

Several tests use `yield*` in a `finally` deliberately, to exercise this machinery (`test/resource.test.ts`, `test/run.test.ts`, `test/spawn.test.ts`, `test/scoped.test.ts`, `test/trap.test.ts`). Internal implementations that are correct by construction (`lib/ensure.ts`, `lib/task.ts`, `lib/task-group.ts`, `lib/using.ts`, `lib/scoped.ts`) are also unchanged.

`lib/using.ts` is worth a second look independently: it does `finally { yield* call(() => dispose.call(value)); }` inside a `resource()`. Nothing follows the try/finally in that frame, so it does not leak today, but it is the same shape.

Docs only — no runtime change. `deno fmt` and `deno lint` clean.

## Related

Downstream in effectionx: thefrontside/effectionx#225 adds the corresponding policy, and thefrontside/effectionx#226 migrates 8 sites. One of them (`chain.finally()`) was genuinely broken by this — teardown ran in a `finally` inside `call()`, and the halt escaped into the caller's frame.