### PR TITLE
🐛 preserve unknown error causes

### DIFF
--- a/lib/action.ts
+++ b/lib/action.ts
@@ -13,7 +13,7 @@ import type { Operation } from "./types.ts";
  *           action is resolved, rejected, or discarded.
  */
 interface Executor<T> {
-  (resolve: (value: T) => void, reject: (error: Error) => void): () => void;
+  (resolve: (value: T) => void, reject: (error: unknown) => void): () => void;
 }
 
 /**
@@ -53,7 +53,7 @@ export function action<T>(executor: Executor<T>, desc?: string): Operation<T> {
       let resolve = (value: T) => {
         settle(Ok(value));
       };
-      let reject = (error: Error) => {
+      let reject = (error: unknown) => {
         settle(Err(error));
       };
       let discard = executor(resolve, reject);

--- a/lib/future.ts
+++ b/lib/future.ts
@@ -5,7 +5,7 @@ import { withResolvers } from "./with-resolvers.ts";
 export interface FutureWithResolvers<T> {
   future: Future<T>;
   resolve(value: T): void;
-  reject(error: Error): void;
+  reject(error: unknown): void;
 }
 export function createFuture<T>(): FutureWithResolvers<T> {
   let promise = lazyPromiseWithResolvers<T>();
@@ -16,7 +16,7 @@ export function createFuture<T>(): FutureWithResolvers<T> {
     operation.resolve(value);
   };
 
-  let reject = (error: Error) => {
+  let reject = (error: unknown) => {
     promise.reject(error);
     operation.reject(error);
   };

--- a/lib/lazy-promise.ts
+++ b/lib/lazy-promise.ts
@@ -14,7 +14,7 @@ export function lazyPromiseWithResolvers<T>(): PromiseWithResolvers<T> {
   let resolve = ((value: T) => settle(Ok(value))) as PromiseWithResolvers<
     T
   >["resolve"];
-  let reject = (error: Error) => settle(Err(error));
+  let reject = (error: unknown) => settle(Err(error));
 
   let promise = lazyPromise<T>((resolve, reject) => {
     let record = (result: Result<T>) => {
@@ -38,7 +38,7 @@ export function lazyPromiseWithResolvers<T>(): PromiseWithResolvers<T> {
 export function lazyPromise<T>(
   resolver: (
     resolve: (value: T) => void,
-    reject: (error: Error) => void,
+    reject: (error: unknown) => void,
   ) => void,
 ): Promise<T> {
   let _promise: Promise<T> | undefined = undefined;

--- a/lib/result.ts
+++ b/lib/result.ts
@@ -15,7 +15,7 @@ export type Result<T> = {
   value: T;
 } | {
   readonly ok: false;
-  error: Error;
+  error: unknown;
 };
 
 /**
@@ -58,17 +58,8 @@ export function Ok<T>(value?: T): Result<T | undefined> {
 export function Err<T>(cause: unknown): Result<T> {
   return {
     ok: false,
-    error: cause instanceof Error
-      ? cause
-      : new ThrownValueError(String(cause), { cause }),
+    error: cause,
   };
-}
-
-class ThrownValueError extends Error {
-  constructor(message: string, options?: ErrorOptions) {
-    super(message, options);
-    this.name = "ThrownValueError";
-  }
 }
 
 /**

--- a/lib/trap.ts
+++ b/lib/trap.ts
@@ -19,7 +19,7 @@ export function* trap<T>(operation: () => Operation<T>): Operation<T> {
       trap.outcome = Just(Ok(value));
     }
   } catch (error) {
-    trap.outcome = Just(Err(error as Error));
+    trap.outcome = Just(Err(error));
   } finally {
     scope.set(ErrorContext, original);
     // deno-lint-ignore no-unsafe-finally
@@ -32,7 +32,7 @@ export class Trap<T> implements ErrorBoundary {
 
   constructor(public routine: Coroutine<unknown>) {}
 
-  raise(error: Error): void {
+  raise(error: unknown): void {
     this.outcome = Just(Err(error));
     this.routine.unwind();
   }
@@ -54,7 +54,7 @@ export class Trap<T> implements ErrorBoundary {
 }
 
 export interface ErrorBoundary {
-  raise(error: Error): void;
+  raise(error: unknown): void;
 }
 
 export const ErrorContext = createContext<ErrorBoundary>(

--- a/lib/with-resolvers.ts
+++ b/lib/with-resolvers.ts
@@ -33,14 +33,14 @@ export interface WithResolvers<T> {
   resolve(value: T): void;
 
   /**
-   * Cause {@link operation} to raise `Error`. Any calling operation
+   * Cause {@link operation} to raise `error`. Any calling operation
    * waiting on `operation` will. Yielding to `operation` subsequently
    * will also raise the same error. * If either `resolve` or`reject`
    * has been called before, this will have no effect.
    *
    * @param error - the error to raise
    */
-  reject(error: Error): void;
+  reject(error: unknown): void;
 }
 
 /**
@@ -105,7 +105,7 @@ export function withResolvers<T>(description?: string): WithResolvers<T> {
   };
 
   let resolve = (value: T) => settle(Ok(value));
-  let reject = (error: Error) => settle(Err(error));
+  let reject = (error: unknown) => settle(Err(error));
 
   return { operation, resolve, reject };
 }

--- a/test/result.test.ts
+++ b/test/result.test.ts
@@ -13,16 +13,9 @@ describe("Result", () => {
     expect(Err(error)).toEqual({ ok: false, error });
   });
 
-  it("wraps non-Error causes passed to Err()", () => {
-    let result = Err("oh no");
+  it("preserves non-Error causes passed to Err()", () => {
+    let cause = "oh no";
 
-    if (result.ok) {
-      throw new Error("expected Err() to produce a failed result");
-    }
-
-    expect(result.error).toBeInstanceOf(Error);
-    expect(result.error.name).toEqual("ThrownValueError");
-    expect(result.error.message).toEqual("oh no");
-    expect(result.error.cause).toEqual("oh no");
+    expect(Err(cause)).toEqual({ ok: false, error: cause });
   });
 });

--- a/test/until.test.ts
+++ b/test/until.test.ts
@@ -9,16 +9,11 @@ describe("until", () => {
       expect(yield* until(Promise.resolve(42))).toEqual(42);
     });
   });
-  it("wraps non-Error promise rejections", async () => {
-    expect.assertions(3);
-    await run(function* () {
-      try {
-        yield* until(Promise.reject("error"));
-      } catch (error) {
-        expect(error).toBeInstanceOf(Error);
-        expect((error as Error).message).toBe("error");
-        expect((error as Error).cause).toBe("error");
-      }
-    });
+  it("preserves non-Error promise rejections", async () => {
+    let cause = { message: "error" };
+
+    await expect(run(function* () {
+      yield* until(Promise.reject(cause));
+    })).rejects.toBe(cause);
   });
 });


### PR DESCRIPTION
# Motivation

Effection currently converts every non-`Error` failure into a `ThrownValueError` so `Result.error` remains an `Error`. [#1149](https://github.com/thefrontside/effection/pull/1149) introduced that contract with the public `Result` API. Changing it is a breaking change.

The original value remains available through `cause`, but Effection also uses `Result` inside the runtime and rethrows or rejects with `result.error`. Once a non-`Error` value crosses an Effection boundary, callers catch the wrapper instead of the value that was thrown. Identity checks and type guards therefore receive a different object.

SvelteKit is one concrete case. Its [`HttpError` and `Redirect` values are plain classes](https://github.com/sveltejs/kit/blob/95ee35083f663622a3f370af0a41c530c7d1902c/packages/kit/src/exports/internal/shared.js#L3-L44), and [`isHttpError()` and `isRedirect()` identify them with `instanceof`](https://github.com/sveltejs/kit/blob/95ee35083f663622a3f370af0a41c530c7d1902c/packages/kit/src/exports/index.js#L96-L150). Passing either value through an Effection operation makes those guards fail.

Keeping `Result.error: Error` would require every automatic propagation path to unwrap `ThrownValueError.cause`, while explicit `Err()` and `allSettled()` results would continue to contain the wrapper. This PR uses JavaScript semantics in both cases: `Result.error` is `unknown`, and `Err(cause)` stores the exact cause. Code that needs an `Error` for logging or presentation can normalize it at that boundary.

# Approach

- change `Result.error` and rejection parameters to `unknown`
- store the exact cause in `Err()` and remove `ThrownValueError`
- verify identity preservation through `Err()` and `until()`