### PR TITLE
Accept PromiseLike values in call() and until()

### DIFF
--- a/lib/call.ts
+++ b/lib/call.ts
@@ -27,7 +27,7 @@ import type { Operation } from "./types.ts";
  * @since 3.0
  */
 export interface Callable<
-  T extends Operation<unknown> | Promise<unknown> | unknown,
+  T extends Operation<unknown> | PromiseLike<unknown> | unknown,
   TArgs extends unknown[] = [],
 > {
   (...args: TArgs): T;
@@ -69,7 +69,7 @@ export interface Callable<
  * @since 3.0
  */
 export function call<T, TArgs extends unknown[] = []>(
-  fn: (...args: TArgs) => Promise<T>,
+  fn: (...args: TArgs) => PromiseLike<T>,
 ): Operation<T>;
 export function call<T, TArgs extends unknown[] = []>(
   fn: (...args: TArgs) => Operation<T>,
@@ -90,7 +90,7 @@ export function call<T, TArgs extends unknown[] = []>(
         target instanceof Map || target instanceof Set
       ) {
         return constant(target)[Symbol.iterator]();
-      } else if (isPromise<T>(target)) {
+      } else if (isPromiseLike<T>(target)) {
         return action<T>(function wait(resolve, reject) {
           target.then(resolve, reject);
           return () => {};
@@ -104,14 +104,14 @@ export function call<T, TArgs extends unknown[] = []>(
   };
 }
 
-function isPromise<T>(
-  target: Operation<T> | Promise<T> | T,
-): target is Promise<T> {
-  return target && typeof (target as Promise<T>).then === "function";
+function isPromiseLike<T>(
+  target: Operation<T> | PromiseLike<T> | T,
+): target is PromiseLike<T> {
+  return target && typeof (target as PromiseLike<T>).then === "function";
 }
 
 function isOperation<T>(
-  target: Operation<T> | Promise<T> | T,
+  target: Operation<T> | PromiseLike<T> | T,
 ): target is Operation<T> {
   return target &&
     typeof (target as Operation<T>)[Symbol.iterator] === "function";

--- a/lib/until.ts
+++ b/lib/until.ts
@@ -13,9 +13,9 @@ import type { Operation } from "./types.ts";
  * @returns {Operation<T>} that succeeds or fails depending on the outcome of `promise`
  * @since 3.4
  */
-export function until<T>(promise: Promise<T>): Operation<T> {
+export function until<T>(promise: PromiseLike<T>): Operation<T> {
   return action((resolve, reject) => {
-    promise.then(resolve).catch(reject);
+    promise.then(resolve, reject);
     return () => {};
   });
 }

--- a/test/call.test.ts
+++ b/test/call.test.ts
@@ -28,6 +28,11 @@ describe("call", () => {
     );
   });
 
+  it("evaluates a promise-like function", async () => {
+    let promiseLike: PromiseLike<number> = Promise.resolve(42);
+    await expect(run(() => call(() => promiseLike))).resolves.toEqual(42);
+  });
+
   it("evaluates a vanilla function", async () => {
     await expect(run(() => call(() => 42))).resolves.toEqual(42);
   });

--- a/test/until.test.ts
+++ b/test/until.test.ts
@@ -9,6 +9,16 @@ describe("until", () => {
       expect(yield* until(Promise.resolve(42))).toEqual(42);
     });
   });
+  it("resolves promise-like values", async () => {
+    let promiseLike = {
+      then(resolve: (value: number) => void) {
+        resolve(42);
+        return promiseLike;
+      },
+    } as PromiseLike<number>;
+
+    await expect(run(() => until(promiseLike))).resolves.toEqual(42);
+  });
   it("preserves non-Error promise rejections", async () => {
     let cause = { message: "error" };
 


### PR DESCRIPTION
# Motivation

`call()` and `until()` only consume thenables, but their public types require full `Promise` implementations. This rejects valid `PromiseLike` values, and `until()` also calls `.catch()`, which is not part of the `PromiseLike` contract.

# Approach

- Accept `PromiseLike` values in `Callable`, `call()`, and `until()`.
- Pass the rejection handler directly to `.then()` so `until()` uses only the `PromiseLike` interface.
- Cover both APIs with promise-like regression tests.