### PR TITLE
🐛 unwrap non-Error runtime failures

### DIFF
--- a/lib/coroutine.ts
+++ b/lib/coroutine.ts
@@ -1,5 +1,5 @@
 import { ReducerContext } from "./reducer.ts";
-import { Err, Ok } from "./result.ts";
+import { Err, Ok, unbox } from "./result.ts";
 import type { Coroutine, Effect, Operation, Scope } from "./types.ts";
 import type { Maybe } from "./maybe.ts";
 import type { Result } from "./result.ts";
@@ -72,10 +72,16 @@ export function createCoroutine<T>(
       let { resumeWith } = routine.data;
       if (!resumeWith.ok) {
         data.unwinding = false;
+        let error: unknown = resumeWith.error;
+        try {
+          unbox(resumeWith);
+        } catch (cause) {
+          error = cause;
+        }
         if (iterator.throw) {
-          return iterator.throw(resumeWith.error);
+          return iterator.throw(error);
         } else {
-          throw resumeWith.error;
+          throw error;
         }
       } else if (data.unwinding && !data.critical) {
         data.unwinding = false;

--- a/lib/do.ts
+++ b/lib/do.ts
@@ -1,4 +1,4 @@
-import type { Result } from "./result.ts";
+import { type Result, unbox } from "./result.ts";
 import type { Effect, Operation } from "./types.ts";
 
 /**
@@ -23,11 +23,7 @@ export function Do<T>(effect: Effect<T>): Operation<T> {
       return {
         next() {
           if (result) {
-            if (result.ok) {
-              return { done: true, value: result.value };
-            } else {
-              throw result.error;
-            }
+            return { done: true, value: unbox(result) };
           } else {
             return { done: false, value: perform };
           }

--- a/lib/lazy-promise.ts
+++ b/lib/lazy-promise.ts
@@ -1,4 +1,4 @@
-import { Err, Ok, type Result } from "./result.ts";
+import { Err, Ok, type Result, unbox } from "./result.ts";
 
 type PromiseWithResolvers<T> = ReturnType<typeof Promise.withResolvers<T>>;
 
@@ -18,10 +18,10 @@ export function lazyPromiseWithResolvers<T>(): PromiseWithResolvers<T> {
 
   let promise = lazyPromise<T>((resolve, reject) => {
     let record = (result: Result<T>) => {
-      if (result.ok) {
-        resolve(result.value);
-      } else {
-        reject(result.error);
+      try {
+        resolve(unbox(result));
+      } catch (error) {
+        reject(error);
       }
     };
 
@@ -38,7 +38,7 @@ export function lazyPromiseWithResolvers<T>(): PromiseWithResolvers<T> {
 export function lazyPromise<T>(
   resolver: (
     resolve: (value: T) => void,
-    reject: (error: Error) => void,
+    reject: (error: unknown) => void,
   ) => void,
 ): Promise<T> {
   let _promise: Promise<T> | undefined = undefined;

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -136,7 +136,7 @@ export async function main(
 
         yield* exit(0);
       } catch (error) {
-        yield* resolve({ status: 1, error: error as Error });
+        yield* resolve({ status: 1, error });
       } finally {
         clearInterval(interval);
       }
@@ -151,7 +151,7 @@ export async function main(
     }
   }
 
-  if (result.error) {
+  if ("error" in result) {
     console.error(result.error);
   }
 
@@ -164,7 +164,7 @@ interface Exit {
   status: number;
   message?: string;
   signal?: string;
-  error?: Error;
+  error?: unknown;
 }
 
 interface HostOperation<T> {

--- a/lib/race.ts
+++ b/lib/race.ts
@@ -2,7 +2,7 @@ import { spawn } from "./spawn.ts";
 import { trap } from "./trap.ts";
 import type { Operation, Task, Yielded } from "./types.ts";
 import { withResolvers } from "./with-resolvers.ts";
-import { Err, Ok, type Result } from "./result.ts";
+import { Err, Ok, type Result, unbox } from "./result.ts";
 
 /**
  * Race the given operations against each other and return the value of
@@ -72,9 +72,5 @@ export function* race<T extends Operation<unknown>>(
     yield* task;
   }
 
-  if (result.ok) {
-    return result.value;
-  } else {
-    throw result.error;
-  }
+  return unbox(result);
 }

--- a/lib/result.ts
+++ b/lib/result.ts
@@ -78,7 +78,9 @@ export function unbox<T>(result: Result<T>): T {
   if (result.ok) {
     return result.value;
   } else {
-    throw result.error;
+    throw result.error instanceof ThrownValueError
+      ? result.error.cause
+      : result.error;
   }
 }
 

--- a/lib/task.ts
+++ b/lib/task.ts
@@ -2,7 +2,7 @@
 import { Priority } from "./contexts.ts";
 import { createCoroutine, critical, SettleContext } from "./coroutine.ts";
 import { type Maybe, Nothing } from "./maybe.ts";
-import { Ok, type Result } from "./result.ts";
+import { Ok, type Result, unbox } from "./result.ts";
 import { createScopeInternal, type ScopeInternal } from "./scope-internal.ts";
 import { encapsulate, TaskGroupContext } from "./task-group.ts";
 import { ErrorContext, trap } from "./trap.ts";
@@ -95,7 +95,7 @@ class TaskInternal<T> implements Task<T> {
     let halted = async () => {
       let outcome = await signal();
       if (control.interrupted && outcome.exists && !outcome.value.ok) {
-        throw outcome.value.error;
+        unbox(outcome.value);
       }
     };
 
@@ -104,7 +104,7 @@ class TaskInternal<T> implements Task<T> {
         value: function* halt() {
           let outcome = yield* signal();
           if (control.interrupted && outcome.exists && !outcome.value.ok) {
-            throw outcome.value.error;
+            unbox(outcome.value);
           }
         },
       },
@@ -120,12 +120,7 @@ class TaskInternal<T> implements Task<T> {
   *[Symbol.iterator]() {
     let outcome = yield* this.routine.future;
     if (outcome.exists) {
-      let result = outcome.value;
-      if (result.ok) {
-        return result.value;
-      } else {
-        throw result.error;
-      }
+      return unbox(outcome.value);
     } else {
       throw new Error(`halted`);
     }
@@ -137,19 +132,12 @@ class TaskInternal<T> implements Task<T> {
     if (this._promise) {
       return this._promise;
     }
-    return this._promise = new Promise((resolve, reject) => {
-      this.routine.future.then((outcome) => {
-        if (outcome.exists) {
-          let result = outcome.value;
-          if (result.ok) {
-            resolve(result.value);
-          } else {
-            reject(result.error);
-          }
-        } else {
-          reject(new Error("halted"));
-        }
-      });
+    return this._promise = this.routine.future.then((outcome) => {
+      if (outcome.exists) {
+        return unbox(outcome.value);
+      } else {
+        throw new Error("halted");
+      }
     });
   }
 }

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -86,6 +86,17 @@ describe("main", () => {
     });
   });
 
+  it("prints falsy non-Error causes", async () => {
+    await run(function* () {
+      let proc = yield* x("deno", ["run", "test/main/fail.unknown.ts"]);
+
+      let { stderr, exitCode } = yield* proc;
+
+      expect(stderr).toContain("false");
+      expect(exitCode).toEqual(1);
+    });
+  });
+
   it("works even if suspend is the only operation", async () => {
     await run(function* () {
       let proc = yield* x("deno", ["run", "test/main/just.suspend.ts"]);

--- a/test/main/fail.unknown.ts
+++ b/test/main/fail.unknown.ts
@@ -1,0 +1,5 @@
+import { main } from "../../mod.ts";
+
+await main(function* () {
+  throw false;
+});

--- a/test/race.test.ts
+++ b/test/race.test.ts
@@ -68,6 +68,13 @@ describe("race()", () => {
     await expect(result).rejects.toHaveProperty("message", "boom: foo");
   });
 
+  it("preserves non-Error causes", async () => {
+    let cause = { message: "boom" };
+    let result = run(() => race([call(() => Promise.reject(cause))]));
+
+    await expect(result).rejects.toBe(cause);
+  });
+
   it("has a type signature equivalent to Promise.race()", () => {
     let resolve = <T>(value: T) => call(() => value);
 

--- a/test/result.test.ts
+++ b/test/result.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "./suite.ts";
 
-import { Err, Ok } from "../mod.ts";
+import { Err, Ok, unbox } from "../mod.ts";
 
 describe("Result", () => {
   it("constructs successful results with Ok()", () => {
@@ -24,5 +24,16 @@ describe("Result", () => {
     expect(result.error.name).toEqual("ThrownValueError");
     expect(result.error.message).toEqual("oh no");
     expect(result.error.cause).toEqual("oh no");
+  });
+
+  it("unboxes non-Error causes", () => {
+    let cause = { message: "oh no" };
+
+    try {
+      unbox(Err(cause));
+      throw new Error("expected unbox() to throw");
+    } catch (error) {
+      expect(error).toBe(cause);
+    }
   });
 });

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -308,6 +308,18 @@ describe("run()", () => {
     await expect(task).rejects.toHaveProperty("message", "bang");
   });
 
+  it("preserves non-Error causes from child tasks", async () => {
+    let cause = { message: "boom" };
+    let task = run(function* Main() {
+      yield* spawn(function* Boomer() {
+        throw cause;
+      });
+      yield* suspend();
+    });
+
+    await expect(task).rejects.toBe(cause);
+  });
+
   it("throws an error in halt() if its finally block blows up", async () => {
     let task = run(function* main() {
       try {

--- a/test/until.test.ts
+++ b/test/until.test.ts
@@ -9,16 +9,11 @@ describe("until", () => {
       expect(yield* until(Promise.resolve(42))).toEqual(42);
     });
   });
-  it("wraps non-Error promise rejections", async () => {
-    expect.assertions(3);
-    await run(function* () {
-      try {
-        yield* until(Promise.reject("error"));
-      } catch (error) {
-        expect(error).toBeInstanceOf(Error);
-        expect((error as Error).message).toBe("error");
-        expect((error as Error).cause).toBe("error");
-      }
-    });
+  it("preserves non-Error promise rejections", async () => {
+    let cause = { message: "error" };
+
+    await expect(run(function* () {
+      yield* until(Promise.reject(cause));
+    })).rejects.toBe(cause);
   });
 });


### PR DESCRIPTION
# Motivation

Effection v4 deliberately keeps `Result.error` typed as `Error`, wrapping non-`Error` causes in `ThrownValueError`. Automatic propagation currently rethrows or rejects that wrapper, so caught values lose their original identity and runtime guards such as `instanceof` fail. This is the v4-compatible follow-up discussed in #1229.

# Approach

- keep explicit failed `Result` values wrapped as `Error`
- restore the original cause when failures cross operation, coroutine, task, race, halt, and Promise boundaries
- cover promise rejections, races, background child failures, and direct `unbox()` behavior

Validation: `deno fmt`, `deno lint`, `deno check mod.ts experimental.ts`, and the full 235-step test suite.