### PR TITLE
🐛 Avoid duplicating inherited API middleware

### DIFF
--- a/lib/api-internal.ts
+++ b/lib/api-internal.ts
@@ -87,22 +87,27 @@ export function decorateApi<A>(
 ) {
   // read existing total and local
   let current = scope.get(api.context) ?? { total: {}, local: {} };
+  let hasOwnContext = scope.hasOwn(api.context);
 
-  let local = decorate(current.local, {
+  let total = hasOwnContext
+    ? current.total
+    : decorate(current.total, current.local);
+
+  let local = decorate(hasOwnContext ? current.local : {}, {
     [options?.at ?? "max"]: decorator,
   });
 
-  if (!scope.hasOwn(api.context)) {
+  if (!hasOwnContext) {
     scope.set(api.context, {
       local,
-      total: current.total,
+      total,
       handle: api.core,
     });
   } else {
     current.local = local;
   }
 
-  install(scope, api, current.total);
+  install(scope, api, total);
 }
 
 function decorate<A>(base: Decorator<A>, next: Decorator<A>): Decorator<A> {

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -289,6 +289,59 @@ describe("api", () => {
     });
   });
 
+  it("does not duplicate existing ancestor middleware when propagating later additions", async () => {
+    let api = createApi("test", {
+      *test(order: string[]): Operation<string[]> {
+        return order;
+      },
+    });
+
+    await run(function* () {
+      yield* api.around({
+        *test(args, next) {
+          let [input] = args;
+          let output = yield* next(input.concat("parent-before"));
+          return output.concat("/parent-before");
+        },
+      });
+
+      let tester = yield* resource<{ test(): Operation<string[]> }>(
+        function* (provide) {
+          let scope = yield* useScope();
+          yield* api.around({
+            *test(args, next) {
+              let [input] = args;
+              let output = yield* next(input.concat("child"));
+              return output.concat("/child");
+            },
+          });
+          yield* provide({
+            *test() {
+              return yield* scope.run(() => api.operations.test([]));
+            },
+          });
+        },
+      );
+
+      yield* api.around({
+        *test(args, next) {
+          let [input] = args;
+          let output = yield* next(input.concat("parent-after"));
+          return output.concat("/parent-after");
+        },
+      });
+
+      expect(yield* tester.test()).toEqual([
+        "parent-before",
+        "parent-after",
+        "child",
+        "/child",
+        "/parent-after",
+        "/parent-before",
+      ]);
+    });
+  });
+
   it("isolates sibling scopes from each other's middleware", async () => {
     let api = createApi("test", {
       *test(order: string[]): Operation<string[]> {


### PR DESCRIPTION
# Motivation

When a child scope adds contextual API middleware after inheriting middleware from its parent, Effection 4.1 stores the inherited middleware as part of the child's local decoration. If the parent later adds more middleware, propagation recomputes the inherited total and applies the original parent middleware twice.

This blocks `@effectionx/context-api` from delegating to Effection's experimental `createApi` without regressing its existing live-parent middleware guarantees.

# Approach

- Separate the inherited middleware total from child-local middleware when a scope first decorates an API.
- Keep later ancestor propagation live while ensuring each inherited middleware appears exactly once.
- Add a regression test covering parent middleware installed both before and after a child installs its own middleware.

# Verification

- `deno task test` — 37 suites, 234 steps passed
- `deno lint`
- `deno check mod.ts experimental.ts`
- `deno fmt lib/api-internal.ts test/api.test.ts`
- `deno task build:npm 4.1.1`
